### PR TITLE
Fix widget counters + Star Birth Live Activity spam

### DIFF
--- a/solyn/SolynWidget/SolynWidget.swift
+++ b/solyn/SolynWidget/SolynWidget.swift
@@ -794,6 +794,17 @@ struct WidgetPersistenceController {
         if let appGroupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WidgetPersistenceController.appGroupIdentifier) {
             let storeURL = appGroupURL.appendingPathComponent("solyn.sqlite")
             let description = NSPersistentStoreDescription(url: storeURL)
+
+            // These MUST match the app's PersistenceController. The app creates the
+            // store with history tracking + file protection; a reader that opens it
+            // without the same options gets a stale/empty view (widget shows zeros).
+            #if os(iOS)
+            description.setOption(FileProtectionType.completeUntilFirstUserAuthentication as NSObject,
+                                  forKey: NSPersistentStoreFileProtectionKey)
+            #endif
+            description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+            description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+
             container.persistentStoreDescriptions = [description]
         }
 
@@ -802,6 +813,10 @@ struct WidgetPersistenceController {
                 logger.error("Widget Core Data error: \(error.localizedDescription)")
             }
         }
+
+        // Pick up writes the app makes while the widget process is alive.
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
     }
 }
 

--- a/solyn/solyn/LiveActivityManager.swift
+++ b/solyn/solyn/LiveActivityManager.swift
@@ -106,6 +106,13 @@ final class LiveActivityManager {
         #if os(iOS)
         guard #available(iOS 16.2, *), areActivitiesEnabled else { return }
 
+        // Never stack: end any Star Birth activity that's still on screen before
+        // starting a new one. Belt-and-suspenders alongside the once-per-day gate
+        // at the call site.
+        for existing in Activity<StarBirthActivityAttributes>.activities {
+            Task { await existing.end(nil, dismissalPolicy: .immediate) }
+        }
+
         let attributes = StarBirthActivityAttributes(moodRaw: moodRaw)
         let state = StarBirthActivityAttributes.ContentState(streak: streak, totalStars: totalStars)
         let content = ActivityContent(state: state, staleDate: Date().addingTimeInterval(dismissAfter))

--- a/solyn/solyn/TodayView.swift
+++ b/solyn/solyn/TodayView.swift
@@ -938,11 +938,16 @@ struct TodayView: View {
                         Task { @MainActor in
                             let streak = currentStreak(in: viewContext)
                             let total = totalEntryCount(in: viewContext)
-                            LiveActivityManager.shared.fireStarBirthActivity(
-                                streak: streak,
-                                totalStars: total,
-                                moodRaw: entry.mood ?? ""
-                            )
+                            // Celebrate only the FIRST entry of the day. Subsequent
+                            // same-day entries must not stack a new "a new star
+                            // appeared" Live Activity each time.
+                            if entriesTodayCount(in: viewContext) <= 1 {
+                                LiveActivityManager.shared.fireStarBirthActivity(
+                                    streak: streak,
+                                    totalStars: total,
+                                    moodRaw: entry.mood ?? ""
+                                )
+                            }
                             LiveActivityManager.shared.refreshStreakActivity(
                                 streak: streak,
                                 hasEntryToday: true,
@@ -1176,6 +1181,17 @@ func currentStreak(in context: NSManagedObjectContext) -> Int {
 
 func totalEntryCount(in context: NSManagedObjectContext) -> Int {
     let request = NSFetchRequest<DiaryEntry>(entityName: "DiaryEntry")
+    return (try? context.count(for: request)) ?? 0
+}
+
+/// Number of entries created today — used to fire the Star Birth celebration
+/// only on the first entry of the day.
+func entriesTodayCount(in context: NSManagedObjectContext) -> Int {
+    let calendar = Calendar.current
+    let startOfDay = calendar.startOfDay(for: Date())
+    let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) ?? Date()
+    let request = NSFetchRequest<DiaryEntry>(entityName: "DiaryEntry")
+    request.predicate = NSPredicate(format: "date >= %@ AND date < %@", startOfDay as NSDate, endOfDay as NSDate)
     return (try? context.count(for: request)) ?? 0
 }
 


### PR DESCRIPTION
## Two bugs reported on device

### 1. Widget counters showed zero
The widget's `WidgetPersistenceController` opened the shared App Group Core Data store **without** the options the app sets when it creates that store. The app enables persistent **history tracking** + remote-change notifications + file protection; a client that opens a history-tracked store without matching options gets a stale/empty view — so streak and total counts read as 0.

**Fix:** aligned `WidgetPersistenceController`'s store description with `PersistenceController` (history tracking, remote-change, `completeUntilFirstUserAuthentication` file protection) and set `automaticallyMergesChangesFromParent`.

### 2. "Day 1" notification + multiple per day
`currentStreak(in:)` is actually correct — "Day 1" was a genuine 1-day streak. The real bug: the **Star Birth Live Activity fired on every entry save** with no dedup, so multiple voice notes in a day stacked multiple "a new star appeared" activities.

**Fix (two layers):**
- Gated the celebration to the **first entry of the day** via new `entriesTodayCount(in:)` (`TodayView`).
- `fireStarBirthActivity` now **ends any existing Star Birth activity before starting a new one** (`LiveActivityManager`), so they can never stack.

## Verification
Correct by inspection; **needs a device build to confirm** widget refresh + ActivityKit behavior (can't be validated in a headless environment). Files changed: `SolynWidget.swift`, `TodayView.swift`, `LiveActivityManager.swift`.