### PR TITLE
SEO/AEO: personal-digital-twin pillar + answer-engine schema + CTR fixes

### DIFF
--- a/solyn/website/public/about.html
+++ b/solyn/website/public/about.html
@@ -12,7 +12,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>About DailyVox — Why I Built a Free On-Device AI Voice Journal</title>
-  <meta name="description" content="The story behind DailyVox. Built by Karthikeyan NG, a 20-year diary writer who started talking instead of writing. The vision: a Digital Twin that lives on your phone, not someone else's server.">
+  <meta name="description" content="The story behind DailyVox, built by Karthikeyan NG after 20 years of diary writing. The vision: a Digital Twin that lives on your phone, not a server.">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://getdailyvox.com/about">
@@ -666,6 +666,10 @@
     ],
     "license": "https://opensource.org/licenses/MIT"
   }
+  </script>
+
+  <script type="application/ld+json">
+  { "@context":"https://schema.org","@type":"WebPage","name":"About DailyVox — Founder's Note","speakable":{"@type":"SpeakableSpecification","cssSelector":["h1",".subtitle"]},"url":"https://getdailyvox.com/about" }
   </script>
 </head>
 <body>

--- a/solyn/website/public/alternative/apple-journal.html
+++ b/solyn/website/public/alternative/apple-journal.html
@@ -64,6 +64,8 @@
       </div>
 
       <div class="article-body">
+        <p><strong>The best Apple Journal alternative in 2026 is <a href="https://apps.apple.com/app/id6760454642">DailyVox</a></strong> — a free, voice-first journaling app that adds the AI layer Apple left out: on-device mood tracking, sentiment analysis, pattern detection, and a personal Digital Twin that learns from your entries. Like Apple Journal, everything stays private on your iPhone; unlike Apple Journal, it actually understands what you say. <a href="https://apps.apple.com/app/id6760454642">Download DailyVox free on the App Store &rarr;</a></p>
+
         <p>When Apple launched its Journal app, the journaling community got excited. Apple's privacy-first reputation, combined with deep iOS integration, promised something special. But what arrived was... basic. Very basic. Apple Journal is essentially a note-taking app with journaling suggestions. If you tried it and thought "is this it?", you're not alone.</p>
 
         <h2>What Apple Journal Does Well</h2>

--- a/solyn/website/public/blog/how-to-export-day-one.html
+++ b/solyn/website/public/blog/how-to-export-day-one.html
@@ -49,6 +49,20 @@
     ]
   }
   </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "name": "How to Export Your Day One Journal",
+    "description": "Export your Day One journal entries in JSON, PDF, or plain text, then move your data to another app.",
+    "step": [
+      { "@type": "HowToStep", "name": "Export from Day One on Mac", "text": "Open Day One on your Mac, go to File > Export, choose the journal(s) you want to export, select your format (JSON, PDF, or Plain Text), then choose a save location and click Export.", "url": "https://getdailyvox.com/blog/how-to-export-day-one#step-1" },
+      { "@type": "HowToStep", "name": "Export from Day One on iPhone or iPad", "text": "Open Day One, tap the three-dot menu (...) in the top right, tap Export Journal, select your format and journal(s), then choose where to save (Files, AirDrop, etc.).", "url": "https://getdailyvox.com/blog/how-to-export-day-one#step-1" },
+      { "@type": "HowToStep", "name": "Choose your export format", "text": "JSON is the most complete export and the best choice for moving to another app — it keeps full entry text, dates, tags, location, weather, photos, and metadata. PDF gives a readable, printable archive but is hard to import. Plain text gives a simple .txt file of entry text and dates only.", "url": "https://getdailyvox.com/blog/how-to-export-day-one#step-2" },
+      { "@type": "HowToStep", "name": "Move your data to a new app", "text": "Pick a destination based on your priorities: DailyVox imports Day One JSON for full on-device privacy with no cloud or subscription; Obsidian works if you want local Markdown files; Journey or Diarium import Day One JSON but use cloud sync. Sync and test the import before deleting your Day One account.", "url": "https://getdailyvox.com/blog/how-to-export-day-one#where-to-move" }
+    ]
+  }
+  </script>
 </head>
 <body>
   <nav>

--- a/solyn/website/public/faq.html
+++ b/solyn/website/public/faq.html
@@ -11,8 +11,8 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox FAQ — Everything About the Voice Journal That Lives on Your iPhone</title>
-  <meta name="description" content="Answers to every question about DailyVox: privacy, on-device AI, the Digital Twin, the constellation, Dynamic Island Live Activities, mood tracking, data export, and more.">
+  <title>DailyVox FAQ — Privacy, On-Device AI &amp; Your Data</title>
+  <meta name="description" content="Answers about DailyVox: privacy, on-device AI, the Digital Twin, mood tracking, data export, and more — the free voice journal for iPhone.">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://getdailyvox.com/faq">
@@ -70,6 +70,10 @@
       {"@type":"ListItem","position":2,"name":"FAQ"}
     ]
   }
