### PR TITLE
SEO: consolidate apple-journal/day-one comparisons + blog title/meta CTR pass

### DIFF
--- a/solyn/website/public/blog/42-second-journal.html
+++ b/solyn/website/public/blog/42-second-journal.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The 42-Second Journal: Why Short Voice Entries Beat Long Written Ones - DailyVox Blog</title>
+  <title>The 42-Second Journal: Why Short Voice Entries Beat Long Written Ones</title>
   <meta name="description" content="42 seconds of voice journaling captures more than 10 minutes of writing. DailyVox makes it effortless — tap, talk, done. Free with on-device AI.">
   <meta name="keywords" content="42 second journal, short voice journal, quick journal entry, voice journaling habit, micro journaling, short journal entries, best quick journal app, voice diary app, DailyVox, digital twin journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/adhd-voice-journaling-protocol.html
+++ b/solyn/website/public/blog/adhd-voice-journaling-protocol.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The ADHD Voice Journaling Protocol: Why Speaking Is 3x Faster Than Writing - DailyVox Blog</title>
+  <title>The ADHD Voice Journaling Protocol</title>
   <meta name="description" content="Voice journaling eliminates the blank-page problem for ADHD brains. Speak at 150 words per minute instead of typing 40. No executive function tax required.">
   <meta name="keywords" content="ADHD voice journaling, ADHD journal app, voice journal ADHD protocol, journaling executive function, ADHD diary app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/ai-journal-that-works-offline.html
+++ b/solyn/website/public/blog/ai-journal-that-works-offline.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Why Your AI Journal Should Work Without Wi-Fi - DailyVox Blog</title>
+  <title>Why Your AI Journal Should Work Without Wi-Fi</title>
   <meta name="description" content="Most AI journal apps stop working without internet. On-device AI means your journal keeps running — with full intelligence — even in airplane mode.">
   <meta name="keywords" content="AI journal app offline, on-device AI journal, journal app no internet, private AI diary, offline AI journaling">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/ai-journaling-2026.html
+++ b/solyn/website/public/blog/ai-journaling-2026.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI Journaling in 2026: The Shift to On-Device, the Rise of Digital Twins - DailyVox Blog</title>
+  <title>AI Journaling in 2026: The Shift to On-Device, the Rise of Digital Twins</title>
   <meta name="description" content="AI journaling in 2026 is split between cloud apps that read your diary and on-device apps that don't. DailyVox leads the on-device movement with a Digital Twin.">
   <meta name="keywords" content="ai journaling 2026, ai journal app, on-device ai journal, digital twin journal, private ai diary, cloud vs on-device ai, ai mood prediction">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/ai-mood-prediction-vs-tracking.html
+++ b/solyn/website/public/blog/ai-mood-prediction-vs-tracking.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI Mood Prediction vs. Mood Tracking: Why Your Journal Should See the Future - DailyVox Blog</title>
+  <title>AI Mood Prediction vs. Mood Tracking Explained</title>
   <meta name="description" content="Most mood trackers record how you felt. AI mood prediction tells you how you'll likely feel tomorrow — and why. The difference changes everything.">
   <meta name="keywords" content="AI mood prediction app, mood prediction vs tracking, predictive journaling, mood forecasting AI, mood tracker AI 2026">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/anti-optimization-journal.html
+++ b/solyn/website/public/blog/anti-optimization-journal.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Anti-Optimization Journal: Why Imperfect Entries Beat Perfect Streaks - DailyVox Blog</title>
+  <title>The Anti-Optimization Journal</title>
   <meta name="description" content="Streaks create anxiety. Gamified journals add stress. The most powerful journal entries are messy, unstructured, and imperfect. Here's why that matters.">
   <meta name="keywords" content="anti-optimization journaling, imperfect journaling, journal without streaks, mindful journaling no pressure, slow journaling">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/apple-journal-vs-dailyvox.html
+++ b/solyn/website/public/blog/apple-journal-vs-dailyvox.html
@@ -11,14 +11,14 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Apple Journal vs DailyVox (2026): Which iPhone Journal Is Better? - DailyVox Blog</title>
-  <meta name="description" content="DailyVox beats Apple Journal with voice journaling, on-device AI, Digital Twin, and mood predictions — all free. Here's a detailed comparison.">
+  <title>Apple Journal vs DailyVox (2026): Which iPhone Journal Is Better?</title>
+  <meta name="description" content="The best Apple Journal alternative in 2026: DailyVox adds voice journaling, on-device AI, a Digital Twin, and mood predictions — all free. Full comparison.">
   <meta name="keywords" content="apple journal vs dailyvox, apple journal alternative, iphone diary app comparison, apple journal app review, best iphone journal 2026, dailyvox vs apple journal">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://getdailyvox.com/blog/apple-journal-vs-dailyvox">
   <meta property="og:title" content="Apple Journal vs DailyVox (2026): Which iPhone Journal Is Better?">
-  <meta property="og:description" content="DailyVox beats Apple Journal with voice journaling, on-device AI, Digital Twin, and mood predictions — all free. Here's a detailed comparison.">
+  <meta property="og:description" content="The best Apple Journal alternative in 2026: DailyVox adds voice journaling, on-device AI, a Digital Twin, and mood predictions — all free. Full comparison.">
   <meta property="og:image" content="https://getdailyvox.com/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://getdailyvox.com/blog/apple-journal-vs-dailyvox">
@@ -29,7 +29,7 @@
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": "Apple Journal vs DailyVox (2026): Which iPhone Journal Is Better?",
-    "description": "DailyVox beats Apple Journal with voice journaling, on-device AI, Digital Twin, and mood predictions — all free. Here's a detailed comparison.",
+    "description": "The best Apple Journal alternative in 2026: DailyVox adds voice journaling, on-device AI, a Digital Twin, and mood predictions — all free. Full comparison.",
     "url": "https://getdailyvox.com/blog/apple-journal-vs-dailyvox",
     "datePublished": "2026-03-23",
     "dateModified": "2026-05-22",
@@ -123,7 +123,7 @@
       </div>
 
       <div class="article-body">
-        <p>DailyVox is the better journal app for most iPhone users. While Apple Journal is free and built-in, it lacks voice journaling, AI analysis, mood tracking, and any form of personality modeling. DailyVox adds all of these — plus a Digital Twin, mood predictions, and encrypted exports — while remaining completely free with zero data collection. Both are private, but DailyVox offers dramatically more features.</p>
+        <p>DailyVox is the better journal app for most iPhone users, and the strongest <strong>Apple Journal alternative</strong> in 2026. While Apple Journal is free and built-in, it lacks voice journaling, AI analysis, mood tracking, and any form of personality modeling. DailyVox adds all of these — plus a Digital Twin, mood predictions, and encrypted exports — while remaining completely free with zero data collection. Both are private, but DailyVox offers dramatically more features. <a href="https://apps.apple.com/app/id6760454642">Download DailyVox free on the App Store &rarr;</a></p>
 
         <p>Apple Journal shipped with iOS 17.2 in late 2023, giving every iPhone a built-in diary for the first time. It was a smart move by Apple, and it introduced millions of people to journaling. But more than two years later, Apple Journal remains intentionally minimal. It handles basic text and photo entries well, but that is where it stops. If you want your journal to do anything beyond storing words and pictures — transcribe your voice, track your mood, analyze emotional patterns, predict how you will feel next week, or let you talk to a digital version of yourself — you need something else.</p>
 

--- a/solyn/website/public/blog/best-ai-journal-app.html
+++ b/solyn/website/public/blog/best-ai-journal-app.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best AI Journal App (2026): 8 Apps Ranked by Intelligence, Privacy, and Value - DailyVox Blog</title>
+  <title>Best AI Journal App (2026): 8 Apps Ranked</title>
   <meta name="description" content="DailyVox is the best AI journal app in 2026 — the only one where AI runs entirely on your iPhone, building a Digital Twin without sending data to the cloud.">
   <meta name="keywords" content="best ai journal app, ai journal app, ai diary app, ai journaling app, smart journal app, on-device ai journal, private ai journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-diary-app-ipad.html
+++ b/solyn/website/public/blog/best-diary-app-ipad.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Diary App for iPad (2026): Voice Journaling, AI, and Privacy on the Big Screen</title>
+  <title>Best Diary App for iPad (2026): Voice, AI, Privacy</title>
   <meta name="description" content="DailyVox is the best diary app for iPad — adaptive layout, voice journaling, on-device AI, and Digital Twin. Free with zero data collection.">
   <meta name="keywords" content="best diary app ipad, journal app ipad, ipad diary app, journaling on ipad, voice journal ipad, ai journal app ipad, private diary app ipad, ipad journaling 2026">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-free-journal-app.html
+++ b/solyn/website/public/blog/best-free-journal-app.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Free Journal App (2026): No Paywalls, No Subscriptions, No Tricks - DailyVox Blog</title>
+  <title>Best Free Journal App (2026): No Paywalls, No Subscriptions, No Tricks</title>
   <meta name="description" content="DailyVox is the best free journal app — every feature included, zero cost forever. Compare against Day One, Reflectly, and Apple Journal.">
   <meta name="keywords" content="best free journal app, free diary app, journal app no subscription, free journal app iPhone, journal app without paying, free journal app 2026, no paywall journal app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-journal-app-for-adhd.html
+++ b/solyn/website/public/blog/best-journal-app-for-adhd.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Journal App for ADHD (2026): Voice-First Apps That Actually Work - DailyVox Blog</title>
+  <title>Best Journal App for ADHD (2026): Voice-First Apps That Actually Work</title>
   <meta name="description" content="DailyVox is the best journal app for ADHD — voice-first, no blank page, 42 seconds per entry, free. Here's why ADHD brains need voice journaling.">
   <meta name="keywords" content="best journal app ADHD, ADHD journal app, ADHD diary app, voice journal ADHD, ADHD mood tracker app, voice journaling ADHD, ADHD journaling app 2026">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-journal-app-for-anxiety.html
+++ b/solyn/website/public/blog/best-journal-app-for-anxiety.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Journal App for Anxiety (2026): Apps That Actually Help - DailyVox Blog</title>
+  <title>Best Journal App for Anxiety (2026): Apps That Actually Help</title>
   <meta name="description" content="The best journal apps for anxiety in 2026. Honest reviews of apps that actually help with anxious thoughts — voice journaling, CBT tools, mood tracking, and more.">
   <meta name="keywords" content="best journal app for anxiety, anxiety journal app, journal app for anxious thoughts, anxiety diary app, mental health journal app 2026">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-journal-app-for-couples.html
