### PR TITLE
Add Product Hunt featured badge to homepage

### DIFF
--- a/solyn/website/public/index.html
+++ b/solyn/website/public/index.html
@@ -633,6 +633,9 @@ footer .wordmark{ display:inline-flex; align-items:center; gap:9px; }
       <div class="trust">
         <span>Free forever</span><span>On-device</span><span>No account</span><span>Open source</span>
       </div>
+      <div class="ph-badge" style="margin-top:22px">
+        <a href="https://www.producthunt.com/products/dailyvox?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-dailyvox" target="_blank" rel="noopener noreferrer"><img alt="DailyVox - Speak 42 seconds a day — a private, on-device voice diary | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1179869&amp;theme=light&amp;t=1782294881277"></a>
+      </div>
     </div>
     <div class="reveal device-wrap">
       <div class="device-floor" aria-hidden="true"></div>


### PR DESCRIPTION
Adds the official PH 'Featured' embed badge to the homepage hero (light theme, matches the hero background). Links to the DailyVox PH launch.