### PR TITLE
Prototype: native Liquid Glass tab bar (iOS 26)

### DIFF
--- a/solyn/solyn/ContentView.swift
+++ b/solyn/solyn/ContentView.swift
@@ -58,11 +58,18 @@ struct ContentView: View {
             }
         }
         .onAppear {
-            // Warm tab bar appearance
-            let appearance = UITabBarAppearance()
-            appearance.configureWithDefaultBackground()
-            UITabBar.appearance().standardAppearance = appearance
-            UITabBar.appearance().scrollEdgeAppearance = appearance
+            // On iOS 26+, let the system render the native Liquid Glass tab bar.
+            // A manual UITabBarAppearance override forces an opaque background and
+            // defeats the glass material, so we only apply the warm configured
+            // appearance on iOS 25 and earlier.
+            if #available(iOS 26.0, *) {
+                // No override — inherit the native Liquid Glass tab bar.
+            } else {
+                let appearance = UITabBarAppearance()
+                appearance.configureWithDefaultBackground()
+                UITabBar.appearance().standardAppearance = appearance
+                UITabBar.appearance().scrollEdgeAppearance = appearance
+            }
         }
     }
 }

--- a/solyn/solyn/ContentView.swift
+++ b/solyn/solyn/ContentView.swift
@@ -61,7 +61,7 @@ struct ContentView: View {
             // On iOS 26+, let the system render the native Liquid Glass tab bar.
             // A manual UITabBarAppearance override forces an opaque background and
             // defeats the glass material, so we only apply the warm configured
-            // appearance on iOS 25 and earlier.
+            // appearance on releases before iOS 26.
             if #available(iOS 26.0, *) {
                 // No override — inherit the native Liquid Glass tab bar.
             } else {


### PR DESCRIPTION
Prototype for review on device.

The bottom tab bar is a standard SwiftUI `TabView` + `.tabItem`, so it inherits **Liquid Glass automatically** on the iOS 26 SDK — *except* the `UITabBarAppearance` override in `ContentView.onAppear` was forcing an opaque background and defeating the glass material.

**Change:** skip the appearance override on iOS 26+ (inherit native Liquid Glass); keep the warm configured appearance on iOS 25 and earlier. No new glass symbols, so it builds on any SDK; the glass shows on iOS 26 devices.

**Not included (deliberate):** glass on *custom* controls (recording button, floating buttons) via `.glassEffect()` / `.buttonStyle(.glass)`. Per the design discussion, keep glass on the chrome and warmth on the content — that's a separate, larger pass.

⚠️ Visual change — review on an iOS 26 device/simulator.