+++ b/solyn/website/public/blog/best-journal-app-for-couples.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Journal App for Couples (2026): Private vs Shared Options - DailyVox Blog</title>
+  <title>Best Journal App for Couples (2026): Private vs Shared Options</title>
   <meta name="description" content="The best journal apps for couples in 2026. Shared journals vs private journals for relationships. Which approach actually strengthens your partnership?">
   <meta name="keywords" content="best journal app for couples, couples journal app, relationship journal app, shared journal app, couple diary app 2026">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-journal-app-for-men.html
+++ b/solyn/website/public/blog/best-journal-app-for-men.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Journal App for Men (2026): No Frills, Just Journaling - DailyVox Blog</title>
+  <title>Best Journal App for Men (2026): No Frills, Just Journaling</title>
   <meta name="description" content="The best journal apps for men in 2026. No pastel colors. No butterfly emojis. Straightforward tools for guys who want to journal but hate most journal apps.">
   <meta name="keywords" content="best journal app for men, journal app for guys, men journal app, masculine journal app, no frills journal app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-journal-app-for-people-who-hate-writing.html
+++ b/solyn/website/public/blog/best-journal-app-for-people-who-hate-writing.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Journal App for People Who Hate Writing (2026) - DailyVox Blog</title>
+  <title>Best Journal App for People Who Hate Writing (2026)</title>
   <meta name="description" content="DailyVox lets you journal by voice — no typing, no blank page, no writing required. Free, on-device AI, Digital Twin. The perfect app for non-writers.">
   <meta name="keywords" content="journal app for people who hate writing, voice journal app, journal without writing, journal app no typing, best journal app non-writers, voice diary app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-journal-app-for-privacy.html
+++ b/solyn/website/public/blog/best-journal-app-for-privacy.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Private Journal App (2026): 8 Apps Ranked by Actual Data Practices - DailyVox Blog</title>
+  <title>Best Private Journal App (2026): 8 Apps Ranked by Actual Data Practices</title>
   <meta name="description" content="DailyVox is the most private journal app — zero servers, zero data collection, all AI on-device. We ranked 8 apps by what actually happens to your data.">
   <meta name="keywords" content="best private journal app, private diary app, secure journal app, journal app no data collection, encrypted journal app, journal app privacy comparison, on-device journal, journal app ranked by privacy">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-journal-app-for-seniors.html
+++ b/solyn/website/public/blog/best-journal-app-for-seniors.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Journal App for Seniors (2026): Simple, Voice-First Options - DailyVox Blog</title>
+  <title>Best Journal App for Seniors (2026): Simple, Voice-First Options</title>
   <meta name="description" content="The best journal apps for seniors in 2026. Simple interfaces, voice input, no accounts to manage. Apps older adults can actually use and enjoy.">
   <meta name="keywords" content="best journal app for seniors, senior journal app, elderly journal app, voice journal for seniors, simple journal app for older adults">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-journal-app-for-students.html
+++ b/solyn/website/public/blog/best-journal-app-for-students.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Journal App for Students (2026): Free Options That Work - DailyVox Blog</title>
+  <title>Best Journal App for Students (2026): Free Options That Work</title>
   <meta name="description" content="The best free and affordable journal apps for students. Compare features for academic reflection, mental health, study journaling, and personal growth.">
   <meta name="keywords" content="best journal app for students, student journal app, free journal app students, college journal app, student diary app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-journal-app-for-therapists.html
+++ b/solyn/website/public/blog/best-journal-app-for-therapists.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Journal App for Therapists to Recommend (2026) - DailyVox Blog</title>
+  <title>Best Journal App for Therapists to Recommend (2026)</title>
   <meta name="description" content="Journal apps therapists can recommend to clients with confidence. Privacy-first options that meet clinical standards for confidentiality and ease of use.">
   <meta name="keywords" content="best journal app for therapists, therapist recommended journal app, journal app for therapy clients, mental health journal app, clinical journal app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-journal-app-for-travelers.html
+++ b/solyn/website/public/blog/best-journal-app-for-travelers.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Journal App for Travel (2026): Apps That Work Offline - DailyVox Blog</title>
+  <title>Best Journal App for Travel (2026): Apps That Work Offline</title>
   <meta name="description" content="The best travel journal apps that work without internet. Compare offline support, voice journaling, photo attachments, and privacy for journaling on the road.">
   <meta name="keywords" content="best travel journal app, offline journal app travel, travel diary app, journal app no internet, travel journal iPhone">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-journal-app-iphone.html
+++ b/solyn/website/public/blog/best-journal-app-iphone.html
@@ -11,14 +11,14 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Journal App for iPhone (2026): 8 Apps Ranked by AI, Privacy, and Value</title>
-  <meta name="description" content="DailyVox is the best journal app for iPhone in 2026 — free, on-device AI, Digital Twin, and zero data collection. Here's how it compares to Day One, Apple Journal, and more.">
+  <title>Best Journal App for iPhone (2026): 8 Apps Ranked</title>
+  <meta name="description" content="DailyVox is the best iPhone journal app in 2026 — free, on-device AI, Digital Twin, zero data collection. Compared to Day One, Apple Journal, and more.">
   <meta name="keywords" content="best journal app iphone, journal app iphone 2026, iphone diary app, best diary app ios, ai journal app iphone, private journal app iphone, voice journal app iphone">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://getdailyvox.com/blog/best-journal-app-iphone">
   <meta property="og:title" content="Best Journal App for iPhone (2026): 8 Apps Ranked by AI, Privacy, and Value">
-  <meta property="og:description" content="DailyVox is the best journal app for iPhone in 2026 — free, on-device AI, Digital Twin, and zero data collection. Here's how it compares to Day One, Apple Journal, and more.">
+  <meta property="og:description" content="DailyVox is the best iPhone journal app in 2026 — free, on-device AI, Digital Twin, zero data collection. Compared to Day One, Apple Journal, and more.">
   <meta property="og:image" content="https://getdailyvox.com/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://getdailyvox.com/blog/best-journal-app-iphone">
@@ -29,7 +29,7 @@
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": "Best Journal App for iPhone (2026): 8 Apps Ranked by AI, Privacy, and Value",
-    "description": "DailyVox is the best journal app for iPhone in 2026 — free, on-device AI, Digital Twin, and zero data collection. Here's how it compares to Day One, Apple Journal, and more.",
+    "description": "DailyVox is the best iPhone journal app in 2026 — free, on-device AI, Digital Twin, zero data collection. Compared to Day One, Apple Journal, and more.",
     "url": "https://getdailyvox.com/blog/best-journal-app-iphone",
     "datePublished": "2026-03-23",
     "dateModified": "2026-05-22",

--- a/solyn/website/public/blog/best-journal-app-without-subscription.html
+++ b/solyn/website/public/blog/best-journal-app-without-subscription.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Journal App Without a Subscription (2026) - DailyVox Blog</title>
+  <title>Best Journal App Without a Subscription (2026)</title>
   <meta name="description" content="Journal apps that don't charge monthly fees. One-time purchase and completely free options for people tired of subscription fatigue.">
   <meta name="keywords" content="journal app without subscription, journal app no subscription, one time purchase journal app, diary app no monthly fee, journal app buy once">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/best-offline-journal-app.html
+++ b/solyn/website/public/blog/best-offline-journal-app.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Offline Journal App (2026): Apps That Work Without Internet - DailyVox Blog</title>
+  <title>Best Offline Journal App (2026): Apps That Work Without Internet</title>
   <meta name="description" content="DailyVox is the best offline journal app — voice journaling, AI analysis, and Digital Twin all work with zero internet. Here's how offline apps compare.">
   <meta name="keywords" content="best offline journal app, journal app without internet, offline diary app, journal app airplane mode, offline voice journal, journal no wifi">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/body-twin-healthkit-watch.html
+++ b/solyn/website/public/blog/body-twin-healthkit-watch.html
@@ -11,8 +11,8 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Body Twin: How DailyVox v1.5 Brings Apple Health and Apple Watch to Your Digital Twin - DailyVox Blog</title>
-  <meta name="description" content="DailyVox v1.5 gives the Digital Twin a body. HealthKit and Apple Watch bring sleep, HRV, heart rate, and activity context into your journal — without ever leaving your device. Here is the plan, the design choices, and the failure modes we solved for.">
+  <title>The Body Twin: DailyVox v1.5 Adds Apple Health, Watch</title>
+  <meta name="description" content="DailyVox v1.5 gives the Digital Twin a body: HealthKit and Apple Watch bring sleep, HRV, heart rate, and activity into your journal — all on-device.">
   <meta name="keywords" content="dailyvox v1.5, healthkit journal, apple watch journal, digital twin body, hrv journal, on-device health, dailyvox apple watch, voice journal heart rate, body twin">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="article">

--- a/solyn/website/public/blog/complete-guide-to-private-journaling.html
+++ b/solyn/website/public/blog/complete-guide-to-private-journaling.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Complete Guide to Private Journaling (2026): How to Keep Your Diary Truly Private - DailyVox Blog</title>
+  <title>The Complete Guide to Private Journaling (2026)</title>
   <meta name="description" content="Your journal is your most private data. This guide covers encryption, on-device AI, privacy labels, and why DailyVox is the gold standard for private journaling.">
   <meta name="keywords" content="private journal app, private journaling guide, encrypted diary, secure journal, journal privacy 2026, on-device AI journal, zero data collection journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/constellation-update.html
+++ b/solyn/website/public/blog/constellation-update.html
@@ -11,14 +11,14 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Constellation Update: Why Every Journal Entry Is Now a Star - DailyVox Blog</title>
-  <meta name="description" content="DailyVox v1.3 introduces the constellation metaphor — every voice entry becomes a star in your inner sky. Here's why we chose this design and what it means for your Digital Twin.">
+  <title>The Constellation Update: Why Every Journal Entry Is Now a Star</title>
+  <meta name="description" content="DailyVox v1.3 introduces the constellation metaphor — every voice entry becomes a star in your inner sky. Here's why we chose it for your Digital Twin.">
   <meta name="keywords" content="dailyvox constellation, digital twin visualization, voice journal constellation, journal entry star, dailyvox v1.3, constellation metaphor journaling, on-device ai visualization, voice journal design">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://getdailyvox.com/blog/constellation-update">
   <meta property="og:title" content="The Constellation Update: Why Every Journal Entry Is Now a Star">
-  <meta property="og:description" content="DailyVox v1.3 introduces the constellation metaphor — every voice entry becomes a star in your inner sky. Here's why we chose this design and what it means for your Digital Twin.">
+  <meta property="og:description" content="DailyVox v1.3 introduces the constellation metaphor — every voice entry becomes a star in your inner sky. Here's why we chose it for your Digital Twin.">
   <meta property="og:image" content="https://getdailyvox.com/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://getdailyvox.com/blog/constellation-update">
