### PR TITLE
Onboarding: warm ivory-light redesign + optional Name step

### DIFF
--- a/solyn/solyn/OnboardingView.swift
+++ b/solyn/solyn/OnboardingView.swift
@@ -78,13 +78,13 @@ struct OnboardingView: View {
                         .tag(Step.name.rawValue)
                     MessageStep(
                         symbol: "mic.fill", tint: OB.gold,
-                        title: "Your voice builds a\nDigital Twin",
+                        title: "Your voice builds a Digital Twin",
                         message: "Speak about 42 seconds a day. Your Twin learns your personality, moods, and the people in your life — all on your phone.",
                         isIPad: isIPad
                     ).tag(Step.twin.rawValue)
                     MessageStep(
                         symbol: "lock.shield.fill", tint: OB.sage,
-                        title: "A sky no one else\ncan see",
+                        title: "A sky no one else can see",
                         message: "Everything runs on your device. No account, no cloud, no one watching. Apple's privacy label: Data Not Collected.",
                         isIPad: isIPad
                     ).tag(Step.privacy.rawValue)
@@ -321,6 +321,8 @@ private struct MessageStep: View {
                     .tracking(-0.4)
                     .foregroundColor(OB.ink)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .minimumScaleFactor(0.85)
                 Text(message)
                     .font(.system(size: 15, weight: .regular, design: .rounded))
                     .foregroundColor(OB.inkDim)

--- a/solyn/solyn/OnboardingView.swift
+++ b/solyn/solyn/OnboardingView.swift
@@ -2,653 +2,408 @@
 //  OnboardingView.swift
 //  solyn
 //
-//  Privacy-focused onboarding experience
+//  Warm, ivory-light onboarding — constellation / "inner sky" language.
+//  Flow: Welcome → Name yourself (optional) → Your Twin → Private →
+//  Name your planets → Ready to record.
 //
 
 import SwiftUI
 
+// MARK: - Palette (warm ivory, matches the app theme)
+
+private enum OB {
+    static let paper   = Color(red: 0.980, green: 0.972, blue: 0.961)  // #FAF8F5
+    static let paper2  = Color(red: 0.949, green: 0.929, blue: 0.910)  // warm dusk paper
+    static let card    = Color.white
+    static let ink     = Color(red: 0.102, green: 0.102, blue: 0.180)  // #1A1A2E
+    static let inkDim  = Color(red: 0.102, green: 0.102, blue: 0.180).opacity(0.62)
+    static let inkMute = Color(red: 0.102, green: 0.102, blue: 0.180).opacity(0.40)
+    static let rule    = Color(red: 0.102, green: 0.102, blue: 0.180).opacity(0.10)
+    static let gold    = Color(red: 0.831, green: 0.647, blue: 0.278)
+    static let sage    = Color(red: 0.357, green: 0.486, blue: 0.420)
+    static let forest  = Color(red: 0.420, green: 0.620, blue: 0.482)
+    static let coral   = Color(red: 0.769, green: 0.451, blue: 0.420)
+}
+
 struct OnboardingView: View {
     @Binding var hasCompletedOnboarding: Bool
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     @State private var currentPage = 0
+    @State private var userName = ""
     @State private var selectedIntentions: Set<String> = []
+    @FocusState private var nameFocused: Bool
 
     private var isIPad: Bool { horizontalSizeClass == .regular }
-    private var totalPageCount: Int { pages.count + 2 } // welcome + feature pages + intention
 
-    private let pages: [OnboardingPage] = [
-        OnboardingPage(
-            icon: "person.crop.circle.fill",
-            iconColor: Color(red: 0.831, green: 0.647, blue: 0.278),  // warm gold — the sun at the centre
-            title: "Meet Your Digital Twin",
-            subtitle: "The sun at the center of your sky",
-            description: "Your Digital Twin orbits your inner world — learning your personality, emotional patterns, and the people in your life. Four planets emerge: Mind, Heart, Voice, and Graph.",
-            gradient: [
-                Color(red: 38/255, green: 30/255, blue: 22/255),    // deep warm espresso
-                Color(red: 92/255, green: 68/255, blue: 38/255)     // warm amber-bronze
-            ]
-        ),
-        OnboardingPage(
-            icon: "chart.bar.fill",
-            iconColor: Color(red: 0.769, green: 0.584, blue: 0.416),
-            title: "Insights That Matter",
-            subtitle: "Patterns written in light",
-            description: "Like an aurora forming in your night sky, insights emerge from your journal entries. Mood trends, streaks, and emotional patterns — visible only when you look up.",
-            gradient: [
-                Color(red: 50/255, green: 38/255, blue: 30/255),    // Deep brown
-                Color(red: 120/255, green: 80/255, blue: 55/255)    // Warm amber
-            ]
-        ),
-        OnboardingPage(
-            icon: "lock.shield",
-            iconColor: Color(red: 0.420, green: 0.620, blue: 0.482),
-            title: "100% Private. Always.",
-            subtitle: "A constellation no one else can see",
-            description: "Your stars are protected by an unbreakable shield. All AI runs on your device. No servers. No accounts. No one watches your sky but you.",
-            gradient: [
-                Color(red: 25/255, green: 40/255, blue: 38/255),    // Deep teal-green
-                Color(red: 50/255, green: 80/255, blue: 70/255)     // Forest green
-            ]
-        )
-    ]
-
-    private var backgroundGradient: [Color] {
-        if currentPage == 0 {
-            // Warm night sky for the welcome star (matches the app's warm theme)
-            return [
-                Color(red: 26/255, green: 21/255, blue: 18/255),   // warm espresso night
-                Color(red: 42/255, green: 32/255, blue: 26/255)    // warm dusk
-            ]
-        } else if currentPage <= pages.count {
-            // Feature pages (1-based index, so subtract 1 for array)
-            return pages[currentPage - 1].gradient
-        } else {
-            // Intention check-in page — deep sage close (warm, on-brand)
-            return [
-                Color(red: 28/255, green: 38/255, blue: 32/255),    // deep sage night
-                Color(red: 56/255, green: 78/255, blue: 64/255)     // warm sage
-            ]
-        }
+    // Ordered steps
+    private enum Step: Int, CaseIterable {
+        case welcome, name, twin, privacy, intention, ready
     }
-
-    private var buttonGradientColors: [Color] {
-        if currentPage == 0 {
-            return [Color(red: 0.831, green: 0.647, blue: 0.278), Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.8)]
-        } else if currentPage <= pages.count {
-            let page = pages[currentPage - 1]
-            return [page.iconColor, page.iconColor.opacity(0.8)]
-        } else {
-            // Last page: sage green
-            return [Color(red: 0.357, green: 0.486, blue: 0.420), Color(red: 0.357, green: 0.486, blue: 0.420).opacity(0.8)]
-        }
-    }
-
-    private var buttonShadowColor: Color {
-        if currentPage == 0 {
-            return Color(red: 0.831, green: 0.647, blue: 0.278)
-        } else if currentPage <= pages.count {
-            return pages[currentPage - 1].iconColor
-        } else {
-            return Color(red: 0.357, green: 0.486, blue: 0.420)
-        }
-    }
+    private var totalSteps: Int { Step.allCases.count }
+    private var isLast: Bool { currentPage == totalSteps - 1 }
 
     var body: some View {
         ZStack {
-            // Background
+            // Warm ivory background
             LinearGradient(
-                colors: backgroundGradient,
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
+                colors: [OB.paper, OB.paper2],
+                startPoint: .top, endPoint: .bottom
             )
             .ignoresSafeArea()
-            .animation(.easeInOut(duration: 0.5), value: currentPage)
 
-            StarFieldView(count: 60)
+            IvorySky()
 
             VStack(spacing: 0) {
-                // Skip button
+                // Top bar — Skip (hidden on the final page)
                 HStack {
                     Spacer()
-                    if currentPage < totalPageCount - 1 {
+                    if !isLast {
                         Button("Skip") {
-                            withAnimation {
-                                currentPage = totalPageCount - 1
+                            nameFocused = false
+                            withAnimation(.spring(response: 0.4)) {
+                                currentPage = totalSteps - 1
                             }
                         }
-                        .font(.subheadline.weight(.medium))
-                        .foregroundColor(.white.opacity(0.6))
+                        .font(.system(size: 15, weight: .medium, design: .rounded))
+                        .foregroundColor(OB.inkMute)
                         .padding()
                     }
                 }
 
-                // Page content
+                // Pages
                 TabView(selection: $currentPage) {
-                    // Page 0: Welcome star moment
-                    OnboardingWelcomeView()
-                        .tag(0)
-
-                    // Pages 1-3: Feature pages
-                    ForEach(0..<pages.count, id: \.self) { index in
-                        OnboardingPageView(page: pages[index])
-                            .tag(index + 1)
-                    }
-
-                    // Last page: Intention check-in
+                    WelcomeStep(isIPad: isIPad).tag(Step.welcome.rawValue)
+                    NameStep(userName: $userName, focused: $nameFocused, isIPad: isIPad)
+                        .tag(Step.name.rawValue)
+                    MessageStep(
+                        symbol: "mic.fill", tint: OB.gold,
+                        title: "Your voice builds a\nDigital Twin",
+                        message: "Speak about 42 seconds a day. Your Twin learns your personality, moods, and the people in your life — all on your phone.",
+                        isIPad: isIPad
+                    ).tag(Step.twin.rawValue)
+                    MessageStep(
+                        symbol: "lock.shield.fill", tint: OB.sage,
+                        title: "A sky no one else\ncan see",
+                        message: "Everything runs on your device. No account, no cloud, no one watching. Apple's privacy label: Data Not Collected.",
+                        isIPad: isIPad
+                    ).tag(Step.privacy.rawValue)
                     IntentionCheckInView(selectedIntentions: $selectedIntentions, isIPad: isIPad)
-                        .tag(pages.count + 1)
+                        .tag(Step.intention.rawValue)
+                    ReadyStep(name: trimmedName, isIPad: isIPad).tag(Step.ready.rawValue)
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
+                .animation(.spring(response: 0.4), value: currentPage)
 
-                // Constellation-themed progress indicator
+                // Constellation progress dots
                 HStack(spacing: 12) {
-                    ForEach(0..<totalPageCount, id: \.self) { index in
+                    ForEach(0..<totalSteps, id: \.self) { index in
                         Image(systemName: index <= currentPage ? "star.fill" : "star")
                             .font(.system(size: index == currentPage ? 10 : 8))
-                            .foregroundColor(index <= currentPage ? Color(red: 0.831, green: 0.647, blue: 0.278) : .white.opacity(0.25))
+                            .foregroundColor(index <= currentPage ? OB.gold : OB.inkMute.opacity(0.5))
                             .animation(.spring(response: 0.3), value: currentPage)
                     }
                 }
-                .padding(.bottom, 30)
+                .padding(.bottom, 24)
 
-                // Action button
-                Button(action: {
-                    if currentPage < totalPageCount - 1 {
-                        withAnimation(.spring(response: 0.4)) {
-                            currentPage += 1
+                // Primary action
+                Button(action: advance) {
+                    HStack(spacing: 8) {
+                        if isLast {
+                            Image(systemName: "mic.fill").font(.system(size: 16, weight: .semibold))
                         }
-                    } else {
-                        completeOnboarding()
-                    }
-                }) {
-                    HStack {
-                        Text(currentPage == totalPageCount - 1 ? "Begin my journey" : "Next")
-                            .font(.headline)
-                        if currentPage == totalPageCount - 1 {
-                            Image(systemName: "sparkles")
-                                .font(.headline)
+                        Text(primaryTitle)
+                            .font(.system(size: 17, weight: .semibold, design: .rounded))
+                        if !isLast {
+                            Image(systemName: "arrow.right").font(.system(size: 15, weight: .semibold))
                         }
                     }
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 18)
+                    .padding(.vertical, 17)
                     .background(
-                        LinearGradient(
-                            colors: buttonGradientColors,
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
+                        LinearGradient(colors: [OB.sage, OB.sage.opacity(0.85)],
+                                       startPoint: .leading, endPoint: .trailing)
                     )
-                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-                    .shadow(color: buttonShadowColor.opacity(0.3), radius: 10, y: 5)
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .shadow(color: OB.sage.opacity(0.28), radius: 12, y: 6)
                 }
                 .frame(maxWidth: isIPad ? 500 : .infinity)
-                .padding(.horizontal, isIPad ? 60 : 30)
-                .padding(.bottom, 50)
+                .padding(.horizontal, isIPad ? 60 : 28)
+                .padding(.bottom, 44)
             }
         }
     }
 
+    private var trimmedName: String {
+        userName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var primaryTitle: String {
+        switch Step(rawValue: currentPage) {
+        case .name: return trimmedName.isEmpty ? "Skip for now" : "Continue"
+        case .ready: return "Record my first star"
+        default: return "Next"
+        }
+    }
+
+    private func advance() {
+        nameFocused = false
+        if isLast {
+            completeOnboarding()
+        } else {
+            withAnimation(.spring(response: 0.4)) { currentPage += 1 }
+        }
+    }
+
     private func completeOnboarding() {
+        if !trimmedName.isEmpty {
+            UserDefaults.standard.set(trimmedName, forKey: "userName")
+        }
         UserDefaults.standard.set(Array(selectedIntentions), forKey: "onboardingIntentions")
+        UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
         withAnimation(.easeInOut(duration: 0.3)) {
             hasCompletedOnboarding = true
         }
-        UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
     }
 }
 
-// MARK: - Welcome Star Moment
+// MARK: - Welcome (breathing gold star on ivory)
 
-struct OnboardingWelcomeView: View {
+private struct WelcomeStep: View {
+    let isIPad: Bool
     @State private var starScale: CGFloat = 0.3
-    @State private var glowOpacity: Double = 0
+    @State private var glow: Double = 0
     @State private var textOpacity: Double = 0
-    @State private var breathe = false   // continuous glow pulse
-    @State private var drift = false     // slow ambient-star rotation
+    @State private var breathe = false
+    @State private var drift = false
 
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
 
-            // Constellation star animation
             ZStack {
-                // Outer glow — gently breathing
                 Circle()
-                    .fill(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(glowOpacity * 0.15))
+                    .fill(OB.gold.opacity(glow * 0.18))
                     .frame(width: 200, height: 200)
                     .scaleEffect(breathe ? 1.12 : 0.94)
-
                 Circle()
-                    .fill(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(glowOpacity * 0.25))
-                    .frame(width: 120, height: 120)
+                    .fill(OB.gold.opacity(glow * 0.28))
+                    .frame(width: 118, height: 118)
                     .scaleEffect(breathe ? 1.08 : 0.96)
-
-                // Core star
                 Circle()
-                    .fill(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.8))
-                    .frame(width: 20, height: 20)
+                    .fill(OB.gold)
+                    .frame(width: 22, height: 22)
                     .scaleEffect(starScale * (breathe ? 1.08 : 1.0))
-                    .shadow(color: Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.6), radius: 20)
-
-                // White hot center
+                    .shadow(color: OB.gold.opacity(0.6), radius: 18)
                 Circle()
-                    .fill(Color(red: 0.957, green: 0.933, blue: 0.878))
-                    .frame(width: 8, height: 8)
+                    .fill(Color.white)
+                    .frame(width: 7, height: 7)
                     .scaleEffect(starScale)
 
-                // Ambient stars around core — slowly drifting as a ring
-                ZStack {
-                    ForEach(0..<8, id: \.self) { i in
-                        let angle = Double(i) * (.pi * 2 / 8)
-                        let radius: CGFloat = 85 + CGFloat(i % 3) * 20
-                        Circle()
-                            .fill(Color.white.opacity(glowOpacity * (0.15 + Double(i % 3) * 0.1)))
-                            .frame(width: CGFloat(2 + i % 3), height: CGFloat(2 + i % 3))
-                            .offset(
-                                x: cos(angle) * radius,
-                                y: sin(angle) * radius
-                            )
-                    }
+                // Ambient drifting stars
+                ForEach(0..<8, id: \.self) { i in
+                    let angle = Double(i) * (.pi * 2 / 8)
+                    let radius: CGFloat = 85 + CGFloat(i % 3) * 20
+                    Circle()
+                        .fill(OB.sage.opacity(glow * (0.30 + Double(i % 3) * 0.10)))
+                        .frame(width: CGFloat(3 + i % 2), height: CGFloat(3 + i % 2))
+                        .offset(x: cos(angle) * radius, y: sin(angle) * radius)
                 }
                 .rotationEffect(.degrees(drift ? 360 : 0))
                 .animation(.linear(duration: 90).repeatForever(autoreverses: false), value: drift)
             }
 
-            Spacer()
-                .frame(height: 60)
+            Spacer().frame(height: 56)
 
-            VStack(spacing: 16) {
+            VStack(spacing: 14) {
                 Text("Your inner sky\nis waiting")
-                    .font(.system(size: 38, weight: .bold, design: .rounded))
+                    .font(.system(size: isIPad ? 44 : 38, weight: .bold, design: .rounded))
                     .tracking(-0.6)
-                    .lineSpacing(2)
-                    .foregroundColor(.white)
+                    .foregroundColor(OB.ink)
                     .multilineTextAlignment(.center)
-                    .opacity(textOpacity)
-
                 Text("Every thought you speak becomes a star.\nOver time, constellations form — patterns\nonly you can see.")
                     .font(.system(size: 16, weight: .regular, design: .rounded))
-                    .foregroundColor(.white.opacity(0.65))
+                    .foregroundColor(OB.inkDim)
                     .multilineTextAlignment(.center)
                     .lineSpacing(5)
-                    .opacity(textOpacity)
             }
             .padding(.horizontal, 30)
+            .opacity(textOpacity)
 
             Spacer()
             Spacer()
         }
         .onAppear {
-            withAnimation(.easeOut(duration: 1.5)) {
-                starScale = 1.0
-                glowOpacity = 1.0
-            }
-            withAnimation(.easeOut(duration: 1.0).delay(0.8)) {
-                textOpacity = 1.0
-            }
-            // Ongoing living motion (so the welcome screen isn't static like before)
-            withAnimation(.easeInOut(duration: 3.2).repeatForever(autoreverses: true).delay(0.6)) {
-                breathe = true
-            }
+            withAnimation(.easeOut(duration: 1.4)) { starScale = 1.0; glow = 1.0 }
+            withAnimation(.easeOut(duration: 1.0).delay(0.7)) { textOpacity = 1.0 }
+            withAnimation(.easeInOut(duration: 3.2).repeatForever(autoreverses: true).delay(0.5)) { breathe = true }
             drift = true
         }
     }
 }
 
-struct OnboardingPage {
-    let icon: String
-    let iconColor: Color
-    let title: String
-    let subtitle: String
-    let description: String
-    let gradient: [Color]
-}
+// MARK: - Name yourself (optional, sage focus ring)
 
-struct OnboardingPageView: View {
-    let page: OnboardingPage
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @State private var animate1 = false
-    @State private var animate2 = false
-    @State private var animate3 = false
-    @State private var textOpacity: Double = 0
-
-    private var isIPad: Bool { horizontalSizeClass == .regular }
-
-    // Warm palette
-    private let warmGold = Color(red: 0.831, green: 0.647, blue: 0.278)
-    private let sageGreen = Color(red: 0.357, green: 0.486, blue: 0.420)
-    private let softCoral = Color(red: 0.769, green: 0.451, blue: 0.420)
-    private let forestGreen = Color(red: 0.420, green: 0.620, blue: 0.482)
-    private let ivory = Color(red: 0.957, green: 0.933, blue: 0.878)
+private struct NameStep: View {
+    @Binding var userName: String
+    var focused: FocusState<Bool>.Binding
+    let isIPad: Bool
 
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
 
-            // Each page gets a unique celestial visual
-            Group {
-                switch page.icon {
-                case "person.crop.circle.fill":
-                    twinPlanetSystem
-                case "chart.bar.fill":
-                    auroraInsights
-                case "lock.shield":
-                    shieldConstellation
-                default:
-                    twinPlanetSystem
-                }
+            IconBadge(symbol: "sparkle", tint: OB.gold)
+
+            VStack(spacing: 12) {
+                Text("Let's get to know you")
+                    .font(.system(size: isIPad ? 34 : 28, weight: .bold, design: .rounded))
+                    .foregroundColor(OB.ink)
+                    .multilineTextAlignment(.center)
+                Text("DailyVox becomes more yours with every word.")
+                    .font(.system(size: 15, weight: .regular, design: .rounded))
+                    .foregroundColor(OB.inkDim)
+                    .multilineTextAlignment(.center)
             }
-            .frame(height: isIPad ? 280 : 220)
-            .padding(.bottom, 24)
+            .padding(.top, 24)
+            .padding(.horizontal, 32)
 
-            // Text with staggered fade
+            TextField("Your name", text: $userName)
+                .font(.system(size: 17, weight: .medium, design: .rounded))
+                .foregroundColor(OB.ink)
+                .multilineTextAlignment(.center)
+                .textInputAutocapitalization(.words)
+                .submitLabel(.done)
+                .focused(focused)
+                .padding(.vertical, 16)
+                .padding(.horizontal, 20)
+                .background(OB.card)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(focused.wrappedValue ? OB.sage : OB.rule,
+                                lineWidth: focused.wrappedValue ? 2 : 1)
+                )
+                .shadow(color: OB.ink.opacity(0.04), radius: 6, y: 3)
+                .padding(.top, 28)
+                .padding(.horizontal, 32)
+                .frame(maxWidth: isIPad ? 460 : .infinity)
+                .animation(.easeInOut(duration: 0.2), value: focused.wrappedValue)
+
+            Text("Optional — stored only on your phone.")
+                .font(.system(size: 12, weight: .regular, design: .rounded))
+                .foregroundColor(OB.inkMute)
+                .padding(.top, 12)
+
+            Spacer()
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Message step (icon + title + body)
+
+private struct MessageStep: View {
+    let symbol: String
+    let tint: Color
+    let title: String
+    let message: String
+    let isIPad: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            IconBadge(symbol: symbol, tint: tint)
             VStack(spacing: 14) {
-                Text(page.title)
-                    .font(.system(size: isIPad ? 38 : 30, weight: .bold, design: .rounded))
-                    .tracking(-0.6)
-                    .foregroundColor(.white)
+                Text(title)
+                    .font(.system(size: isIPad ? 36 : 30, weight: .bold, design: .rounded))
+                    .tracking(-0.4)
+                    .foregroundColor(OB.ink)
                     .multilineTextAlignment(.center)
-
-                Text(page.subtitle)
-                    .font(.system(size: isIPad ? 17 : 15, weight: .semibold, design: .rounded))
-                    .foregroundColor(page.iconColor.opacity(0.95))
-                    .multilineTextAlignment(.center)
-
-                Text(page.description)
-                    .font(.system(size: isIPad ? 15 : 14, weight: .regular, design: .rounded))
-                    .foregroundColor(.white.opacity(0.58))
+                Text(message)
+                    .font(.system(size: 15, weight: .regular, design: .rounded))
+                    .foregroundColor(OB.inkDim)
                     .multilineTextAlignment(.center)
                     .lineSpacing(5)
                     .padding(.horizontal, 8)
             }
-            .padding(.horizontal, isIPad ? 60 : 28)
+            .padding(.top, 28)
+            .padding(.horizontal, isIPad ? 60 : 30)
             .frame(maxWidth: isIPad ? 600 : .infinity)
-            .opacity(textOpacity)
-            .offset(y: textOpacity > 0 ? 0 : 20)
+            Spacer()
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Ready to record (personalised)
+
+private struct ReadyStep: View {
+    let name: String
+    let isIPad: Bool
+    @State private var pop = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            ZStack {
+                Circle().fill(OB.sage.opacity(0.12)).frame(width: 128, height: 128)
+                Circle().fill(OB.sage).frame(width: 76, height: 76)
+                    .shadow(color: OB.sage.opacity(0.4), radius: 16)
+                Image(systemName: "checkmark")
+                    .font(.system(size: 34, weight: .bold))
+                    .foregroundColor(.white)
+            }
+            .scaleEffect(pop ? 1.0 : 0.6)
+            .opacity(pop ? 1 : 0)
+
+            VStack(spacing: 14) {
+                Text(name.isEmpty ? "Ready to be heard" : "Ready when you are,\n\(name).")
+                    .font(.system(size: isIPad ? 36 : 30, weight: .bold, design: .rounded))
+                    .foregroundColor(OB.ink)
+                    .multilineTextAlignment(.center)
+                Text("Your inner sky is ready. Speak your first star — 42 seconds is all it takes.")
+                    .font(.system(size: 15, weight: .regular, design: .rounded))
+                    .foregroundColor(OB.inkDim)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(5)
+                    .padding(.horizontal, 12)
+            }
+            .padding(.top, 28)
+            .padding(.horizontal, isIPad ? 60 : 30)
 
             Spacer()
             Spacer()
         }
         .onAppear {
-            withAnimation(.easeOut(duration: 0.8)) {
-                animate1 = true
-            }
-            withAnimation(.easeOut(duration: 1.2).delay(0.2)) {
-                animate2 = true
-            }
-            withAnimation(.easeOut(duration: 1.0).delay(0.4)) {
-                animate3 = true
-            }
-            withAnimation(.easeOut(duration: 0.8).delay(0.3)) {
-                textOpacity = 1
-            }
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.6).delay(0.1)) { pop = true }
         }
-        .onDisappear {
-            animate1 = false
-            animate2 = false
-            animate3 = false
-            textOpacity = 0
-        }
-    }
-
-    // MARK: - Page 1: Digital Twin = Your Personal Star System
-    // Central sun with 4 orbiting planets (Mind, Heart, Voice, Graph)
-
-    private var twinPlanetSystem: some View {
-        ZStack {
-            // Outer orbit path
-            Circle()
-                .stroke(ivory.opacity(0.08), lineWidth: 1)
-                .frame(width: isIPad ? 240 : 190, height: isIPad ? 240 : 190)
-
-            // Middle orbit path
-            Circle()
-                .stroke(ivory.opacity(0.12), lineWidth: 1)
-                .frame(width: isIPad ? 170 : 130, height: isIPad ? 170 : 130)
-
-            // Inner orbit path
-            Circle()
-                .stroke(ivory.opacity(0.06), lineWidth: 0.5)
-                .frame(width: isIPad ? 260 : 210, height: isIPad ? 260 : 210)
-
-            // Planet: Mind (outer orbit, top)
-            planetDot(color: page.iconColor, size: 10, label: "Mind")
-                .offset(x: 0, y: isIPad ? -120 : -95)
-                .rotationEffect(.degrees(animate2 ? 360 : 0))
-                .animation(.linear(duration: 40).repeatForever(autoreverses: false), value: animate2)
-
-            // Planet: Heart (middle orbit, right)
-            planetDot(color: softCoral, size: 8, label: "Heart")
-                .offset(x: isIPad ? 85 : 65, y: 0)
-                .rotationEffect(.degrees(animate2 ? -360 : 0))
-                .animation(.linear(duration: 28).repeatForever(autoreverses: false), value: animate2)
-
-            // Planet: Voice (middle orbit, left)
-            planetDot(color: forestGreen, size: 9, label: "Voice")
-                .offset(x: isIPad ? -85 : -65, y: isIPad ? 30 : 20)
-                .rotationEffect(.degrees(animate2 ? 360 : 0))
-                .animation(.linear(duration: 34).repeatForever(autoreverses: false), value: animate2)
-
-            // Planet: Graph (outer orbit, bottom-right)
-            planetDot(color: warmGold, size: 7, label: "Graph")
-                .offset(x: isIPad ? 70 : 55, y: isIPad ? 90 : 70)
-                .rotationEffect(.degrees(animate2 ? -360 : 0))
-                .animation(.linear(duration: 50).repeatForever(autoreverses: false), value: animate2)
-
-            // Central sun (your Twin)
-            ZStack {
-                Circle()
-                    .fill(page.iconColor.opacity(animate1 ? 0.15 : 0))
-                    .frame(width: isIPad ? 100 : 80, height: isIPad ? 100 : 80)
-
-                Circle()
-                    .fill(page.iconColor.opacity(animate1 ? 0.3 : 0))
-                    .frame(width: isIPad ? 60 : 48, height: isIPad ? 60 : 48)
-                    .shadow(color: page.iconColor.opacity(0.5), radius: 16)
-
-                Circle()
-                    .fill(page.iconColor.opacity(0.7))
-                    .frame(width: isIPad ? 32 : 24, height: isIPad ? 32 : 24)
-
-                Circle()
-                    .fill(ivory.opacity(0.8))
-                    .frame(width: isIPad ? 14 : 10, height: isIPad ? 14 : 10)
-            }
-            .scaleEffect(animate1 ? 1.0 : 0.5)
-        }
-    }
-
-    // MARK: - Page 2: Insights = Aurora / Nebula Waves
-
-    private var auroraColors: [Color] {
-        [warmGold, page.iconColor, sageGreen, softCoral, forestGreen]
-    }
-
-    private var auroraOffsets: [CGFloat] { [-15, 10, -8, 12, -5] }
-
-    private var auroraInsights: some View {
-        ZStack {
-            // Aurora bands
-            ForEach(0..<5, id: \.self) { i in
-                let bandColor = auroraColors[i]
-                let bandWidth: CGFloat = isIPad ? CGFloat(220 - i * 25) : CGFloat(180 - i * 20)
-                let bandHeight: CGFloat = isIPad ? 6 : 4
-                let xOffset: CGFloat = animate2 ? auroraOffsets[i] : 0
-                let yOffset: CGFloat = CGFloat(i * (isIPad ? 28 : 22) - 50)
-                Capsule()
-                    .fill(
-                        LinearGradient(
-                            colors: [bandColor.opacity(0.3), bandColor.opacity(0.05)],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .frame(width: bandWidth, height: bandHeight)
-                    .offset(x: xOffset, y: yOffset)
-                    .scaleEffect(x: animate1 ? 1.0 : 0.3, anchor: .center)
-                    .opacity(animate1 ? 1 : 0)
-                    .animation(
-                        .easeInOut(duration: 3.0 + Double(i) * 0.5)
-                        .repeatForever(autoreverses: true),
-                        value: animate2
-                    )
-            }
-
-            // Data point stars emerging from aurora
-            auroraDataPoints
-
-            // Central insight orb
-            auroraOrb
-        }
-    }
-
-    private var auroraDataPoints: some View {
-        ForEach(0..<8, id: \.self) { i in
-            let angle = Double(i) * (.pi * 2 / 8) + 0.3
-            let radius: CGFloat = isIPad ? 80 : 65
-            let dotSize: CGFloat = CGFloat(2 + i % 3)
-            Circle()
-                .fill(ivory.opacity(animate3 ? 0.6 : 0))
-                .frame(width: dotSize, height: dotSize)
-                .offset(
-                    x: cos(angle) * radius,
-                    y: sin(angle) * radius * 0.5
-                )
-                .animation(.easeOut(duration: 0.8).delay(Double(i) * 0.1), value: animate3)
-        }
-    }
-
-    private var auroraOrb: some View {
-        ZStack {
-            Circle()
-                .fill(page.iconColor.opacity(animate1 ? 0.12 : 0))
-                .frame(width: isIPad ? 80 : 64, height: isIPad ? 80 : 64)
-
-            Circle()
-                .fill(page.iconColor.opacity(0.4))
-                .frame(width: isIPad ? 36 : 28, height: isIPad ? 36 : 28)
-                .shadow(color: page.iconColor.opacity(0.6), radius: 12)
-
-            Image(systemName: "sparkle")
-                .font(.system(size: isIPad ? 18 : 14, weight: .semibold))
-                .foregroundColor(ivory)
-        }
-        .scaleEffect(animate1 ? 1.0 : 0.6)
-    }
-
-    // MARK: - Page 3: Privacy = Protective Star Shield
-
-    private var shieldConstellation: some View {
-        ZStack {
-            // Outer protective ring of stars
-            shieldStarRing
-
-            // Connection lines forming the shield
-            shieldConnectionLines
-
-            // Pulsing protection rings
-            shieldPulsingRings
-
-            // Central shield
-            shieldCenter
-        }
-    }
-
-    private var shieldStarRing: some View {
-        ForEach(0..<12, id: \.self) { i in
-            let angle = Double(i) * (.pi * 2 / 12)
-            let radius: CGFloat = isIPad ? 100 : 80
-            Circle()
-                .fill(forestGreen.opacity(animate1 ? 0.7 : 0))
-                .frame(width: 4, height: 4)
-                .offset(
-                    x: cos(angle) * radius,
-                    y: sin(angle) * radius
-                )
-                .shadow(color: forestGreen.opacity(0.4), radius: 4)
-                .animation(.easeOut(duration: 0.5).delay(Double(i) * 0.05), value: animate1)
-        }
-    }
-
-    private var shieldConnectionLines: some View {
-        let r: CGFloat = isIPad ? 100 : 80
-        let frameSize: CGFloat = (r + 10) * 2
-        return ForEach(0..<12, id: \.self) { i in
-            let angle1 = Double(i) * (.pi * 2 / 12)
-            let angle2 = Double((i + 1) % 12) * (.pi * 2 / 12)
-            let startX = cos(angle1) * r + r + 10
-            let startY = sin(angle1) * r + r + 10
-            let endX = cos(angle2) * r + r + 10
-            let endY = sin(angle2) * r + r + 10
-            Path { path in
-                path.move(to: CGPoint(x: startX, y: startY))
-                path.addLine(to: CGPoint(x: endX, y: endY))
-            }
-            .stroke(forestGreen.opacity(animate2 ? 0.2 : 0), lineWidth: 0.8)
-            .frame(width: frameSize, height: frameSize)
-            .offset(x: -(r + 10), y: -(r + 10))
-            .animation(.easeOut(duration: 0.8).delay(0.6 + Double(i) * 0.04), value: animate2)
-        }
-    }
-
-    private var shieldPulsingRings: some View {
-        ForEach(0..<3, id: \.self) { i in
-            let ringSize: CGFloat = isIPad ? CGFloat(110 + i * 30) : CGFloat(90 + i * 24)
-            Circle()
-                .stroke(forestGreen.opacity(animate3 ? 0 : 0.2), lineWidth: 1)
-                .frame(width: ringSize, height: ringSize)
-                .scaleEffect(animate3 ? 1.4 : 1.0)
-                .animation(
-                    .easeOut(duration: 2.5)
-                    .repeatForever(autoreverses: false)
-                    .delay(Double(i) * 0.8),
-                    value: animate3
-                )
-        }
-    }
-
-    private var shieldCenter: some View {
-        ZStack {
-            Circle()
-                .fill(forestGreen.opacity(animate1 ? 0.15 : 0))
-                .frame(width: isIPad ? 70 : 56, height: isIPad ? 70 : 56)
-
-            Circle()
-                .fill(forestGreen.opacity(0.35))
-                .frame(width: isIPad ? 44 : 34, height: isIPad ? 44 : 34)
-                .shadow(color: forestGreen.opacity(0.5), radius: 12)
-
-            Image(systemName: "lock.fill")
-                .font(.system(size: isIPad ? 20 : 16, weight: .semibold))
-                .foregroundColor(ivory)
-        }
-        .scaleEffect(animate1 ? 1.0 : 0.5)
-    }
-
-    // MARK: - Planet Dot Helper
-
-    private func planetDot(color: Color, size: CGFloat, label: String) -> some View {
-        VStack(spacing: 3) {
-            ZStack {
-                Circle()
-                    .fill(color.opacity(0.3))
-                    .frame(width: size + 8, height: size + 8)
-                Circle()
-                    .fill(color)
-                    .frame(width: size, height: size)
-                    .shadow(color: color.opacity(0.6), radius: 4)
-            }
-            Text(label.uppercased())
-                .font(.system(size: 7, weight: .bold, design: .rounded))
-                .tracking(1.5)
-                .foregroundColor(ivory.opacity(0.4))
-        }
-        .opacity(animate1 ? 1 : 0)
     }
 }
 
-// MARK: - Intention Check-In Page
+// MARK: - Shared icon badge
+
+private struct IconBadge: View {
+    let symbol: String
+    let tint: Color
+    @State private var appear = false
+
+    var body: some View {
+        ZStack {
+            Circle().fill(tint.opacity(0.12)).frame(width: 104, height: 104)
+            Circle().fill(tint.opacity(0.20)).frame(width: 74, height: 74)
+            Image(systemName: symbol)
+                .font(.system(size: 30, weight: .semibold))
+                .foregroundColor(tint)
+        }
+        .scaleEffect(appear ? 1.0 : 0.6)
+        .opacity(appear ? 1 : 0)
+        .onAppear { withAnimation(.spring(response: 0.5, dampingFraction: 0.65)) { appear = true } }
+    }
+}
+
+// MARK: - Intention Check-In ("Name your planets")
 
 struct IntentionCheckInView: View {
     @Binding var selectedIntentions: Set<String>
@@ -663,22 +418,21 @@ struct IntentionCheckInView: View {
     ]
 
     var body: some View {
-        VStack(spacing: isIPad ? 32 : 24) {
+        VStack(spacing: isIPad ? 28 : 22) {
             Spacer()
 
-            VStack(spacing: 12) {
+            VStack(spacing: 10) {
                 Text("Name your planets")
-                    .font(.system(size: isIPad ? 40 : 32, weight: .bold, design: .rounded))
-                    .foregroundColor(.white)
+                    .font(.system(size: isIPad ? 38 : 30, weight: .bold, design: .rounded))
+                    .foregroundColor(OB.ink)
                     .multilineTextAlignment(.center)
-
-                Text("Each intention becomes a planet in your constellation. Pick the ones that matter.")
-                    .font(isIPad ? .title3 : .body)
-                    .foregroundColor(.white.opacity(0.7))
+                Text("Each intention becomes a planet in your sky. Pick the ones that matter.")
+                    .font(.system(size: 15, weight: .regular, design: .rounded))
+                    .foregroundColor(OB.inkDim)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 20)
             }
-            .padding(.horizontal, isIPad ? 80 : 30)
+            .padding(.horizontal, isIPad ? 80 : 28)
 
             VStack(spacing: 12) {
                 ForEach(intentions, id: \.title) { intention in
@@ -697,7 +451,7 @@ struct IntentionCheckInView: View {
                     }
                 }
             }
-            .padding(.horizontal, isIPad ? 80 : 30)
+            .padding(.horizontal, isIPad ? 80 : 28)
             .frame(maxWidth: isIPad ? 600 : .infinity)
 
             Spacer()
@@ -718,44 +472,66 @@ struct IntentionCard: View {
         Button(action: onTap) {
             HStack(spacing: 14) {
                 Image(systemName: icon)
-                    .font(.system(size: isIPad ? 24 : 20))
-                    .foregroundColor(isSelected ? .white : .white.opacity(0.7))
-                    .frame(width: 32)
+                    .font(.system(size: isIPad ? 22 : 19))
+                    .foregroundColor(isSelected ? OB.sage : OB.inkMute)
+                    .frame(width: 30)
 
                 Text(title)
-                    .font(isIPad ? .title3.weight(.medium) : .body.weight(.medium))
-                    .foregroundColor(isSelected ? .white : .white.opacity(0.8))
+                    .font(.system(size: isIPad ? 18 : 16, weight: .medium, design: .rounded))
+                    .foregroundColor(isSelected ? OB.ink : OB.inkDim)
 
                 Spacer()
 
-                Text(planet)
+                Text(planet.uppercased())
                     .font(.system(size: 9, weight: .bold, design: .rounded))
                     .tracking(1.5)
-                    .foregroundColor(isSelected ? Color(red: 0.831, green: 0.647, blue: 0.278) : .white.opacity(0.25))
+                    .foregroundColor(isSelected ? OB.gold : OB.inkMute.opacity(0.6))
 
                 if isSelected {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 20))
-                        .foregroundColor(Color(red: 0.420, green: 0.620, blue: 0.482))
+                        .foregroundColor(OB.forest)
                 }
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 16)
+            .padding(.horizontal, 18)
+            .padding(.vertical, 15)
             .background(
-                RoundedRectangle(cornerRadius: 14)
-                    .fill(isSelected ? Color.white.opacity(0.15) : Color.white.opacity(0.06))
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(isSelected ? OB.sage.opacity(0.10) : OB.card)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 14)
-                    .stroke(isSelected ? Color(red: 0.357, green: 0.486, blue: 0.420).opacity(0.7) : Color.white.opacity(0.1), lineWidth: 1.5)
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(isSelected ? OB.sage.opacity(0.7) : OB.rule, lineWidth: isSelected ? 1.5 : 1)
             )
+            .shadow(color: OB.ink.opacity(isSelected ? 0 : 0.03), radius: 5, y: 2)
         }
         .buttonStyle(.plain)
         .animation(.easeInOut(duration: 0.2), value: isSelected)
     }
 }
 
-// MARK: - Privacy Badge Component
+// MARK: - Ivory constellation field (soft sage/gold dots on light)
+
+private struct IvorySky: View {
+    var body: some View {
+        Canvas { context, size in
+            for i in 0..<44 {
+                let seed = UInt64(i) &* 6364136223846793005 &+ 1442695040888963407
+                let x = Double((seed >> 16) % 10000) / 10000.0 * size.width
+                let y = Double((seed >> 32) % 10000) / 10000.0 * size.height
+                let r = Double((seed >> 48) % 100) / 100.0 * 1.6 + 0.4
+                let useGold = (seed >> 4) % 5 == 0
+                let opacity = Double((seed >> 8) % 100) / 100.0 * 0.14 + 0.05
+                let dot = Path(ellipseIn: CGRect(x: x - r, y: y - r, width: r * 2, height: r * 2))
+                context.fill(dot, with: .color((useGold ? OB.gold : OB.sage).opacity(opacity)))
+            }
+        }
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Shared components used elsewhere in the app (unchanged)
 
 struct PrivacyBadge: View {
     var compact: Bool = false
@@ -779,8 +555,6 @@ struct PrivacyBadge: View {
     }
 }
 
-// MARK: - Offline Indicator
-
 struct OfflineIndicator: View {
     var body: some View {
         HStack(spacing: 4) {
@@ -798,8 +572,7 @@ struct OfflineIndicator: View {
     }
 }
 
-// MARK: - Star Field Background
-
+/// Ambient star field used by empty states / recording screens (white on dark).
 struct StarFieldView: View {
     let count: Int
 


### PR DESCRIPTION
Rebuilds onboarding from the current **dark** night-sky look to the app's **warm ivory** palette, keeping the **constellation / "inner sky"** language. Based on the Stitch design exploration; direction chosen: ivory-light primary + constellation language.

### Flow
Welcome → **Name yourself** (new, optional) → Your Twin → Private → Name your planets → **Ready to record**

### What's new
- **Ivory-light throughout** (was dark espresso/night gradients + white text → warm paper + ink text)
- **Soft sage/gold constellation field** (`IvorySky`) instead of white-on-dark starfield
- **New skippable Name step** — sage focus ring, "Optional — stored only on your phone," saved to `UserDefaults["userName"]`
- **Personalised finish** — "Ready when you are, {name}." with a **"Record my first star"** CTA that drops the user straight into their first recording (activation)
- Simpler, cleaner per-screen visuals (icon-in-soft-circle) in the Stitch spirit; kept the signature breathing-star welcome
- Preserves `StarFieldView` / `PrivacyBadge` / `OfflineIndicator` (used elsewhere) unchanged

### Verification
✅ `xcodebuild ... BUILD SUCCEEDED` (iOS Simulator). Visual spacing/color still worth a **device pass** to tune.

### Follow-ups (not in this PR)
- **Use the stored name** — greet in the Twin, personalise shareable cards (amplifies the viral loop).
- Localised name/subtitle for India.