+  </script>
+
+  <script type="application/ld+json">
+  { "@context":"https://schema.org","@type":"WebPage","name":"DailyVox FAQ — Privacy, On-Device AI & Your Data","speakable":{"@type":"SpeakableSpecification","cssSelector":["h1",".subtitle"]},"url":"https://getdailyvox.com/faq" }
   </script>
 
   <style>

--- a/solyn/website/public/glossary.html
+++ b/solyn/website/public/glossary.html
@@ -71,6 +71,10 @@
     }
   </style>
 
+  <script type="application/ld+json">
+  { "@context":"https://schema.org","@type":"WebPage","name":"Voice Journaling Glossary","speakable":{"@type":"SpeakableSpecification","cssSelector":["h1",".page-content p:first-of-type"]},"url":"https://getdailyvox.com/glossary" }
+  </script>
+
   <!-- DefinedTermSet Schema -->
   <script type="application/ld+json">
   {
@@ -271,7 +275,7 @@
         <dd>A network of brain regions that becomes active during introspection, daydreaming, and self-referential thinking. Journaling engages the default mode network, which is associated with self-awareness, autobiographical memory, and constructing personal narratives. This is why journaling often leads to unexpected insights.</dd>
 
         <dt>Digital Twin</dt>
-        <dd>In the context of personal AI, a digital twin is a computational model that mirrors aspects of an individual — personality traits, emotional patterns, values, and accumulated knowledge. DailyVox builds a private digital twin entirely on-device that learns from your journal entries over time and can predict moods, generate personality insights, and identify patterns you might not notice yourself.</dd>
+        <dd>In the context of personal AI, a digital twin is a computational model that mirrors aspects of an individual — personality traits, emotional patterns, values, and accumulated knowledge. DailyVox builds a private digital twin entirely on-device that learns from your journal entries over time and can predict moods, generate personality insights, and identify patterns you might not notice yourself. <a href="/personal-digital-twin">Read: what is a personal digital twin? →</a></dd>
 
         <dt id="e">Emotional Granularity</dt>
         <dd>The ability to distinguish between closely related emotions with precision. A person with high emotional granularity can tell the difference between feeling anxious, frustrated, and disappointed, rather than just "bad." Research shows that developing emotional granularity improves emotional regulation. Journaling and mood tracking help build this skill over time.</dd>

--- a/solyn/website/public/index.html
+++ b/solyn/website/public/index.html
@@ -12,7 +12,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DailyVox — A Personal AI that Grows on Your Phone</title>
-  <meta name="description" content="DailyVox is a voice journal with a living on-device AI. Speak every day, and watch a Digital Twin — a model of your personality — take shape. Entirely on your phone. Free and open source.">
+  <meta name="description" content="Free, open-source voice journal for iPhone with on-device AI. Speak daily and a Digital Twin of your personality takes shape — all on your phone.">
   <meta name="keywords" content="personal AI, digital twin app, on-device voice journal, private AI diary, Apple Foundation Models, iPhone journal AI, SFSpeechRecognizer, NLTagger">
   <meta name="author" content="DailyVox">
   <meta name="theme-color" content="#FAF8F5">
@@ -694,7 +694,7 @@ footer .wordmark{ display:inline-flex; align-items:center; gap:9px; }
     <div class="vision-feature reveal">
       <p class="eyebrow">the vision</p>
       <h2 id="vis-h" style="margin-bottom:28px; max-width:18ch">The most accurate <span class="accent">mirror</span> of yourself.</h2>
-      <p class="body-p">Your Digital Twin is the most accurate mirror of yourself that has ever existed. It remembers everything you've shared. It sees patterns you can't. Over time, it learns how you think, how you feel, and who you mention. It predicts your mood before you journal. It answers questions about your personality. And it runs entirely on your phone — <strong>private, permanent, yours alone.</strong></p>
+      <p class="body-p">Your Digital Twin is the most accurate mirror of yourself that has ever existed. It remembers everything you've shared. It sees patterns you can't. Over time, it learns how you think, how you feel, and who you mention. It predicts your mood before you journal. It answers questions about your personality. And it runs entirely on your phone — <strong>private, permanent, yours alone.</strong> <a href="/personal-digital-twin">What is a personal digital twin? →</a></p>
     </div>
     <div class="narrow" style="margin-inline:0">
       <div class="grid2 reveal">

--- a/solyn/website/public/personal-digital-twin.html
+++ b/solyn/website/public/personal-digital-twin.html
@@ -80,6 +80,10 @@
   { "@context":"https://schema.org","@type":"WebPage","name":"What Is a Personal Digital Twin?","speakable":{"@type":"SpeakableSpecification","cssSelector":["h1",".answer-box",".lede"]},"url":"https://getdailyvox.com/personal-digital-twin" }
   </script>
 
+  <script type="application/ld+json">
+  { "@context":"https://schema.org","@type":"SoftwareApplication","name":"DailyVox","description":"Free on-device AI voice journal that builds a personal digital twin — a private personality model of you from your journal entries. iPhone-only, zero cloud.","applicationCategory":"HealthApplication","operatingSystem":"iOS 17.0+","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"downloadUrl":"https://apps.apple.com/app/id6760454642","aggregateRating":{"@type":"AggregateRating","ratingValue":"5","ratingCount":"1"},"author":{"@type":"Organization","name":"DailyVox","url":"https://getdailyvox.com"} }
+  </script>
+
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
     :root {

--- a/solyn/website/public/personal-digital-twin.html
+++ b/solyn/website/public/personal-digital-twin.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R544S4KDBQ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-R544S4KDBQ');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>What Is a Personal Digital Twin? Definition &amp; How It Works</title>
+  <meta name="description" content="A personal digital twin is a private AI model of your personality that learns from you. What it is, how it works, and how to build one on your phone.">
+  <meta name="keywords" content="personal digital twin, digital twin of yourself, digital twin app, what is a personal digital twin, digital twin of a person, personal AI, digital clone">
+  <meta name="theme-color" content="#FAF8F5">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://getdailyvox.com/personal-digital-twin">
+  <meta property="og:title" content="What Is a Personal Digital Twin?">
+  <meta property="og:description" content="A private AI model of your personality, emotions, and values that learns from you — and lives on your phone. The complete guide.">
+  <meta property="og:image" content="https://getdailyvox.com/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="DailyVox — your personal digital twin on iPhone.">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://getdailyvox.com/og-image.png">
+  <link rel="canonical" href="https://getdailyvox.com/personal-digital-twin">
+
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700;800;900&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "What Is a Personal Digital Twin?",
+    "description": "A personal digital twin is a private AI model of an individual's personality, emotional patterns, values, and knowledge that learns from the data they generate.",
+    "datePublished": "2026-06-29",
+    "dateModified": "2026-06-29",
+    "author": { "@type": "Person", "name": "Karthikeyan NG", "url": "https://getdailyvox.com/about" },
+    "publisher": { "@type": "Organization", "name": "DailyVox", "url": "https://getdailyvox.com" },
+    "mainEntityOfPage": "https://getdailyvox.com/personal-digital-twin",
+    "about": { "@type": "DefinedTerm", "name": "Personal Digital Twin", "description": "A private, computational model of an individual person — their personality traits, emotional patterns, values, and accumulated knowledge — that learns from the data the person generates and can reflect, predict, and respond as a mirror of that person." }
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      { "@type": "Question", "name": "What is a personal digital twin?", "acceptedAnswer": { "@type": "Answer", "text": "A personal digital twin is a private AI model of an individual — their personality traits, emotional patterns, values, and knowledge — that learns from the data the person generates, such as journal entries. Unlike a static profile, it updates over time and can reflect patterns back to you, predict moods, and answer questions about your own history." } },
+      { "@type": "Question", "name": "What is the difference between a personal digital twin and an industrial digital twin?", "acceptedAnswer": { "@type": "Answer", "text": "An industrial digital twin is a simulation of a physical object or system — a jet engine, a factory, a building — used to predict mechanical behavior. A personal digital twin models a human being: personality, emotions, and values rather than physics. Both are living models that update with new data, but a personal digital twin is about self-knowledge, not machinery." } },
+      { "@type": "Question", "name": "Can I build a digital twin of myself?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. The most accessible way today is through journaling apps that build the model from your own words. DailyVox, for example, builds a personal digital twin on your iPhone from your voice journal entries — entirely on-device, with no account and no cloud. The more you journal, the more accurate the twin becomes." } },
+      { "@type": "Question", "name": "Is a personal digital twin the same as an AI chatbot or a digital clone?", "acceptedAnswer": { "@type": "Answer", "text": "Not quite. A generic chatbot answers from public training data and knows nothing about you. A personal digital twin is grounded in your own data, so it reflects your actual patterns, language, and history. 'Digital clone' is a popular term for the same idea taken further — a twin detailed enough to converse in your voice." } },
+      { "@type": "Question", "name": "Is my personal digital twin private?", "acceptedAnswer": { "@type": "Answer", "text": "It depends on where it is built. Cloud-based services upload your data to their servers. A privacy-first personal digital twin is built and stored entirely on your own device, so the model of you never leaves your phone. DailyVox uses this on-device approach, and Apple verifies it with a 'Data Not Collected' privacy label." } },
+      { "@type": "Question", "name": "What data does a personal digital twin need?", "acceptedAnswer": { "@type": "Answer", "text": "A personal digital twin learns from data that reflects how you think and feel — most naturally, journal entries, spoken or written. From that text it extracts personality signals, emotional tone, recurring people and topics, and values. It does not require sensors or wearables, though some twins add those for a richer picture." } }
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org","@type":"BreadcrumbList",
+    "itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Home","item":"https://getdailyvox.com/"},
+      {"@type":"ListItem","position":2,"name":"Personal Digital Twin"}
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  { "@context":"https://schema.org","@type":"WebPage","name":"What Is a Personal Digital Twin?","speakable":{"@type":"SpeakableSpecification","cssSelector":["h1",".answer-box",".lede"]},"url":"https://getdailyvox.com/personal-digital-twin" }
+  </script>
+
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --paper: #FAF8F5; --paper-2: #F2EDE8;
+      --card: #ffffff;
+      --ink: #1A1A2E;
+      --ink-dim: rgba(26,26,46,0.62); --ink-mute: rgba(26,26,46,0.42);
+      --rule: rgba(26,26,46,0.08); --rule-2: rgba(26,26,46,0.16);
+      --uv: #5B7C6B; --uv-wash: rgba(91,124,107,0.06); --bio: #D4A547;
+      --display: 'Nunito', system-ui, sans-serif;
+      --sans: 'Inter', -apple-system, system-ui, sans-serif;
+      --mono: 'DM Mono', ui-monospace, monospace;
+    }
+    body {
+      font-family: var(--sans);
+      background: var(--paper); color: var(--ink);
+      line-height: 1.55; -webkit-font-smoothing: antialiased;
+    }
+    a { color: inherit; text-decoration: none; }
+    .wrap { max-width: 960px; margin: 0 auto; padding: 0 28px; }
+    .topbar {
+      position: sticky; top: 0; z-index: 80;
+      background: rgba(250,248,245,0.78);
+      backdrop-filter: blur(18px) saturate(150%); -webkit-backdrop-filter: blur(18px) saturate(150%);
+      border-bottom: 1px solid var(--rule);
+    }
+    .topbar .wrap { display: flex; align-items: center; justify-content: space-between;
+      padding: 14px 28px; gap: 20px; }
+    .logo { display: flex; align-items: center; gap: 10px; }
+    .logo-mark { width: 30px; height: 30px; border-radius: 7px;
+      background: url("/apple-touch-icon.png") center/cover;
+      box-shadow: 0 1px 2px rgba(26,26,46,0.08); }
+    .logo-text { font-family: var(--display); font-weight: 600; font-size: 17px; }
+    .nav { display: flex; gap: 4px; }
+    .nav a { padding: 8px 14px; border-radius: 6px;
+      font-family: var(--mono); font-size: 12px; font-weight: 500;
+      color: var(--ink-dim); }
+    .nav a.active { color: var(--ink); }
+    .nav a:hover { background: rgba(26,26,46,0.04); color: var(--ink); }
+    .cta-btn { background: var(--ink); color: var(--paper);
+      padding: 9px 18px; border-radius: 7px;
+      font-family: var(--mono); font-size: 12px; font-weight: 600; }
+    @media (max-width: 700px) { .nav { display: none; } }
+
+    .hero { padding: 72px 0 36px; position: relative; }
+    .hero::before { content: ''; position: absolute; inset: 0;
+      background: radial-gradient(circle at 80% 30%, rgba(91,124,107,0.04) 0%, transparent 40%);
+      pointer-events: none; }
+    .hero .marker { font-family: var(--mono); font-size: 11px; font-weight: 600;
+      letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute); margin-bottom: 18px; }
+    .hero .marker .diamond { color: var(--uv); margin-right: 8px; }
+    .hero h1 { font-family: var(--display);
+      font-size: clamp(40px, 5.6vw, 66px); font-weight: 600; line-height: 1.06;
+      letter-spacing: -0.035em; margin-bottom: 22px; }
+    .hero h1 em { font-style: italic; color: var(--uv); }
+    .hero .lede { font-size: 18px; line-height: 1.5; color: var(--ink-dim); max-width: 660px; }
+    .hero .lede strong { color: var(--ink); }
+
+    .answer-box {
+      margin: 26px 0 8px; padding: 22px 26px;
+      background: var(--card); border: 1px solid var(--rule-2);
+      border-left: 3px solid var(--uv); border-radius: 10px;
+      font-size: 18px; line-height: 1.55; color: var(--ink);
+      max-width: 720px;
+    }
+    .answer-box strong { font-weight: 700; }
+
+    .content { padding: 40px 0 64px; }
+    .content h2 {
+      font-family: var(--display);
+      font-size: 28px; font-weight: 600; letter-spacing: -0.018em;
+      margin: 44px 0 14px;
+      position: relative; padding-left: 18px;
+    }
+    .content h2::before {
+      content: '◆'; position: absolute; left: 0; top: 12px;
+      color: var(--uv); font-size: 10px;
+    }
+    .content h3 {
+      font-family: var(--display);
+      font-size: 19px; font-weight: 600;
+      margin: 28px 0 8px;
+    }
+    .content p { margin-bottom: 14px; color: var(--ink-dim); }
+    .content p strong { color: var(--ink); font-weight: 600; }
+    .content ul, .content ol { margin: 0 0 16px 24px; }
+    .content li { margin-bottom: 8px; color: var(--ink-dim); }
+    .content li strong { color: var(--ink); }
+    .content a { color: var(--uv); text-decoration: underline;
+      text-decoration-thickness: 1px; text-underline-offset: 2px; }
+    .content table { width: 100%; border-collapse: collapse; margin: 20px 0;
+      font-size: 14px; }
+    .content th, .content td { padding: 12px 16px; text-align: left;
+      border-bottom: 1px solid var(--rule); vertical-align: top; }
+    .content th { font-family: var(--mono); font-size: 11px;
+      letter-spacing: 0.08em; text-transform: uppercase;
+      color: var(--ink-mute); font-weight: 600; }
+    .content td { color: var(--ink-dim); }
+    .content td strong { color: var(--ink); font-weight: 600; }
+
+    .faq-q { font-family: var(--display); font-size: 18px; font-weight: 600;
+      color: var(--ink); margin: 24px 0 6px; }
+
+    .cta-card { margin: 56px 0 24px; padding: 36px 40px;
+      background: var(--ink); color: var(--paper); border-radius: 12px; }
+    .cta-card h3 { font-family: var(--display); font-size: 24px; font-weight: 600;
+      margin-bottom: 10px; color: var(--paper); }
+    .cta-card p { color: rgba(250,248,245,0.7); margin-bottom: 22px; }
+    .cta-card a { display: inline-block; padding: 12px 22px;
+      background: var(--paper); color: var(--ink); border-radius: 7px;
+      font-family: var(--mono); font-size: 13px; font-weight: 600; text-decoration: none; }
+    .cta-card a:hover { background: var(--bio); }
+
+    .footer { padding: 48px 0; border-top: 1px solid var(--rule); background: var(--paper-2); }
+    .footer .wrap { display: flex; flex-direction: column; gap: 18px; }
+    .footer-row { display: flex; justify-content: space-between; align-items: center;
+      flex-wrap: wrap; gap: 18px; }
+    .footer-links { display: flex; gap: 22px; flex-wrap: wrap; }
+    .footer-links a { font-family: var(--mono); font-size: 12px; color: var(--ink-dim); }
+    .footer-links a:hover { color: var(--ink); }
+    .footer-copy { font-family: var(--mono); font-size: 11px; color: var(--ink-mute); }
+  </style>
+</head>
+<body>
+
+  <header class="topbar">
+    <div class="wrap">
+      <a href="/" class="logo">
+        <span class="logo-mark"></span>
+        <span class="logo-text">DailyVox</span>
+      </a>
+      <nav class="nav">
+        <a href="/technology">Technology</a>
+        <a href="/about">About</a>
+        <a href="/blog">Journal</a>
+        <a href="/faq">FAQ</a>
+      </nav>
+      <a href="https://apps.apple.com/app/id6760454642" class="cta-btn">Get the app</a>
+    </div>
+  </header>
+
+  <section class="hero wrap">
+    <div class="marker"><span class="diamond">◆</span>PERSONAL AI · DIGITAL TWIN</div>
+    <h1>What is a <em>personal digital twin</em>?</h1>
+    <p class="answer-box"><strong>A personal digital twin is a private AI model of an individual</strong> — their personality traits, emotional patterns, values, and knowledge — that learns from the data the person generates, such as journal entries, and can reflect those patterns back, predict moods, and answer questions about that person's own history.</p>
+    <p class="lede">It is the human counterpart to the <strong>industrial digital twin</strong> used in engineering. Instead of simulating a jet engine or a factory, a personal digital twin models <strong>you</strong> — and the most private versions live entirely on your own phone.</p>
+  </section>
+
+  <main class="content wrap">
+
+    <h2>Personal digital twin vs. industrial digital twin</h2>
+    <p>The phrase "digital twin" started in engineering, where it means a live virtual replica of a physical object — a turbine, an aircraft, a power plant — fed by sensor data and used to simulate and predict mechanical behaviour. A <strong>personal digital twin</strong> borrows the same core idea (a living model that updates as new data arrives) and points it at a person instead of a machine.</p>
+    <table>
+      <thead>
+        <tr><th>Dimension</th><th>Industrial digital twin</th><th>Personal digital twin</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><strong>Models</strong></td><td>A physical object or system</td><td>A human being</td></tr>
+        <tr><td><strong>Input data</strong></td><td>Sensors, telemetry, CAD</td><td>Journal entries, voice, text</td></tr>
+        <tr><td><strong>Predicts</strong></td><td>Wear, failure, performance</td><td>Mood, patterns, themes</td></tr>
+        <tr><td><strong>Goal</strong></td><td>Optimise the machine</td><td>Understand yourself</td></tr>
+        <tr><td><strong>Lives</strong></td><td>Cloud / enterprise servers</td><td>Ideally, your own device</td></tr>
+      </tbody>
+    </table>
+    <p>So when someone asks "what is a digital twin of a person?", they are describing a personal digital twin: a model of who you are, not what you operate.</p>
+
+    <h2>How a personal digital twin works</h2>
+    <p>A personal digital twin is built in three stages:</p>
+    <ol>
+      <li><strong>Capture</strong> — you generate honest, first-person data. Journaling is the richest source, because it captures how you actually think and feel in your own words.</li>
+      <li><strong>Extract</strong> — language models read that data and pull out signals: personality traits, emotional tone, recurring people and places, values, and communication style.</li>
+      <li><strong>Reflect</strong> — those signals are assembled into a model that can mirror patterns back to you, surface trends you would not notice yourself, and predict how you tend to respond.</li>
+    </ol>
+    <p>Crucially, the twin is <strong>living</strong>: every new entry refines it. A twin built from a week of entries is a sketch; a twin built from a year is a detailed portrait.</p>
+
+    <h2>What a personal digital twin can do</h2>
+    <ul>
+      <li><strong>Reflect your patterns</strong> — show how your mood moves across weeks and what tends to precede the dips and the highs.</li>
+      <li><strong>Predict, not just record</strong> — anticipate likely mood and energy from your recent history.</li>
+      <li><strong>Hold your context</strong> — remember the people, projects, and themes that recur in your life.</li>
+      <li><strong>Answer questions about you</strong> — "what was I worried about last spring?" — grounded in your own history rather than generic advice.</li>
+    </ul>
+
+    <h2>Personal digital twin and privacy: why on-device matters</h2>
+    <p>A personal digital twin is, by definition, the most intimate dataset you will ever create — a model of your inner life. That makes <strong>where it is built and stored</strong> the most important question to ask of any "digital twin app".</p>
+    <p>Cloud services upload your raw entries to their servers to build the model. A privacy-first approach builds and keeps the twin <strong>entirely on your own device</strong>, so the model of you never leaves your phone. There is no server to breach, no account to leak, and no company reading your journal. This is the approach we believe a personal digital twin should take.</p>
+
+    <h2>How DailyVox builds your personal digital twin</h2>
+    <p><a href="/">DailyVox</a> is a free voice journal for iPhone that builds a personal digital twin — it calls it your <strong>Digital Twin</strong> — entirely on-device. You speak for as little as forty-two seconds a day. DailyVox transcribes it with Apple's on-device Speech framework, reads the emotional tone and named entities with the NaturalLanguage framework, and grows a private model of your personality on Apple's Neural Engine.</p>
+    <p>Because everything runs on your phone, the twin works in airplane mode, needs no account, and carries Apple's "Data Not Collected" privacy label. You can read exactly how it works in <a href="/technology">the technology breakdown</a>, see every term defined in the <a href="/glossary">glossary</a>, or read <a href="/about">why it was built</a>.</p>
+
+    <h2>Frequently asked questions</h2>
+
+    <p class="faq-q">Can I build a digital twin of myself?</p>
+    <p>Yes. The most accessible way today is a journaling app that builds the model from your own words. DailyVox builds one on your iPhone from your voice entries, on-device and account-free. The more you journal, the more accurate the twin becomes.</p>
+
+    <p class="faq-q">Is a personal digital twin the same as an AI chatbot or a digital clone?</p>
+    <p>Not quite. A generic chatbot answers from public training data and knows nothing about you. A personal digital twin is grounded in your own data, so it reflects your real patterns, language, and history. "Digital clone" is a popular term for the same idea taken further — a twin detailed enough to converse in your voice.</p>
+
+    <p class="faq-q">What data does a personal digital twin need?</p>
+    <p>Data that reflects how you think and feel — most naturally, journal entries, spoken or written. From that text it extracts personality signals, emotional tone, recurring people and topics, and values. It does not require wearables, though some twins add them for a richer picture.</p>
+
+    <p class="faq-q">Is my personal digital twin private?</p>
+    <p>It depends where it is built. Cloud services upload your data; a privacy-first twin is built and stored entirely on your device, so the model of you never leaves your phone. That is the approach DailyVox takes.</p>
+
+    <div class="cta-card">
+      <h3>Build your own digital twin — free</h3>
+      <p>Speak for forty-two seconds a day. Watch a private model of your personality take shape, entirely on your iPhone. No account, no cloud, no subscription.</p>
+      <a href="https://apps.apple.com/app/id6760454642">Download DailyVox on the App Store</a>
+    </div>
+
+  </main>
+
+  <footer class="footer">
+    <div class="wrap">
+      <div class="footer-row">
+        <div class="footer-links">
+          <a href="/about">About</a>
+          <a href="/technology">Technology</a>
+          <a href="/personal-digital-twin">Digital Twin</a>
+          <a href="/blog">Journal</a>
+          <a href="/faq">FAQ</a>
+          <a href="/glossary">Glossary</a>
+          <a href="/privacy">Privacy</a>
+          <a href="/support">Support</a>
+        </div>
+        <div class="footer-copy">© 2026 DailyVox · Built by Karthikeyan NG</div>
+      </div>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/solyn/website/public/privacy.html
+++ b/solyn/website/public/privacy.html
@@ -36,6 +36,35 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700;800;900&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
 
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      { "@type": "Question", "name": "Does DailyVox collect my data?", "acceptedAnswer": { "@type": "Answer", "text": "No. DailyVox has no servers, so there is no infrastructure to collect data with — this is privacy by architecture, not by policy. Apple's App Store privacy nutrition label for DailyVox reads 'Data Not Collected,' verified during App Store review." } },
+      { "@type": "Question", "name": "Where is my journal data stored?", "acceptedAnswer": { "@type": "Answer", "text": "All your data lives on your iPhone or iPad, in the app's sandboxed storage protected by iOS. The database is encrypted at rest with iOS Data Protection, so when the device is locked your entries are mathematically inaccessible without your passcode or biometric." } },
+      { "@type": "Question", "name": "Does DailyVox work without an account?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. There is no account, no sign-up, and no email required. You download DailyVox and start journaling immediately. Optional iCloud sync uses your existing Apple ID and is disabled by default." } },
+      { "@type": "Question", "name": "Does DailyVox send my journal to cloud AI like OpenAI or Anthropic?", "acceptedAnswer": { "@type": "Answer", "text": "No. DailyVox does not send your entries to OpenAI, Google, Anthropic, or any cloud AI vendor. All AI features — speech recognition, sentiment analysis, named entity recognition, and personality modelling — run on your device's Neural Engine using Apple's built-in frameworks, with no network calls." } },
+      { "@type": "Question", "name": "Is DailyVox open source so I can verify the privacy claims?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. The entire DailyVox codebase is published on GitHub under the MIT License at github.com/intrepidkarthi/dailyvox. Anyone can read the source and confirm there are no network calls in the AI pipeline — privacy claims should be verifiable, not just stated." } },
+      { "@type": "Question", "name": "What permissions does DailyVox need?", "acceptedAnswer": { "@type": "Answer", "text": "DailyVox requests the microphone (to record your voice) and speech recognition (for on-device transcription). Face ID/Touch ID, Photo Library, and Notifications are all optional and requested only when you use the related feature. None of these permissions cause data to leave your device." } }
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org","@type":"BreadcrumbList",
+    "itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Home","item":"https://getdailyvox.com/"},
+      {"@type":"ListItem","position":2,"name":"Privacy"}
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  { "@context":"https://schema.org","@type":"WebPage","name":"DailyVox Privacy Policy — Privacy by Architecture","speakable":{"@type":"SpeakableSpecification","cssSelector":["h1",".lede"]},"url":"https://getdailyvox.com/privacy" }
+  </script>
+
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
     :root {

--- a/solyn/website/public/sitemap-core.xml
+++ b/solyn/website/public/sitemap-core.xml
@@ -3,6 +3,7 @@
   <url><loc>https://getdailyvox.com/</loc><lastmod>2026-05-06</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>
   <url><loc>https://getdailyvox.com/about</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://getdailyvox.com/technology</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://getdailyvox.com/personal-digital-twin</loc><lastmod>2026-06-29</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://getdailyvox.com/for-students</loc><lastmod>2026-06-08</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://getdailyvox.com/compare</loc><lastmod>2026-05-06</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://getdailyvox.com/faq</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>

--- a/solyn/website/public/support.html
+++ b/solyn/website/public/support.html
@@ -36,6 +36,35 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700;800;900&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
 
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      { "@type": "Question", "name": "Is my data private?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. DailyVox processes everything on your device. There are no servers receiving your data. Your voice recordings, transcriptions, photos, and Digital Twin model never leave your phone." } },
+      { "@type": "Question", "name": "Does the app work offline?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Recording, journaling, transcription, mood detection, and all AI features work fully offline. Verifiable in airplane mode." } },
+      { "@type": "Question", "name": "How do I back up my data?", "acceptedAnswer": { "@type": "Answer", "text": "Go to Settings → Export Data. You can export in JSON, Markdown, CSV, plain text, or password-protected encrypted format (AES-256-GCM). You can also enable iCloud sync for automatic backup." } },
+      { "@type": "Question", "name": "Can I sync across devices?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Enable iCloud sync in Settings to sync diary entries across your Apple devices via CloudKit. Your data is encrypted with your Apple ID. iCloud sync is optional and disabled by default." } },
+      { "@type": "Question", "name": "What is the Digital Twin?", "acceptedAnswer": { "@type": "Answer", "text": "Your Digital Twin is a private AI model that learns your personality, emotional patterns, communication style, and personal knowledge graph from your journal entries. It grows more accurate with every entry and stays 100% on your device." } },
+      { "@type": "Question", "name": "How do I lock the app?", "acceptedAnswer": { "@type": "Answer", "text": "Go to Settings → App Lock and enable Face ID or Touch ID protection. The app locks automatically when you leave it and requires authentication to re-enter." } },
+      { "@type": "Question", "name": "Can I attach photos?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. You can attach up to 5 photos per diary entry. Photos are stored locally on your device and are never uploaded to any server." } },
+      { "@type": "Question", "name": "How do I delete my data?", "acceptedAnswer": { "@type": "Answer", "text": "Swipe left on any entry in the Timeline view to delete it. To remove all data, uninstall the app. For iCloud data, manage it through your device's iCloud settings." } },
+      { "@type": "Question", "name": "What iOS version is required?", "acceptedAnswer": { "@type": "Answer", "text": "DailyVox requires iOS 17.0 or later. The Dynamic Island recording timer requires an iPhone 14 Pro or newer." } },
+      { "@type": "Question", "name": "How do the Live Activities work?", "acceptedAnswer": { "@type": "Answer", "text": "When you start recording, a Live Activity appears in the Dynamic Island (or as a Lock Screen banner on non-Pro iPhones) showing your elapsed time and waveform. After your entry saves, a brief 'new star appeared' Live Activity celebrates the entry and auto-dismisses. The streak Live Activity is opt-in — enable in Settings → Live Activities." } }
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org","@type":"BreadcrumbList",
+    "itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Home","item":"https://getdailyvox.com/"},
+      {"@type":"ListItem","position":2,"name":"Support"}
+    ]
+  }
+  </script>
+
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
     :root {

--- a/solyn/website/public/technology.html
+++ b/solyn/website/public/technology.html
@@ -11,8 +11,8 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox Technology — On-Device AI Architecture for Private Voice Journaling</title>
-  <meta name="description" content="A deep technical breakdown of DailyVox's on-device AI pipeline. SFSpeechRecognizer, NLTagger, NLEmbedding, Foundation Models, Core Data, CryptoKit — nine Apple frameworks, zero third-party SDKs, all inference on Neural Engine.">
+  <title>DailyVox Technology — On-Device AI Architecture</title>
+  <meta name="description" content="A technical breakdown of DailyVox's on-device AI pipeline: nine Apple frameworks, zero third-party SDKs, all inference on the Neural Engine. No cloud.">
   <meta name="keywords" content="on-device AI, voice journaling, digital twin, Apple Foundation Models, NLTagger, SFSpeechRecognizer, privacy, iOS development">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="article">


### PR DESCRIPTION
## Goal
Move DailyVox toward page-1 for the **personal digital twin** intent cluster on Google, and toward being **cited by AI answer engines** (ChatGPT, Gemini, Claude). The bare head term "digital twin" is industrial/enterprise (IBM, Azure, GE) and not winnable short-term — so this targets the winnable consumer cluster: *personal digital twin · digital twin of yourself · digital twin app · what is a personal digital twin.*

## What's in here

### 🆕 Pillar page — `/personal-digital-twin`
The centerpiece. A definitive, answer-first explainer built to be *the* citable source:
- One-sentence quotable definition in an answer box up top (snippet/Speakable target)
- **Personal vs. industrial** digital-twin disambiguation table (claims the consumer intent)
- How it works · what it can do · privacy/on-device · how DailyVox builds it
- FAQ section
- Schema: `Article` + `FAQPage` + `BreadcrumbList` + `Speakable` (+ `DefinedTerm`)
- Linked from the **homepage** (exact-match anchor, 825-views/mo page), the **glossary** DT term, and `sitemap-core.xml`

### 🔍 Answer-engine schema (AEO)
- `Speakable` added to **glossary, faq, about, privacy**
- `FAQPage` added to **privacy** + **support** (9 Q&A each, previously unmarked prose)
- `HowTo` added to **how-to-export-day-one** (top-performing blog post; was steps-in-prose)

### ✍️ CTR fixes (Tier 1)
Trimmed oversized titles/meta on **index, technology, about, faq** so they stop truncating in SERPs (e.g. technology desc was 226 chars → 150; "Neural Engine" was being cut).

## Validation
All JSON-LD across the 9 changed/new pages parses as valid JSON (verified with a parser pass). Titles ≤62, descriptions ≤162.

## Data backing this
From the fresh GA4 export (Mar 31–Jun 28): traffic is concentrated in homepage + a few high-dwell pages (glossary 111s, about 74s, how-to-export 53 views), with 128/183 pages in the dead long tail. This PR concentrates effort on the proven winners + the new pillar rather than the tail.

## Follow-ups (not in this PR)
- Off-page AEO: steer the content engine to seed the "DailyVox = personal digital twin" association across Reddit/forums (LLM citation is driven heavily by corpus frequency).
- Tier 3: answer-first lede rewrite on `alternative/apple-journal` + glossary intro.