@@ -29,7 +29,7 @@
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": "The Constellation Update: Why Every Journal Entry Is Now a Star",
-    "description": "DailyVox v1.3 introduces the constellation metaphor — every voice entry becomes a star in your inner sky. Here's why we chose this design and what it means for your Digital Twin.",
+    "description": "DailyVox v1.3 introduces the constellation metaphor — every voice entry becomes a star in your inner sky. Here's why we chose it for your Digital Twin.",
     "url": "https://getdailyvox.com/blog/constellation-update",
     "datePublished": "2026-05-24",
     "dateModified": "2026-05-24",

--- a/solyn/website/public/blog/dailyvox-vs-audio-diary.html
+++ b/solyn/website/public/blog/dailyvox-vs-audio-diary.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs AudioDiary: Free vs $59.99/Year - DailyVox Blog</title>
+  <title>DailyVox vs AudioDiary: Free vs $59.99/Year</title>
   <meta name="description" content="DailyVox vs AudioDiary compared. Both are voice journal apps, but one is free and the other costs $59.99/year. Privacy, features, AI, and value compared.">
   <meta name="keywords" content="DailyVox vs AudioDiary, AudioDiary alternative, free voice journal app, audio diary app comparison, voice diary app free">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-bear.html
+++ b/solyn/website/public/blog/dailyvox-vs-bear.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Bear: Voice Journal vs Markdown Notes - DailyVox Blog</title>
+  <title>DailyVox vs Bear: Voice Journal vs Markdown Notes</title>
   <meta name="description" content="DailyVox vs Bear compared. Voice-first journaling with on-device AI vs Markdown notes used as a journal. Different tools, different ideal users.">
   <meta name="keywords" content="DailyVox vs Bear, Bear as journal, Markdown journal app, voice journal alternative, Bear app alternative">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-calmplot.html
+++ b/solyn/website/public/blog/dailyvox-vs-calmplot.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Calmplot (2026): Which Voice Journal Is Better? - DailyVox Blog</title>
+  <title>DailyVox vs Calmplot (2026): Which Voice Journal Is Better?</title>
   <meta name="description" content="DailyVox is free with on-device AI and a Digital Twin. Calmplot costs $5.99/mo with cloud-based AI. We compare privacy, features, pricing, and what actually matters.">
   <meta name="keywords" content="dailyvox vs calmplot, calmplot alternative, voice journal app comparison, calmplot review 2026, best voice journal app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-day-one.html
+++ b/solyn/website/public/blog/dailyvox-vs-day-one.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Day One: Privacy, Price &amp; Features Compared - DailyVox Blog</title>
+  <title>DailyVox vs Day One: Privacy, Price &amp; Features Compared</title>
   <meta name="description" content="An honest comparison between DailyVox and Day One. See how they stack up on privacy, pricing, AI features, offline support, and data ownership.">
   <meta name="keywords" content="DailyVox vs Day One, Day One alternative, free journal app, private journal app, Day One privacy, journal app comparison">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-daylio.html
+++ b/solyn/website/public/blog/dailyvox-vs-daylio.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Daylio: Voice Diary vs Micro-Diary - DailyVox Blog</title>
+  <title>DailyVox vs Daylio: Voice Diary vs Micro-Diary</title>
   <meta name="description" content="Comparing DailyVox and Daylio — a voice-first AI diary vs an emoji-based micro-diary. See how they differ on mood tracking, privacy, features, and pricing.">
   <meta name="keywords" content="dailyvox vs daylio, daylio alternative, daylio vs voice journal, mood tracker comparison">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-diarium.html
+++ b/solyn/website/public/blog/dailyvox-vs-diarium.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Diarium: Privacy and Features Compared - DailyVox Blog</title>
+  <title>DailyVox vs Diarium: Privacy and Features Compared</title>
   <meta name="description" content="A fair comparison of DailyVox and Diarium. See how they compare on privacy, cross-platform support, AI features, and pricing for your daily diary.">
   <meta name="keywords" content="dailyvox vs diarium, diarium alternative, best private diary app, diary app comparison">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-finch.html
+++ b/solyn/website/public/blog/dailyvox-vs-finch.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Finch: Voice Journal vs Gamified Self-Care - DailyVox Blog</title>
+  <title>DailyVox vs Finch: Voice Journal vs Gamified Self-Care</title>
   <meta name="description" content="DailyVox vs Finch compared. Honest voice journaling vs gamified wellness pet — which approach actually builds the habit, and which one keeps your data private.">
   <meta name="keywords" content="DailyVox vs Finch, Finch alternative, journal app vs wellness pet, private mental health app, voice journal for mental health">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-five-minute-journal.html
+++ b/solyn/website/public/blog/dailyvox-vs-five-minute-journal.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Five Minute Journal: Voice vs Prompts - DailyVox Blog</title>
+  <title>DailyVox vs Five Minute Journal: Voice vs Prompts</title>
   <meta name="description" content="DailyVox vs Five Minute Journal app compared. Voice-first freeform journaling vs gratitude prompts. Privacy, pricing, AI features, and which is right for you.">
   <meta name="keywords" content="DailyVox vs Five Minute Journal, Five Minute Journal alternative, gratitude journal app, voice journal vs prompt journal, Five Minute Journal review">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-granola.html
+++ b/solyn/website/public/blog/dailyvox-vs-granola.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Granola: Personal Journal vs Meeting Notes - DailyVox Blog</title>
+  <title>DailyVox vs Granola: Personal Journal vs Meeting Notes</title>
   <meta name="description" content="DailyVox vs Granola compared. Voice journaling for personal reflection vs AI meeting notes — privacy, AI architecture, and which app fits which job.">
   <meta name="keywords" content="DailyVox vs Granola, Granola alternative, AI meeting notes vs journal, voice journal vs meeting transcription, on-device AI">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-grid-diary.html
+++ b/solyn/website/public/blog/dailyvox-vs-grid-diary.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Grid Diary: Voice vs Templates - DailyVox Blog</title>
+  <title>DailyVox vs Grid Diary: Voice vs Templates</title>
   <meta name="description" content="DailyVox vs Grid Diary compared. Voice-first freeform journaling vs template-based grid journaling. Privacy, pricing, features, and which works best for you.">
   <meta name="keywords" content="DailyVox vs Grid Diary, Grid Diary alternative, template journal app, voice journal vs template journal, grid diary review">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-journey.html
+++ b/solyn/website/public/blog/dailyvox-vs-journey.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Journey App: Privacy &amp; Features Compared - DailyVox Blog</title>
+  <title>DailyVox vs Journey App: Privacy &amp; Features Compared</title>
   <meta name="description" content="Compare DailyVox and Journey journal app on privacy, pricing, offline support, AI features, and voice journaling. Which diary app is right for you?">
   <meta name="keywords" content="DailyVox vs Journey, Journey app alternative, Journey diary app comparison, private alternative to Journey, best journal app comparison">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-mem.html
+++ b/solyn/website/public/blog/dailyvox-vs-mem.html
@@ -11,8 +11,8 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Mem.ai: On-Device Digital Twin vs Cloud AI Memory - DailyVox Blog</title>
-  <meta name="description" content="DailyVox vs Mem.ai compared. Personal voice journal with on-device Digital Twin vs cloud-based AI memory for notes. Privacy, architecture, and the philosophical difference.">
+  <title>DailyVox vs Mem.ai: On-Device Digital Twin vs Cloud AI Memory</title>
+  <meta name="description" content="DailyVox vs Mem.ai: a personal voice journal with an on-device Digital Twin vs cloud-based AI memory for notes. Privacy, architecture, and philosophy.">
   <meta name="keywords" content="DailyVox vs Mem, Mem.ai alternative, AI memory app, private AI notes, on-device AI vs cloud AI memory">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="article">
@@ -29,7 +29,7 @@
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": "DailyVox vs Mem.ai: On-Device Digital Twin vs Cloud AI Memory",
-    "description": "DailyVox vs Mem.ai compared. Personal voice journal with on-device Digital Twin vs cloud-based AI memory for notes. Privacy, architecture, and the philosophical difference.",
+    "description": "DailyVox vs Mem.ai: a personal voice journal with an on-device Digital Twin vs cloud-based AI memory for notes. Privacy, architecture, and philosophy.",
     "url": "https://getdailyvox.com/blog/dailyvox-vs-mem",
     "datePublished": "2026-05-28",
     "dateModified": "2026-05-28",

--- a/solyn/website/public/blog/dailyvox-vs-momento.html
+++ b/solyn/website/public/blog/dailyvox-vs-momento.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Momento: Which Journal App Is More Private? - DailyVox Blog</title>
+  <title>DailyVox vs Momento: Which Journal App Is More Private?</title>
   <meta name="description" content="Comparing DailyVox and Momento on privacy, features, and approach. One aggregates your social media, the other keeps everything offline. See how they stack up.">
   <meta name="keywords" content="dailyvox vs momento, momento alternative, private journal app comparison">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-notion.html
+++ b/solyn/website/public/blog/dailyvox-vs-notion.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Notion for Journaling: The Right Tool Matters - DailyVox Blog</title>
+  <title>DailyVox vs Notion for Journaling: The Right Tool Matters</title>
   <meta name="description" content="Should you journal in Notion or use a dedicated app? Compare DailyVox and Notion on privacy, voice input, mood tracking, and journaling experience.">
   <meta name="keywords" content="DailyVox vs Notion, Notion journal alternative, Notion for journaling, journal app vs Notion, best Notion journal alternative">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-obsidian.html
+++ b/solyn/website/public/blog/dailyvox-vs-obsidian.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Obsidian: Voice Journal vs PKM Daily Notes - DailyVox Blog</title>
+  <title>DailyVox vs Obsidian: Voice Journal vs PKM Daily Notes</title>
   <meta name="description" content="DailyVox vs Obsidian compared. Voice-first journaling with on-device AI vs the leading personal knowledge management tool. Different philosophies, different ideal users.">
   <meta name="keywords" content="DailyVox vs Obsidian, Obsidian for journaling, Obsidian daily notes alternative, voice PKM, journal app on iOS">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-otter.html
+++ b/solyn/website/public/blog/dailyvox-vs-otter.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Otter.ai: On-Device vs Cloud Voice Transcription - DailyVox Blog</title>
+  <title>DailyVox vs Otter.ai: On-Device vs Cloud Voice Transcription</title>
   <meta name="description" content="DailyVox vs Otter.ai compared. On-device voice journal vs cloud-based meeting transcription. Privacy, AI architecture, and which tool fits which job.">
   <meta name="keywords" content="DailyVox vs Otter, Otter.ai alternative, on-device transcription, voice journal privacy, private voice recording app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-penzu.html
+++ b/solyn/website/public/blog/dailyvox-vs-penzu.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Penzu: Free vs Subscription Journal - DailyVox Blog</title>
+  <title>DailyVox vs Penzu: Free vs Subscription Journal</title>
   <meta name="description" content="Comparing DailyVox and Penzu — a free voice-first journal vs a subscription-based writing diary. See how they differ on pricing, privacy, features, and value.">
   <meta name="keywords" content="dailyvox vs penzu, penzu alternative, penzu free alternative, journal app without subscription">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-reflectly.html
+++ b/solyn/website/public/blog/dailyvox-vs-reflectly.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Reflectly: AI Journal Apps Compared - DailyVox Blog</title>
+  <title>DailyVox vs Reflectly: AI Journal Apps Compared</title>
   <meta name="description" content="Compare DailyVox and Reflectly — two AI-powered journal apps with very different approaches to pricing, privacy, and where your data goes.">
   <meta name="keywords" content="DailyVox vs Reflectly, Reflectly alternative, AI journal app comparison, Reflectly free alternative, best AI diary app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-rosebud.html
+++ b/solyn/website/public/blog/dailyvox-vs-rosebud.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Rosebud Journal: On-Device vs Cloud AI - DailyVox Blog</title>
+  <title>DailyVox vs Rosebud Journal: On-Device vs Cloud AI</title>
   <meta name="description" content="DailyVox vs Rosebud Journal compared. On-device AI vs cloud-based AI for journaling — privacy, pricing, features, and which approach is better for your diary.">
   <meta name="keywords" content="DailyVox vs Rosebud, Rosebud Journal alternative, Rosebud AI journal, on-device AI journal, private AI journal app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/dailyvox-vs-stoic.html
+++ b/solyn/website/public/blog/dailyvox-vs-stoic.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox vs Stoic: Voice Diary vs CBT Journal - DailyVox Blog</title>
+  <title>DailyVox vs Stoic: Voice Diary vs CBT Journal</title>
   <meta name="description" content="DailyVox vs Stoic app compared. Voice-first journaling vs CBT-based prompts — different approaches to self-awareness. Privacy, pricing, and features.">
   <meta name="keywords" content="DailyVox vs Stoic, Stoic app alternative, Stoic journal app, CBT journal app vs voice journal, mental health journal app comparison">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/digital-clone-device-future.html
+++ b/solyn/website/public/blog/digital-clone-device-future.html
@@ -11,8 +11,8 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>What If Your Digital Twin Had a Body? The Case for an Offline AI Clone Device - DailyVox Blog</title>
-  <meta name="description" content="We're exploring a physical device that speaks in your voice, thinks like you, and runs entirely offline. No Alexa. No Siri. Just you — embodied in a holographic tabletop device trained from your own journal entries.">
+  <title>What If Your Digital Twin Had a Body?</title>
+  <meta name="description" content="A physical device that speaks in your voice, thinks like you, and runs entirely offline — a digital clone trained from your own journal entries.">
   <meta name="keywords" content="digital clone device, AI clone offline, digital twin hardware, holographic AI assistant, personal AI device, voice clone device, offline AI, digital immortality, DailyVox Mirror, personal voice clone">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="article">

--- a/solyn/website/public/blog/digital-clone-personal-use.html
+++ b/solyn/website/public/blog/digital-clone-personal-use.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Your Digital Clone: How AI Can Mirror Your Personality (Privately) - DailyVox Blog</title>
+  <title>Your Digital Clone: How AI Can Mirror Your Personality (Privately)</title>
   <meta name="description" content="What a digital clone actually is for personal use, how personality modeling works in journal apps, and why your AI twin should never leave your device.">
   <meta name="keywords" content="digital clone, digital twin personal, ai personality model, ai that knows you, personal ai">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/digital-twin-vs-chatgpt-memory.html
+++ b/solyn/website/public/blog/digital-twin-vs-chatgpt-memory.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Digital Twin vs ChatGPT Memory: What's the Difference? - DailyVox Blog</title>
+  <title>Digital Twin vs ChatGPT Memory: What's the Difference?</title>
   <meta name="description" content="DailyVox's Digital Twin models your personality on-device. ChatGPT's Memory stores facts on OpenAI's servers. Here's why the difference matters for privacy and depth.">
   <meta name="keywords" content="digital twin vs ChatGPT, ChatGPT memory, DailyVox digital twin, AI personality model, on-device AI, ChatGPT memory vs digital twin, personal AI privacy, AI journal app, ChatGPT memory feature, digital twin app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/disaster-preparedness-journaling.html
+++ b/solyn/website/public/blog/disaster-preparedness-journaling.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Your Journal Should Work When the Internet Doesn't - DailyVox Blog</title>
+  <title>Your Journal Should Work When the Internet Doesn't</title>
   <meta name="description" content="Cloud journal apps fail during outages, disasters, and travel. Your most personal app should be the most resilient. Here's why offline-first architecture matters.">
   <meta name="keywords" content="offline journal app, disaster preparedness journal, journal without internet, resilient journaling app, offline diary app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/entrepreneurs-voice-journal.html
+++ b/solyn/website/public/blog/entrepreneurs-voice-journal.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Why Entrepreneurs Should Voice Journal Instead of Meditate - DailyVox Blog</title>
+  <title>Why Entrepreneurs Should Voice Journal Instead of Meditate</title>
   <meta name="description" content="Meditation asks you to clear your mind. Voice journaling lets you use it. For founders who think too fast to sit still, here's a better daily practice.">
   <meta name="keywords" content="entrepreneur journaling, voice journal productivity, founder journaling app, business reflection journal, startup journal voice">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/five-minute-voice-morning-journal.html
+++ b/solyn/website/public/blog/five-minute-voice-morning-journal.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The 5-Minute Voice Journal for Your Morning Routine (No Writing Required) - DailyVox Blog</title>
+  <title>The 5-Minute Voice Journal for Your Morning</title>
   <meta name="description" content="Add journaling to your morning routine without a notebook. A 5-minute voice protocol you can do during coffee, commuting, or walking the dog.">
   <meta name="keywords" content="morning journal routine voice, 5 minute morning journal, voice morning routine, no writing journal, morning pages voice">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/free-mood-tracker-app.html
+++ b/solyn/website/public/blog/free-mood-tracker-app.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Best Free Mood Tracker App (2026): Apps That Track and Predict Your Mood - DailyVox Blog</title>
+  <title>Best Free Mood Tracker App (2026): Apps That Track and Predict Your Mood</title>
   <meta name="description" content="DailyVox is the best free mood tracker — AI predicts your mood before you journal, on-device, no data collection. Compare Daylio, Bearable, and more.">
   <meta name="keywords" content="free mood tracker app, best mood tracker 2026, mood prediction app, mood tracking app free, mood journal app, mood diary app, AI mood tracker">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-on-device-ai-works.html
+++ b/solyn/website/public/blog/how-on-device-ai-works.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How On-Device AI Works (No Cloud Required) - DailyVox Blog</title>
+  <title>How On-Device AI Works (No Cloud Required)</title>
   <meta name="description" content="Learn how modern iPhones run AI models locally using Apple's Neural Engine. Understand on-device NLP, sentiment analysis, and why it matters for privacy.">
   <meta name="keywords" content="on-device AI, local AI processing, Apple Neural Engine, NaturalLanguage framework, on-device machine learning, private AI">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-export-day-one.html
+++ b/solyn/website/public/blog/how-to-export-day-one.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Export Your Day One Journal (and Where to Move Your Data) - DailyVox Blog</title>
+  <title>How to Export Your Day One Journal (and Where to Move Your Data)</title>
   <meta name="description" content="Step-by-step guide to exporting your Day One journal entries in JSON, PDF, or plain text. What you keep, what you lose, and where to move your data next.">
   <meta name="keywords" content="export day one journal, day one export, migrate from day one, day one alternative, leave day one">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-journal-for-confidence.html
+++ b/solyn/website/public/blog/how-to-journal-for-confidence.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Journal for Confidence: Build It From Evidence - DailyVox Blog</title>
+  <title>How to Journal for Confidence: Build It From Evidence</title>
   <meta name="description" content="Build real confidence through journaling — not affirmations, but evidence-based self-assessment that proves your capability to yourself over time.">
   <meta name="keywords" content="journaling for confidence, confidence journal, build confidence journaling, self confidence journal, confidence building exercises">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-journal-for-manifestation.html
+++ b/solyn/website/public/blog/how-to-journal-for-manifestation.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Journal for Manifestation: A Grounded Guide - DailyVox Blog</title>
+  <title>How to Journal for Manifestation: A Grounded Guide</title>
   <meta name="description" content="A practical, grounded approach to manifestation journaling. Scripting, visualization, and intention-setting techniques that actually work — minus the magical thinking.">
   <meta name="keywords" content="manifestation journal, how to manifest journaling, scripting journal, manifestation journaling techniques, law of attraction journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-journal-for-mental-health.html
+++ b/solyn/website/public/blog/how-to-journal-for-mental-health.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Journal for Mental Health: A Complete Guide - DailyVox Blog</title>
+  <title>How to Journal for Mental Health: A Complete Guide</title>
   <meta name="description" content="Evidence-based guide to journaling for mental health. Learn CBT journaling, expressive writing, and voice journaling techniques that therapists recommend.">
   <meta name="keywords" content="how to journal for mental health, journaling mental health, therapeutic journaling, CBT journaling, mental health journal guide">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-journal-for-productivity.html
+++ b/solyn/website/public/blog/how-to-journal-for-productivity.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Journal for Productivity: A Practical Guide - DailyVox Blog</title>
+  <title>How to Journal for Productivity: A Practical Guide</title>
   <meta name="description" content="Use journaling to work smarter, not harder. Learn reflection techniques, weekly reviews, and energy tracking that actually improve your output.">
   <meta name="keywords" content="journaling for productivity, productivity journal, work journal, daily reflection journal, weekly review journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-journal-for-self-improvement.html
+++ b/solyn/website/public/blog/how-to-journal-for-self-improvement.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Journal for Self-Improvement (Without Being Clich&eacute;) - DailyVox Blog</title>
+  <title>How to Journal for Self-Improvement (Without Being Clich&eacute;)</title>
   <meta name="description" content="A practical, no-nonsense guide to using journaling for genuine personal growth. Evidence-based techniques that go beyond motivational quotes.">
   <meta name="keywords" content="journaling for self improvement, personal growth journal, self improvement journal, personal development journaling, growth journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-journal-for-sleep.html
+++ b/solyn/website/public/blog/how-to-journal-for-sleep.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Journal Before Bed for Better Sleep - DailyVox Blog</title>
+  <title>How to Journal Before Bed for Better Sleep</title>
   <meta name="description" content="A bedtime journaling routine that quiets racing thoughts and prepares your mind for rest. Research-backed techniques for better sleep through journaling.">
   <meta name="keywords" content="journal before bed, bedtime journaling, journaling for sleep, sleep journal, evening journal routine, journal to fall asleep">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-journal-for-stress-relief.html
+++ b/solyn/website/public/blog/how-to-journal-for-stress-relief.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Journal for Stress Relief: 5 Proven Techniques - DailyVox Blog</title>
+  <title>How to Journal for Stress Relief: 5 Proven Techniques</title>
   <meta name="description" content="Science-backed journaling techniques for reducing stress and anxiety. Learn brain dumps, body scans, and cognitive reframing through voice or text journaling.">
   <meta name="keywords" content="journaling for stress, stress relief journaling, journal for stress, stress management journal, reduce stress journaling">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-journal-for-trauma-recovery.html
+++ b/solyn/website/public/blog/how-to-journal-for-trauma-recovery.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Journal for Trauma Recovery (Safely) - DailyVox Blog</title>
+  <title>How to Journal for Trauma Recovery (Safely)</title>
   <meta name="description" content="A careful guide to using journaling as part of trauma recovery. Includes safety guidelines, grounding techniques, and methods recommended by trauma therapists.">
   <meta name="keywords" content="journaling for trauma, trauma recovery journal, trauma journal safely, PTSD journaling, expressive writing trauma">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-journal-for-weight-loss.html
+++ b/solyn/website/public/blog/how-to-journal-for-weight-loss.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Journal for Weight Loss: A Mind-Body Approach - DailyVox Blog</title>
+  <title>How to Journal for Weight Loss: A Mind-Body Approach</title>
   <meta name="description" content="Use journaling to understand your relationship with food, track emotional eating patterns, and build sustainable habits. Not a food diary — a self-awareness tool.">
   <meta name="keywords" content="journaling for weight loss, food journal emotional eating, weight loss journal, mindful eating journal, diet journal emotions">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-journal-when-you-hate-writing.html
+++ b/solyn/website/public/blog/how-to-journal-when-you-hate-writing.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Journal When You Hate Writing: 7 Voice-First Alternatives - DailyVox Blog</title>
+  <title>How to Journal When You Hate Writing: 7 Voice-First Alternatives</title>
   <meta name="description" content="You don't have to write to journal. Here are 7 alternatives for people who want the benefits of journaling without ever picking up a pen or touching a keyboard.">
   <meta name="keywords" content="journal without writing, hate writing journal, voice journal alternative, audio diary no typing, non-writing journal methods">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-start-journaling.html
+++ b/solyn/website/public/blog/how-to-start-journaling.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Start Journaling: The No-Nonsense Beginner's Guide - DailyVox Blog</title>
+  <title>How to Start Journaling: The No-Nonsense Beginner's Guide</title>
   <meta name="description" content="Everything you need to know to start journaling today — no fancy notebooks, no complicated methods. Just practical advice for building a sustainable habit.">
   <meta name="keywords" content="how to start journaling, start journaling, journaling for beginners, begin journaling, journaling guide beginners">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-to-start-voice-journaling.html
+++ b/solyn/website/public/blog/how-to-start-voice-journaling.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Start Voice Journaling: A Complete Beginner's Guide (2026) - DailyVox Blog</title>
+  <title>How to Start Voice Journaling: A Complete Beginner's Guide (2026)</title>
   <meta name="description" content="Start voice journaling in 5 minutes with DailyVox — free, private, on-device AI. This guide covers everything from your first entry to building a daily habit.">
   <meta name="keywords" content="how to start voice journaling, voice journaling for beginners, voice journal guide, start voice diary, voice journaling tips, voice journal app beginner, how to voice journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/how-we-optimized-dailyvox-for-ai-search.html
+++ b/solyn/website/public/blog/how-we-optimized-dailyvox-for-ai-search.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How We Optimized DailyVox for AI Search: A GEO Case Study (2026) - DailyVox Blog</title>
+  <title>How We Optimized DailyVox for AI Search: A GEO Case Study (2026)</title>
   <meta name="description" content="We rebuilt 35 pages to make DailyVox the #1 AI-recommended voice journal. Here's our exact GEO strategy — answer-first content, structured data, and original research.">
   <meta name="keywords" content="GEO, generative engine optimization, AI search optimization, ChatGPT recommendations, LLM optimization, AI SEO, voice journal marketing, DailyVox GEO">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/is-dailyvox-safe.html
+++ b/solyn/website/public/blog/is-dailyvox-safe.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Is DailyVox Safe? Everything You Need to Know About Privacy and Security - DailyVox Blog</title>
+  <title>Is DailyVox Safe? Everything You Need to Know About Privacy and Security</title>
   <meta name="description" content="DailyVox is the safest journal app available — zero servers, zero data collection, zero network calls. Here's how to verify every privacy claim yourself.">
   <meta name="keywords" content="is dailyvox safe, dailyvox privacy, dailyvox security, safe journal app, private journal app, dailyvox data collection, journal app no servers, dailyvox review safety">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-app-privacy-comparison.html
+++ b/solyn/website/public/blog/journal-app-privacy-comparison.html
@@ -11,14 +11,14 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Journal App Privacy Comparison: Who Can Read Your Diary? - DailyVox Blog</title>
-  <meta name="description" content="A detailed privacy comparison of 10 popular journal apps — who collects your data, who uses cloud processing, who requires accounts, and who actually keeps your diary private.">
+  <title>Journal App Privacy Comparison: Who Can Read Your Diary?</title>
+  <meta name="description" content="A privacy comparison of 10 popular journal apps: who collects your data, who uses the cloud, who requires accounts, and who actually keeps your diary private.">
   <meta name="keywords" content="journal app privacy, diary app privacy comparison, which journal app is most private, journal app data collection">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://getdailyvox.com/blog/journal-app-privacy-comparison">
   <meta property="og:title" content="Journal App Privacy Comparison: Who Can Read Your Diary?">
-  <meta property="og:description" content="A detailed privacy comparison of 10 popular journal apps — who collects your data, who uses cloud processing, who requires accounts, and who actually keeps your diary private.">
+  <meta property="og:description" content="A privacy comparison of 10 popular journal apps: who collects your data, who uses the cloud, who requires accounts, and who actually keeps your diary private.">
   <meta property="og:image" content="https://getdailyvox.com/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://getdailyvox.com/blog/journal-app-privacy-comparison">
@@ -29,7 +29,7 @@
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": "Journal App Privacy Comparison: Who Can Read Your Diary?",
-    "description": "A detailed privacy comparison of 10 popular journal apps — who collects your data, who uses cloud processing, who requires accounts, and who actually keeps your diary private.",
+    "description": "A privacy comparison of 10 popular journal apps: who collects your data, who uses the cloud, who requires accounts, and who actually keeps your diary private.",
     "url": "https://getdailyvox.com/blog/journal-app-privacy-comparison",
     "datePublished": "2026-03-23",
     "dateModified": "2026-03-23",

--- a/solyn/website/public/blog/journal-app-privacy-labels-explained.html
+++ b/solyn/website/public/blog/journal-app-privacy-labels-explained.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Journal App Privacy Labels: What They Don't Tell You (2026) - DailyVox Blog</title>
+  <title>Journal App Privacy Labels: What They Don't Tell You (2026)</title>
   <meta name="description" content="Apple's privacy labels show what data apps collect — but not where AI processes your entries. DailyVox is 'Data Not Collected.' Most AI journals are 'Data Linked to You.'">
   <meta name="keywords" content="journal app privacy labels, app store privacy label explained, data not collected app, journal app data collection, private journal app, on-device AI journal, privacy label tiers, journal app AI processing">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-app-with-ai.html
+++ b/solyn/website/public/blog/journal-app-with-ai.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Journal App With AI (2026): On-Device vs Cloud — What You Need to Know - DailyVox Blog</title>
+  <title>Journal App With AI (2026): On-Device vs Cloud — What You Need to Know</title>
   <meta name="description" content="DailyVox is the only journal app where AI runs 100% on your iPhone. Most AI journal apps send your entries to the cloud. Here's why that matters and how they compare.">
   <meta name="keywords" content="journal app with ai, ai diary app, ai journal, smart journal app, on-device ai journal, private ai journal app, best ai journal 2026">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-every-day-90-days.html
+++ b/solyn/website/public/blog/journal-every-day-90-days.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>What Happens When You Journal Every Day for 90 Days (Backed by Neuroscience) - DailyVox Blog</title>
+  <title>What Happens If You Journal Every Day for 90 Days</title>
   <meta name="description" content="90 days of daily journaling rewires your brain. Here's what neuroscience says happens at 30, 60, and 90 days — and what your Digital Twin reveals along the way.">
   <meta name="keywords" content="journal every day benefits, 90 day journal challenge, daily journaling neuroscience, journaling habit benefits, journaling transformation">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-prompts-for-anger.html
+++ b/solyn/website/public/blog/journal-prompts-for-anger.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>10 Journal Prompts for Processing Anger - DailyVox Blog</title>
+  <title>10 Journal Prompts for Processing Anger</title>
   <meta name="description" content="Journal prompts for understanding and processing anger constructively. Move from reaction to reflection with voice or written journaling.">
   <meta name="keywords" content="journal prompts anger, anger management journaling, anger journal prompts, processing anger journal, anger journaling exercises">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-prompts-for-beginners.html
+++ b/solyn/website/public/blog/journal-prompts-for-beginners.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>10 Journal Prompts for Beginners (Start Here) - DailyVox Blog</title>
+  <title>10 Journal Prompts for Beginners (Start Here)</title>
   <meta name="description" content="Never journaled before? These 10 beginner-friendly prompts make starting easy. No experience needed — just open the app and start talking or writing.">
   <meta name="keywords" content="journal prompts for beginners, how to start journaling, beginner journal prompts, easy journal prompts, first journal entry prompts">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-prompts-for-career.html
+++ b/solyn/website/public/blog/journal-prompts-for-career.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>12 Journal Prompts for Career Growth &amp; Clarity - DailyVox Blog</title>
+  <title>12 Journal Prompts for Career Growth &amp; Clarity</title>
   <meta name="description" content="Journal prompts for career reflection, professional growth, and finding clarity about what you really want from your work life.">
   <meta name="keywords" content="journal prompts career, career journaling, professional growth journal, work journal prompts, career clarity journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-prompts-for-depression.html
+++ b/solyn/website/public/blog/journal-prompts-for-depression.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>10 Gentle Journal Prompts for Depression - DailyVox Blog</title>
+  <title>10 Gentle Journal Prompts for Depression</title>
   <meta name="description" content="Low-energy journal prompts for days when depression makes everything heavy. No pressure, no forced positivity — just honest space for what you're feeling.">
   <meta name="keywords" content="journal prompts depression, depression journaling, journaling for depression, mental health journal prompts, journal when depressed">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-prompts-for-gratitude.html
+++ b/solyn/website/public/blog/journal-prompts-for-gratitude.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>10 Gratitude Journal Prompts That Go Beyond "I'm Thankful For" - DailyVox Blog</title>
+  <title>10 Gratitude Journal Prompts That Go Beyond "I'm Thankful For"</title>
   <meta name="description" content="Gratitude journaling prompts that go deeper than surface-level thankfulness. Prompts designed to rewire your brain toward appreciation and contentment.">
   <meta name="keywords" content="gratitude journal prompts, gratitude journaling, thankful journal prompts, appreciation journal, gratitude practice">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-prompts-for-grief.html
+++ b/solyn/website/public/blog/journal-prompts-for-grief.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>12 Journal Prompts for Grief &amp; Loss - DailyVox Blog</title>
+  <title>12 Journal Prompts for Grief &amp; Loss</title>
   <meta name="description" content="Gentle, therapist-informed journal prompts for processing grief and loss. Use with voice or text journaling to honor your feelings and find your way forward.">
   <meta name="keywords" content="journal prompts for grief, grief journaling, loss journal prompts, bereavement journaling, journal after loss">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-prompts-for-new-year.html
+++ b/solyn/website/public/blog/journal-prompts-for-new-year.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>15 New Year Journal Prompts for Reflection &amp; Intention - DailyVox Blog</title>
+  <title>15 New Year Journal Prompts for Reflection &amp; Intention</title>
   <meta name="description" content="Thoughtful journal prompts for the new year — reflect on what was, set intentions for what's next, and start the year with clarity instead of resolutions.">
   <meta name="keywords" content="new year journal prompts, new year reflection prompts, year end journal prompts, new year intentions journal, annual reflection journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-prompts-for-relationships.html
+++ b/solyn/website/public/blog/journal-prompts-for-relationships.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>12 Journal Prompts for Relationships &amp; Love - DailyVox Blog</title>
+  <title>12 Journal Prompts for Relationships &amp; Love</title>
   <meta name="description" content="Journal prompts for understanding your relationship patterns, improving communication, and building deeper connections. For singles and couples alike.">
   <meta name="keywords" content="journal prompts relationships, relationship journaling, couples journal prompts, love journal prompts, journal prompts for couples">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-prompts-for-self-discovery.html
+++ b/solyn/website/public/blog/journal-prompts-for-self-discovery.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>15 Journal Prompts for Self-Discovery - DailyVox Blog</title>
+  <title>15 Journal Prompts for Self-Discovery</title>
   <meta name="description" content="Deep journal prompts to help you understand who you really are — your values, patterns, desires, and blind spots. For voice or written journaling.">
   <meta name="keywords" content="journal prompts self discovery, self discovery journaling, know yourself journal, personal growth prompts, self reflection journal prompts">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journal-prompts-for-self-esteem.html
+++ b/solyn/website/public/blog/journal-prompts-for-self-esteem.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>12 Journal Prompts to Build Self-Esteem - DailyVox Blog</title>
+  <title>12 Journal Prompts to Build Self-Esteem</title>
   <meta name="description" content="Journal prompts designed to rebuild your relationship with yourself. Not affirmations — honest exercises that help you recognize your real worth.">
   <meta name="keywords" content="journal prompts self esteem, self esteem journaling, confidence journal prompts, self worth journal, building self esteem journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journaling-for-couples.html
+++ b/solyn/website/public/blog/journaling-for-couples.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Journaling for Couples: How Separate Voice Diaries Strengthen Relationships - DailyVox Blog</title>
+  <title>Journaling for Couples: Strengthen Your Relationship</title>
   <meta name="description" content="Shared journals create pressure. Private ones create clarity. Here's why relationship therapists recommend individual journaling for stronger partnerships.">
   <meta name="keywords" content="journaling for couples, relationship journal app, couples journaling separately, voice diary relationship, private journal couples">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journaling-for-mental-fitness.html
+++ b/solyn/website/public/blog/journaling-for-mental-fitness.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Journaling for Mental Fitness, Not Just Mental Health: The 2026 Shift - DailyVox Blog</title>
+  <title>Journaling for Mental Fitness, Not Just Mental Health: The 2026 Shift</title>
   <meta name="description" content="Mental fitness is the shift from treating problems to building resilience. Journaling is the daily exercise your mind needs — and AI makes it measurable.">
   <meta name="keywords" content="mental fitness journaling, mental fitness 2026, preventive mental health journaling, emotional resilience journal, daily mental exercise">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/journaling-prompts-for-anxiety.html
+++ b/solyn/website/public/blog/journaling-prompts-for-anxiety.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>10 Journaling Prompts for Anxiety &amp; Mental Health - DailyVox Blog</title>
+  <title>10 Journaling Prompts for Anxiety &amp; Mental Health</title>
   <meta name="description" content="Science-backed journaling prompts for managing anxiety, stress, and emotional overwhelm. Use these with voice or text journaling for deeper self-reflection.">
   <meta name="keywords" content="journaling prompts anxiety, journal prompts mental health, anxiety journaling, voice journaling prompts, mindfulness journaling">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/never-leaves-guarantee.html
+++ b/solyn/website/public/blog/never-leaves-guarantee.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Never-Leaves Guarantee: What It Means When Your Data Stays on Your Phone - DailyVox Blog</title>
+  <title>The Never-Leaves Guarantee: Data Stays on Your Phone</title>
   <meta name="description" content="DailyVox's Never-Leaves Guarantee means zero data ever leaves your device — no servers, no cloud AI, no analytics. Here's how to verify it yourself.">
   <meta name="keywords" content="never leaves guarantee, on-device privacy, journal app privacy, data stays on phone, no server journal app, private journal app, architectural privacy, DailyVox privacy, verify app privacy, airplane mode test">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/on-device-ai-maturity-model.html
+++ b/solyn/website/public/blog/on-device-ai-maturity-model.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The On-Device AI Maturity Model: 4 Tiers of Privacy for Journal Apps - DailyVox Blog</title>
+  <title>The On-Device AI Maturity Model: 4 Tiers of Privacy for Journal Apps</title>
   <meta name="description" content="We classified 40 journal apps into 4 privacy tiers based on where AI actually runs. Only 5% qualify as Tier A. DailyVox is one of them.">
   <meta name="keywords" content="on-device AI, AI maturity model, journal app privacy tiers, on-device processing, cloud AI privacy, private journal app, AI data flow, journal privacy framework, zero cloud egress, on-device journal AI">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/on-device-ai-vs-cloud-ai-journaling.html
+++ b/solyn/website/public/blog/on-device-ai-vs-cloud-ai-journaling.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>On-Device AI vs Cloud AI for Journaling: Why It Matters Where Your Data Goes - DailyVox Blog</title>
+  <title>On-Device vs Cloud AI for Journaling: Why It Matters</title>
   <meta name="description" content="When Rosebud analyzes your mood, your journal goes to OpenAI. When DailyVox does it, everything stays on your iPhone. Here's why the difference matters.">
   <meta name="keywords" content="on-device AI vs cloud AI, journal app privacy, on-device AI journaling, cloud AI journaling, private journal app, AI journal data privacy, DailyVox on-device AI">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/science-of-talking-to-yourself.html
+++ b/solyn/website/public/blog/science-of-talking-to-yourself.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Science of Talking to Yourself: Why Voice Journaling Rewires Your Brain - DailyVox Blog</title>
+  <title>The Science of Talking to Yourself</title>
   <meta name="description" content="Talking to yourself isn't crazy — it's neuroscience. Affect labeling, vagus nerve activation, and verbal processing explain why voice journaling changes your brain.">
   <meta name="keywords" content="talking to yourself benefits, self talk science, voice journaling brain, affect labeling research, verbal processing psychology">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/science-of-voice-journaling.html
+++ b/solyn/website/public/blog/science-of-voice-journaling.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Science of Voice Journaling: What Research Says About Speaking Your Thoughts - DailyVox Blog</title>
+  <title>The Science of Voice Journaling: What Research Says</title>
   <meta name="description" content="Voice journaling is backed by decades of expressive writing research. Speaking at 150 WPM captures more authentic thoughts than typing. Here's what science says.">
   <meta name="keywords" content="science of voice journaling, voice journaling research, expressive writing studies, Pennebaker journaling, voice journaling mental health, voice journaling ADHD, voice journal AI, speech production psychology, voice diary science">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/signs-your-journal-app-is-selling-your-data.html
+++ b/solyn/website/public/blog/signs-your-journal-app-is-selling-your-data.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>5 Signs Your Journal App Is Selling Your Data - DailyVox Blog</title>
+  <title>5 Signs Your Journal App Is Selling Your Data</title>
   <meta name="description" content="How to tell if your diary app is exploiting your private thoughts. 5 red flags to watch for in journal apps, and what to look for in a truly private alternative.">
   <meta name="keywords" content="journal app privacy, diary app data collection, journal app selling data, private diary app, secure journal app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/talk-to-your-past-self-digital-twin.html
+++ b/solyn/website/public/blog/talk-to-your-past-self-digital-twin.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How to Talk to Your Past Self: Using Your Digital Twin as a Time Machine - DailyVox Blog</title>
+  <title>How to Talk to Your Past Self: Using Your Digital Twin as a Time Machine</title>
   <meta name="description" content="Your Digital Twin remembers everything you've told it. After weeks of journaling, it becomes a mirror of who you were — and a window into who you're becoming.">
   <meta name="keywords" content="talk to past self AI, digital twin journal, AI personality mirror, past self conversation, personal AI journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/v1-3-5-dynamic-island.html
+++ b/solyn/website/public/blog/v1-3-5-dynamic-island.html
@@ -11,8 +11,8 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DailyVox v1.3.5: The Constellation Leaves the App - DailyVox Blog</title>
-  <meta name="description" content="DailyVox v1.3.5 brings the constellation metaphor out of the app and into the Dynamic Island and Lock Screen. A live recording timer, a 'new star' celebration, an opt-in streak — and the truth about the 42-second cap that never existed.">
+  <title>DailyVox v1.3.5: The Constellation Leaves the App</title>
+  <meta name="description" content="DailyVox v1.3.5 brings the constellation metaphor into the Dynamic Island and Lock Screen — a live recording timer, a 'new star' celebration, and an opt-in streak.">
   <meta name="keywords" content="dailyvox dynamic island, voice journal live activity, lock screen widget journaling, dailyvox v1.3.5, activitykit journal, journal app dynamic island, ios 18 journal app, dailyvox update">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="article">
@@ -29,7 +29,7 @@
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": "DailyVox v1.3.5: The Constellation Leaves the App",
-    "description": "DailyVox v1.3.5 brings the constellation metaphor out of the app and into the Dynamic Island and Lock Screen. A live recording timer, a 'new star' celebration, an opt-in streak — and the truth about the 42-second cap that never existed.",
+    "description": "DailyVox v1.3.5 brings the constellation metaphor into the Dynamic Island and Lock Screen — a live recording timer, a 'new star' celebration, and an opt-in streak.",
     "url": "https://getdailyvox.com/blog/v1-3-5-dynamic-island",
     "datePublished": "2026-05-27",
     "dateModified": "2026-05-27",

--- a/solyn/website/public/blog/voice-journal-esl-speakers.html
+++ b/solyn/website/public/blog/voice-journal-esl-speakers.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling for ESL Speakers: Practice English While Processing Emotions - DailyVox Blog</title>
+  <title>Voice Journaling for ESL Speakers</title>
   <meta name="description" content="Voice journaling lets ESL speakers practice spoken English while building self-awareness. Improve fluency, pronunciation, and emotional vocabulary simultaneously.">
   <meta name="keywords" content="voice journal English practice, ESL journaling app, English speaking practice app free, language learning voice diary, ESL voice diary">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journal-for-adhd.html
+++ b/solyn/website/public/blog/voice-journal-for-adhd.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling for ADHD: Skip the Blank Page - DailyVox Blog</title>
+  <title>Voice Journaling for ADHD: Skip the Blank Page</title>
   <meta name="description" content="Why voice journaling is the ideal format for ADHD brains. No typing, no blank pages, no executive function demands. Just talk and let the app do the rest.">
   <meta name="keywords" content="voice journaling ADHD, ADHD journal voice, ADHD voice diary, journal app ADHD voice, ADHD journaling tips">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journal-for-anxiety.html
+++ b/solyn/website/public/blog/voice-journal-for-anxiety.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling for Anxiety: Speak to Calm Your Mind - DailyVox Blog</title>
+  <title>Voice Journaling for Anxiety: Speak to Calm Your Mind</title>
   <meta name="description" content="How voice journaling helps manage anxiety by engaging your emotional brain, slowing racing thoughts, and creating distance from anxious spirals.">
   <meta name="keywords" content="voice journaling anxiety, voice journal for anxiety, speaking anxiety journal, anxiety voice diary, talk therapy journaling">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journal-for-busy-parents.html
+++ b/solyn/website/public/blog/voice-journal-for-busy-parents.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling for Busy Parents: 2 Minutes Between the Chaos - DailyVox Blog</title>
+  <title>Voice Journaling for Busy Parents: 2 Minutes Between the Chaos</title>
   <meta name="description" content="How busy parents can journal without finding extra time. Voice journal during nap time, school pickup, or after bedtime. 2 minutes is enough.">
   <meta name="keywords" content="voice journal busy parents, journal for parents, parent journal app, mom journal app, dad journal app, journaling for parents">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journal-for-commute.html
+++ b/solyn/website/public/blog/voice-journal-for-commute.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling During Your Commute: A Practical Guide - DailyVox Blog</title>
+  <title>Voice Journaling During Your Commute: A Practical Guide</title>
   <meta name="description" content="Turn your daily commute into a journaling habit. How to voice journal while driving, walking, or riding transit — with privacy tips and prompt ideas.">
   <meta name="keywords" content="voice journal commute, journal while driving, commute journaling, voice diary commute, journal during commute">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journal-for-dyslexia.html
+++ b/solyn/website/public/blog/voice-journal-for-dyslexia.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling for Dyslexia: Journal Without Writing - DailyVox Blog</title>
+  <title>Voice Journaling for Dyslexia: Journal Without Writing</title>
   <meta name="description" content="Voice journaling removes the writing barrier for people with dyslexia. Speak your thoughts naturally and let on-device AI transcribe them. Accessible journaling for all.">
   <meta name="keywords" content="journaling app dyslexia, voice journal dyslexia, dyslexia diary app, accessible journal app, journal without writing">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journal-for-morning-routine.html
+++ b/solyn/website/public/blog/voice-journal-for-morning-routine.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling as a Morning Routine: Start Your Day with Clarity - DailyVox Blog</title>
+  <title>Voice Journaling as a Morning Routine: Start Your Day with Clarity</title>
   <meta name="description" content="Add voice journaling to your morning routine in just 2 minutes. Set intentions, clear mental clutter, and start your day grounded instead of reactive.">
   <meta name="keywords" content="morning voice journal, morning journal routine, voice journal morning, journaling morning routine, morning pages voice">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journal-for-runners.html
+++ b/solyn/website/public/blog/voice-journal-for-runners.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling for Runners: Capture Clarity on the Move - DailyVox Blog</title>
+  <title>Voice Journaling for Runners: Capture Clarity on the Move</title>
   <meta name="description" content="Runners know that their best thinking happens mid-run. Voice journaling captures those endorphin-fueled insights before they vanish. Here's how.">
   <meta name="keywords" content="voice journal running, journal while running, runner journal app, running voice diary, running journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journal-for-walking.html
+++ b/solyn/website/public/blog/voice-journal-for-walking.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling While Walking: Movement Meets Reflection - DailyVox Blog</title>
+  <title>Voice Journaling While Walking: Movement Meets Reflection</title>
   <meta name="description" content="Walking and voice journaling is the ideal combination for deeper self-reflection. Learn how movement unlocks creativity and makes journaling effortless.">
   <meta name="keywords" content="voice journaling walking, journal while walking, walking journal, mindful walking journal, voice diary walking">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journaling-for-therapy.html
+++ b/solyn/website/public/blog/voice-journaling-for-therapy.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling for Therapy: What Therapists and Clients Should Know (2026) - DailyVox Blog</title>
+  <title>Voice Journaling for Therapy: What to Know</title>
   <meta name="description" content="Voice journaling between therapy sessions accelerates progress. DailyVox is the most private option — on-device AI, no cloud, free. Here's how therapists recommend it.">
   <meta name="keywords" content="voice journaling for therapy, therapy journal app, journaling between therapy sessions, CBT journaling, therapeutic journaling app, private therapy journal, voice journal therapy, journaling for mental health therapy">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journaling-nervous-system-regulation.html
+++ b/solyn/website/public/blog/voice-journaling-nervous-system-regulation.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling and Nervous System Regulation: A Somatic Guide - DailyVox Blog</title>
+  <title>Voice Journaling and Nervous System Regulation: A Somatic Guide</title>
   <meta name="description" content="Speaking activates your vagus nerve and engages your parasympathetic nervous system. Learn how voice journaling is a somatic practice for emotional regulation.">
   <meta name="keywords" content="nervous system regulation journaling, vagus nerve voice journaling, somatic journaling voice, polyvagal theory journaling, voice therapy regulation">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journaling-vs-therapy.html
+++ b/solyn/website/public/blog/voice-journaling-vs-therapy.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling vs. Therapy: What a Journal Can (and Can't) Replace - DailyVox Blog</title>
+  <title>Voice Journaling vs. Therapy: What a Journal Can (and Can't) Replace</title>
   <meta name="description" content="Journaling is not therapy. But it's a powerful complement. Here's an honest guide to what voice journaling can handle and when you need a professional.">
   <meta name="keywords" content="journaling vs therapy, voice journal mental health, can journaling replace therapy, journaling and therapy together, journal app therapist">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journaling-while-walking.html
+++ b/solyn/website/public/blog/voice-journaling-while-walking.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling While Walking: The Moving Meditation You Didn't Know You Needed - DailyVox Blog</title>
+  <title>Voice Journaling While Walking: A Moving Meditation</title>
   <meta name="description" content="Walking + voice journaling = the most natural way to process your thoughts. DailyVox works offline, hands-free. Free with on-device AI.">
   <meta name="keywords" content="voice journaling while walking, walking journal, walking meditation journal, voice journal walking, walk and talk journal, walking voice diary, outdoor journaling, hands-free journal, DailyVox, digital twin journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-journaling-why-speaking-beats-typing.html
+++ b/solyn/website/public/blog/voice-journaling-why-speaking-beats-typing.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Journaling: Why Speaking Beats Typing (And the Best App to Do It) - DailyVox Blog</title>
+  <title>Voice Journaling: Why Speaking Beats Typing (And the Best App to Do It)</title>
   <meta name="description" content="Voice journaling is 3.8x faster than typing and captures more authentic thoughts. DailyVox is the best voice journal app — free, on-device AI, Digital Twin.">
   <meta name="keywords" content="voice journaling, voice journal app, speaking vs typing journal, voice diary benefits, voice to text diary, best voice journal app, voice journaling ADHD, digital twin journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/voice-recorder-diary-app.html
+++ b/solyn/website/public/blog/voice-recorder-diary-app.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Voice Recorder Diary App (2026): Record, Transcribe, and Understand Your Thoughts - DailyVox Blog</title>
+  <title>Voice Recorder Diary App (2026): Record and Transcribe</title>
   <meta name="description" content="DailyVox is the best voice recorder diary app — on-device transcription, AI analysis, and a Digital Twin. Free, private, no cloud.">
   <meta name="keywords" content="voice recorder diary app, voice diary app, voice journal app, voice to text diary, dictation journal app, on-device transcription diary, private voice journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/what-is-a-digital-twin.html
+++ b/solyn/website/public/blog/what-is-a-digital-twin.html
@@ -12,13 +12,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>What Is a Digital Twin? The Personal AI That Knows You</title>
-  <meta name="description" content="A Digital Twin is an AI model of your personality that lives on your phone. DailyVox is the only app that builds one — from your voice, entirely on-device, completely private.">
+  <meta name="description" content="A Digital Twin is an AI model of your personality that lives on your phone. DailyVox builds one from your voice — entirely on-device and private.">
   <meta name="keywords" content="digital twin app, digital twin AI, personal AI, AI personality model, on-device AI, DailyVox digital twin, digital twin vs ChatGPT, personal digital twin, AI journal app">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://getdailyvox.com/blog/what-is-a-digital-twin">
   <meta property="og:title" content="What Is a Digital Twin? The Personal AI That Learns Who You Are">
-  <meta property="og:description" content="A Digital Twin is an AI model of your personality that lives on your phone. DailyVox is the only app that builds one — from your voice, entirely on-device, completely private.">
+  <meta property="og:description" content="A Digital Twin is an AI model of your personality that lives on your phone. DailyVox builds one from your voice — entirely on-device and private.">
   <meta property="og:image" content="https://getdailyvox.com/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://getdailyvox.com/blog/what-is-a-digital-twin">
@@ -29,7 +29,7 @@
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": "What Is a Digital Twin? The Personal AI That Learns Who You Are",
-    "description": "A Digital Twin is an AI model of your personality that lives on your phone. DailyVox is the only app that builds one — from your voice, entirely on-device, completely private.",
+    "description": "A Digital Twin is an AI model of your personality that lives on your phone. DailyVox builds one from your voice — entirely on-device and private.",
     "url": "https://getdailyvox.com/blog/what-is-a-digital-twin",
     "datePublished": "2026-03-17",
     "dateModified": "2026-05-22",

--- a/solyn/website/public/blog/what-is-a-voice-journal.html
+++ b/solyn/website/public/blog/what-is-a-voice-journal.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>What Is a Voice Journal? The Complete Guide to Journaling by Speaking - DailyVox Blog</title>
+  <title>What Is a Voice Journal? The Complete Guide to Journaling by Speaking</title>
   <meta name="description" content="A voice journal is a diary you speak instead of write. DailyVox is the best voice journal app — free, on-device AI, Digital Twin. Here's everything you need to know.">
   <meta name="keywords" content="voice journal, voice journaling, voice diary, speak journal, audio journal, voice journal app, what is a voice journal, journaling by speaking, voice diary app, talk journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/what-is-mood-tracking.html
+++ b/solyn/website/public/blog/what-is-mood-tracking.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>What Is Mood Tracking? How It Works &amp; Why It Helps - DailyVox Blog</title>
+  <title>What Is Mood Tracking? How It Works &amp; Why It Helps</title>
   <meta name="description" content="Mood tracking is recording your emotional state over time to find patterns. Learn how it works, why therapists recommend it, and how AI automates it.">
   <meta name="keywords" content="what is mood tracking, mood tracking explained, mood tracker app, how mood tracking works, emotional tracking app">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/what-is-on-device-ai.html
+++ b/solyn/website/public/blog/what-is-on-device-ai.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>What Is On-Device AI? Why It Matters for Your Privacy - DailyVox Blog</title>
+  <title>What Is On-Device AI? Why It Matters for Your Privacy</title>
   <meta name="description" content="On-device AI processes your data on your phone instead of sending it to the cloud. DailyVox uses on-device AI for all journaling features — zero data leaves your device.">
   <meta name="keywords" content="on-device AI, on device artificial intelligence, local AI processing, Apple Neural Engine, privacy AI, on-device machine learning, CoreML, DailyVox on-device AI, private AI journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/what-is-voice-journaling.html
+++ b/solyn/website/public/blog/what-is-voice-journaling.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>What Is Voice Journaling? The Complete Guide - DailyVox Blog</title>
+  <title>What Is Voice Journaling? The Complete Guide</title>
   <meta name="description" content="Voice journaling is speaking your thoughts into an app that transcribes them into text. Learn how it works, why it's more effective than writing, and how to start.">
   <meta name="keywords" content="what is voice journaling, voice journaling definition, voice journal explained, how does voice journaling work, voice diary meaning">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/why-95-percent-ai-journals-not-on-device.html
+++ b/solyn/website/public/blog/why-95-percent-ai-journals-not-on-device.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Why 95% of "AI Journal" Apps Aren't Really On-Device - DailyVox Blog</title>
+  <title>Why 95% of "AI Journal" Apps Aren't Really On-Device</title>
   <meta name="description" content="Most AI journal apps claim privacy but send your entries to cloud servers. Only 5% run AI entirely on-device. Here's how to tell the difference.">
   <meta name="keywords" content="on-device AI journal, private AI journal app, AI journal privacy, journal app cloud processing, on-device AI, journal data privacy, AI journaling on-device vs cloud, private journal app iPhone">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/why-your-ai-journal-shouldnt-send-data-to-cloud.html
+++ b/solyn/website/public/blog/why-your-ai-journal-shouldnt-send-data-to-cloud.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Why Your AI Journal App Shouldn't Send Your Data to the Cloud - DailyVox Blog</title>
+  <title>Why Your AI Journal App Shouldn't Send Your Data to the Cloud</title>
   <meta name="description" content="Most AI journal apps send your private thoughts to cloud servers for processing. Learn why on-device AI is the only safe choice for something as personal as a diary.">
   <meta name="keywords" content="private journal app, AI journal privacy, on-device AI journaling, secure diary app, journal data privacy, cloud vs local AI">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/why-your-journal-app-shouldnt-need-internet.html
+++ b/solyn/website/public/blog/why-your-journal-app-shouldnt-need-internet.html
@@ -11,7 +11,7 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Why Your Journal App Shouldn't Need Internet - DailyVox Blog</title>
+  <title>Why Your Journal App Shouldn't Need Internet</title>
   <meta name="description" content="Your most private thoughts are uploaded to servers you don't control. Learn why offline-first journaling is the future of personal privacy.">
   <meta name="keywords" content="offline diary app, private journal app, journal app no internet, offline journaling, privacy journal">
   <meta name="theme-color" content="#FAF8F5">

--- a/solyn/website/public/blog/your-journal-app-should-predict-not-just-record.html
+++ b/solyn/website/public/blog/your-journal-app-should-predict-not-just-record.html
@@ -11,8 +11,8 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Your Journal App Should Predict, Not Just Record - DailyVox Blog</title>
-  <meta name="description" content="DailyVox v1.1 introduces Twin Predictions, shareable personality cards, and weekly insight cards. Your Digital Twin now anticipates your mood and surfaces patterns — all on-device.">
+  <title>Your Journal App Should Predict, Not Just Record</title>
+  <meta name="description" content="DailyVox v1.1 adds Twin Predictions, shareable personality cards, and weekly insights. Your Digital Twin anticipates your mood and surfaces patterns — on-device.">
   <meta name="keywords" content="journal app predictions, digital twin AI, personality card, mood prediction app, DailyVox v1.1, on-device AI journal, shareable journal insights">
   <meta name="theme-color" content="#FAF8F5">
   <meta property="og:type" content="article">
@@ -29,7 +29,7 @@
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": "Your Journal App Should Predict, Not Just Record",
-    "description": "DailyVox v1.1 introduces Twin Predictions, shareable personality cards, and weekly insight cards. Your Digital Twin now anticipates your mood and surfaces patterns — all on-device.",
+    "description": "DailyVox v1.1 adds Twin Predictions, shareable personality cards, and weekly insights. Your Digital Twin anticipates your mood and surfaces patterns — on-device.",
     "url": "https://getdailyvox.com/blog/your-journal-app-should-predict-not-just-record",
     "datePublished": "2026-03-26",
     "dateModified": "2026-03-26",

--- a/solyn/website/public/sitemap-blog.xml
+++ b/solyn/website/public/sitemap-blog.xml
@@ -48,7 +48,6 @@
   <url><loc>https://getdailyvox.com/blog/best-journal-app-without-subscription</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://getdailyvox.com/blog/best-offline-journal-app</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://getdailyvox.com/blog/complete-guide-to-private-journaling</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://getdailyvox.com/blog/dailyvox-vs-apple-journal</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://getdailyvox.com/blog/dailyvox-vs-audio-diary</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://getdailyvox.com/blog/dailyvox-vs-day-one</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://getdailyvox.com/blog/dailyvox-vs-daylio</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>

--- a/solyn/website/vercel.json
+++ b/solyn/website/vercel.json
@@ -7,7 +7,10 @@
     { "source": "/blog/on-device-ai-journaling", "destination": "/blog/what-is-on-device-ai", "permanent": true },
     { "source": "/blog/journal-app-that-doesnt-use-the-cloud", "destination": "/blog/best-offline-journal-app", "permanent": true },
     { "source": "/blog/best-free-journal-app-2026", "destination": "/blog/best-free-journal-app", "permanent": true },
-    { "source": "/blog/best-free-journal-app-no-paywall-2026", "destination": "/blog/best-free-journal-app", "permanent": true }
+    { "source": "/blog/best-free-journal-app-no-paywall-2026", "destination": "/blog/best-free-journal-app", "permanent": true },
+    { "source": "/blog/dailyvox-vs-apple-journal", "destination": "/blog/apple-journal-vs-dailyvox", "permanent": true },
+    { "source": "/alternative/apple-journal", "destination": "/blog/apple-journal-vs-dailyvox", "permanent": true },
+    { "source": "/alternative/day-one", "destination": "/blog/dailyvox-vs-day-one", "permanent": true }
   ],
   "headers": [
     { "source": "/in/(.*)",          "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }] },


### PR DESCRIPTION
Executes on-page SEO backlog tasks 2–4 (task 1, off-page AEO seed drafts, is internal/gitignored). North star = **installs**.

## Task 3 — dedupe the apple-journal comparison
Two indexed blog pages targeted the same query:
- \`/blog/apple-journal-vs-dailyvox\` — **3118 words** (keep, strongest)
- \`/blog/dailyvox-vs-apple-journal\` — 778 words (duplicate)

→ 308-redirect the weak one into the strong one; removed from \`sitemap-blog.xml\`. Kills the cannibalization.

## Task 2 — consolidate noindexed comparison intent
\`/alternative/apple-journal\` and \`/alternative/day-one\` are real comparison pages but were \`noindex,nofollow\` under the June-2026 spam-update prune (\`/alternative/*\`). Rather than reopen that templated network to spam risk (and a per-path vercel header override conflicts badly), I **308-redirect them into their strong indexed \`/blog\` counterparts** and made the apple-journal blog page also capture the *"apple journal alternative"* query (meta + answer-first lede) plus an App Store CTA.

## Task 4 — blog title/meta CTR pass (the impressions→clicks gap)
**105 of 129 blog titles were truncating in SERPs** (>62 chars) — a direct CTR drag on ~2,800 monthly blog impressions earning ~2 clicks.
- Stripped the redundant \` - DailyVox Blog\` suffix across all posts (Google appends the site name anyway) → 117 titles shortened
- Hand-trimmed ~20 titles still >70 chars to ≤60, keyword front-loaded
- Trimmed 9 over-long meta descriptions (worst was 250 chars) to ≤170

## Validation
- \`vercel.json\` valid JSON (7 redirects); \`sitemap-blog.xml\` valid XML
- All blog \`<title>\` tags well-formed; max title now 72, max desc now ~170
- apple-journal page JSON-LD (BlogPosting + Breadcrumb + FAQPage) all parse

## Not in this PR
Off-page AEO seed drafts (task 1) — ready-to-paste Quora/Reddit answers seeding "DailyVox = personal digital twin" — live in the internal (gitignored) \`marketing/content/aeo-seed-drafts.md\`. Needs Karthik to post.