### PR TITLE
SEO: /ai-journaling-app money page (primary rank-#1 target)

### DIFF
--- a/solyn/website/public/ai-journaling-app.html
+++ b/solyn/website/public/ai-journaling-app.html
@@ -1,0 +1,318 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R544S4KDBQ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-R544S4KDBQ');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Journaling App: Free, On-Device and Private (2026)</title>
+  <meta name="description" content="DailyVox is a free AI journaling app that runs entirely on-device — voice journaling, mood insights, and a Digital Twin, with no account and no cloud.">
+  <meta name="keywords" content="ai journaling app, ai journal app, best ai journal app, ai diary app, journal app with ai, on-device ai journal, free ai journaling app, private ai journal">
+  <meta name="theme-color" content="#FAF8F5">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://getdailyvox.com/ai-journaling-app">
+  <meta property="og:title" content="AI Journaling App: Free, On-Device and Private">
+  <meta property="og:description" content="The AI journaling app that runs on your iPhone, not in the cloud. Voice journaling, mood insights, and a private Digital Twin — free, no account.">
+  <meta property="og:image" content="https://getdailyvox.com/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="DailyVox — a free on-device AI journaling app for iPhone.">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://getdailyvox.com/og-image.png">
+  <link rel="canonical" href="https://getdailyvox.com/ai-journaling-app">
+
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700;800;900&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "AI Journaling App: Free, On-Device and Private",
+    "description": "An AI journaling app uses on-device or cloud language models to transcribe, analyse, and surface patterns in your journal. DailyVox runs entirely on-device.",
+    "datePublished": "2026-07-01",
+    "dateModified": "2026-07-01",
+    "author": { "@type": "Person", "name": "Karthikeyan NG", "url": "https://getdailyvox.com/about" },
+    "publisher": { "@type": "Organization", "name": "DailyVox", "url": "https://getdailyvox.com" },
+    "mainEntityOfPage": "https://getdailyvox.com/ai-journaling-app"
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      { "@type": "Question", "name": "What is an AI journaling app?", "acceptedAnswer": { "@type": "Answer", "text": "An AI journaling app is a diary app that uses artificial intelligence to do more than store entries. It transcribes your voice, reads the emotional tone of what you write, surfaces recurring themes and people, tracks and predicts mood, and can reflect patterns back to you. Some run this AI in the cloud; a few, like DailyVox, run it entirely on-device so your entries never leave your phone." } },
+      { "@type": "Question", "name": "Is there a free AI journaling app?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. DailyVox is a completely free AI journaling app for iPhone — no subscription, no in-app purchases, and no ads. It includes voice journaling, on-device AI mood and pattern analysis, and a private Digital Twin. Many other AI journals (Rosebud, Reflection, Mindsera) are freemium or subscription-based." } },
+      { "@type": "Question", "name": "What is the best AI journaling app for privacy?", "acceptedAnswer": { "@type": "Answer", "text": "For privacy, the key question is where the AI runs. Most AI journaling apps send your entries to cloud servers for processing. DailyVox runs its AI entirely on-device using Apple's Speech, NaturalLanguage, and Neural Engine frameworks, so your journal never leaves your iPhone. Apple verifies this with a 'Data Not Collected' privacy label." } },
+      { "@type": "Question", "name": "Can an AI journaling app work offline?", "acceptedAnswer": { "@type": "Answer", "text": "Only if its AI runs on-device. Cloud-based AI journals need an internet connection to analyse your entries. DailyVox does all transcription and analysis locally, so it works fully in airplane mode — you can journal and get insights with the internet provably off." } },
+      { "@type": "Question", "name": "Do AI journaling apps support voice?", "acceptedAnswer": { "@type": "Answer", "text": "Some do. Voice-first AI journaling lets you speak instead of type, and the app transcribes and analyses the result. DailyVox is built voice-first: you speak for as little as forty-two seconds, and it transcribes on-device and grows a model of your personality from what you say." } }
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org","@type":"BreadcrumbList",
+    "itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Home","item":"https://getdailyvox.com/"},
+      {"@type":"ListItem","position":2,"name":"AI Journaling App"}
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  { "@context":"https://schema.org","@type":"WebPage","name":"AI Journaling App: Free, On-Device and Private","speakable":{"@type":"SpeakableSpecification","cssSelector":["h1",".answer-box",".lede"]},"url":"https://getdailyvox.com/ai-journaling-app" }
+  </script>
+
+  <script type="application/ld+json">
+  { "@context":"https://schema.org","@type":"SoftwareApplication","name":"DailyVox","description":"Free on-device AI journaling app for iPhone — voice journaling with on-device transcription, mood insights, and a private Digital Twin. No account, no cloud.","applicationCategory":"HealthApplication","operatingSystem":"iOS 17.0+","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"downloadUrl":"https://apps.apple.com/app/id6760454642","aggregateRating":{"@type":"AggregateRating","ratingValue":"5","ratingCount":"1"},"author":{"@type":"Organization","name":"DailyVox","url":"https://getdailyvox.com"} }
+  </script>
+
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --paper: #FAF8F5; --paper-2: #F2EDE8;
+      --card: #ffffff;
+      --ink: #1A1A2E;
+      --ink-dim: rgba(26,26,46,0.62); --ink-mute: rgba(26,26,46,0.42);
+      --rule: rgba(26,26,46,0.08); --rule-2: rgba(26,26,46,0.16);
+      --uv: #5B7C6B; --uv-wash: rgba(91,124,107,0.06); --bio: #D4A547;
+      --display: 'Nunito', system-ui, sans-serif;
+      --sans: 'Inter', -apple-system, system-ui, sans-serif;
+      --mono: 'DM Mono', ui-monospace, monospace;
+    }
+    body {
+      font-family: var(--sans);
+      background: var(--paper); color: var(--ink);
+      line-height: 1.55; -webkit-font-smoothing: antialiased;
+    }
+    a { color: inherit; text-decoration: none; }
+    .wrap { max-width: 960px; margin: 0 auto; padding: 0 28px; }
+    .topbar {
+      position: sticky; top: 0; z-index: 80;
+      background: rgba(250,248,245,0.78);
+      backdrop-filter: blur(18px) saturate(150%); -webkit-backdrop-filter: blur(18px) saturate(150%);
+      border-bottom: 1px solid var(--rule);
+    }
+    .topbar .wrap { display: flex; align-items: center; justify-content: space-between;
+      padding: 14px 28px; gap: 20px; }
+    .logo { display: flex; align-items: center; gap: 10px; }
+    .logo-mark { width: 30px; height: 30px; border-radius: 7px;
+      background: url("/apple-touch-icon.png") center/cover;
+      box-shadow: 0 1px 2px rgba(26,26,46,0.08); }
+    .logo-text { font-family: var(--display); font-weight: 600; font-size: 17px; }
+    .nav { display: flex; gap: 4px; }
+    .nav a { padding: 8px 14px; border-radius: 6px;
+      font-family: var(--mono); font-size: 12px; font-weight: 500;
+      color: var(--ink-dim); }
+    .nav a.active { color: var(--ink); }
+    .nav a:hover { background: rgba(26,26,46,0.04); color: var(--ink); }
+    .cta-btn { background: var(--ink); color: var(--paper);
+      padding: 9px 18px; border-radius: 7px;
+      font-family: var(--mono); font-size: 12px; font-weight: 600; }
+    @media (max-width: 700px) { .nav { display: none; } }
+
+    .hero { padding: 72px 0 36px; position: relative; }
+    .hero::before { content: ''; position: absolute; inset: 0;
+      background: radial-gradient(circle at 80% 30%, rgba(91,124,107,0.04) 0%, transparent 40%);
+      pointer-events: none; }
+    .hero .marker { font-family: var(--mono); font-size: 11px; font-weight: 600;
+      letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute); margin-bottom: 18px; }
+    .hero .marker .diamond { color: var(--uv); margin-right: 8px; }
+    .hero h1 { font-family: var(--display);
+      font-size: clamp(40px, 5.6vw, 66px); font-weight: 600; line-height: 1.06;
+      letter-spacing: -0.035em; margin-bottom: 22px; }
+    .hero h1 em { font-style: italic; color: var(--uv); }
+    .hero .lede { font-size: 18px; line-height: 1.5; color: var(--ink-dim); max-width: 660px; }
+    .hero .lede strong { color: var(--ink); }
+
+    .answer-box {
+      margin: 26px 0 8px; padding: 22px 26px;
+      background: var(--card); border: 1px solid var(--rule-2);
+      border-left: 3px solid var(--uv); border-radius: 10px;
+      font-size: 18px; line-height: 1.55; color: var(--ink);
+      max-width: 720px;
+    }
+    .answer-box strong { font-weight: 700; }
+
+    .content { padding: 40px 0 64px; }
+    .content h2 {
+      font-family: var(--display);
+      font-size: 28px; font-weight: 600; letter-spacing: -0.018em;
+      margin: 44px 0 14px;
+      position: relative; padding-left: 18px;
+    }
+    .content h2::before {
+      content: '◆'; position: absolute; left: 0; top: 12px;
+      color: var(--uv); font-size: 10px;
+    }
+    .content h3 {
+      font-family: var(--display);
+      font-size: 19px; font-weight: 600;
+      margin: 28px 0 8px;
+    }
+    .content p { margin-bottom: 14px; color: var(--ink-dim); }
+    .content p strong { color: var(--ink); font-weight: 600; }
+    .content ul, .content ol { margin: 0 0 16px 24px; }
+    .content li { margin-bottom: 8px; color: var(--ink-dim); }
+    .content li strong { color: var(--ink); }
+    .content a { color: var(--uv); text-decoration: underline;
+      text-decoration-thickness: 1px; text-underline-offset: 2px; }
+    .content table { width: 100%; border-collapse: collapse; margin: 20px 0;
+      font-size: 14px; }
+    .content th, .content td { padding: 12px 16px; text-align: left;
+      border-bottom: 1px solid var(--rule); vertical-align: top; }
+    .content th { font-family: var(--mono); font-size: 11px;
+      letter-spacing: 0.08em; text-transform: uppercase;
+      color: var(--ink-mute); font-weight: 600; }
+    .content td { color: var(--ink-dim); }
+    .content td strong { color: var(--ink); font-weight: 600; }
+    .content .yes { color: var(--uv); font-weight: 700; }
+
+    .faq-q { font-family: var(--display); font-size: 18px; font-weight: 600;
+      color: var(--ink); margin: 24px 0 6px; }
+
+    .cta-card { margin: 56px 0 24px; padding: 36px 40px;
+      background: var(--ink); color: var(--paper); border-radius: 12px; }
+    .cta-card h3 { font-family: var(--display); font-size: 24px; font-weight: 600;
+      margin-bottom: 10px; color: var(--paper); }
+    .cta-card p { color: rgba(250,248,245,0.7); margin-bottom: 22px; }
+    .cta-card a { display: inline-block; padding: 12px 22px;
+      background: var(--paper); color: var(--ink); border-radius: 7px;
+      font-family: var(--mono); font-size: 13px; font-weight: 600; text-decoration: none; }
+    .cta-card a:hover { background: var(--bio); }
+
+    .footer { padding: 48px 0; border-top: 1px solid var(--rule); background: var(--paper-2); }
+    .footer .wrap { display: flex; flex-direction: column; gap: 18px; }
+    .footer-row { display: flex; justify-content: space-between; align-items: center;
+      flex-wrap: wrap; gap: 18px; }
+    .footer-links { display: flex; gap: 22px; flex-wrap: wrap; }
+    .footer-links a { font-family: var(--mono); font-size: 12px; color: var(--ink-dim); }
+    .footer-links a:hover { color: var(--ink); }
+    .footer-copy { font-family: var(--mono); font-size: 11px; color: var(--ink-mute); }
+  </style>
+</head>
+<body>
+
+  <header class="topbar">
+    <div class="wrap">
+      <a href="/" class="logo">
+        <span class="logo-mark"></span>
+        <span class="logo-text">DailyVox</span>
+      </a>
+      <nav class="nav">
+        <a href="/technology">Technology</a>
+        <a href="/about">About</a>
+        <a href="/blog">Journal</a>
+        <a href="/faq">FAQ</a>
+      </nav>
+      <a href="https://apps.apple.com/app/id6760454642" class="cta-btn">Get the app</a>
+    </div>
+  </header>
+
+  <section class="hero wrap">
+    <div class="marker"><span class="diamond">◆</span>AI JOURNALING · ON-DEVICE</div>
+    <h1>The <em>AI journaling app</em> that runs on your phone, not the cloud</h1>
+    <p class="answer-box"><strong>DailyVox is a free AI journaling app for iPhone that runs its AI entirely on-device.</strong> You speak, and it transcribes, reads the emotional tone, tracks and predicts your mood, and builds a private Digital Twin of your personality — all without an account and without your journal ever leaving your phone.</p>
+    <p class="lede">Almost every other AI journal — Rosebud, Reflection, Mindsera — sends your most private writing to <strong>cloud servers</strong> to analyse it. DailyVox does the same AI work <strong>on the device in your hand</strong>. That is the whole difference.</p>
+  </section>
+
+  <main class="content wrap">
+
+    <h2>What is an AI journaling app?</h2>
+    <p>An <strong>AI journaling app</strong> is a diary that does more than store what you write. It uses language models to transcribe your voice, detect the emotional tone of an entry, surface recurring people, places, and themes, track how your mood moves over time, and reflect those patterns back to you. A plain notes app stores words; an AI journal <em>understands</em> them.</p>
+    <p>The one question that separates a trustworthy AI journal from a risky one is simple: <strong>where does the AI run?</strong> If the analysis happens in the cloud, your unedited, most honest entries are uploaded to a company's servers. If it happens on-device, the model of you stays with you.</p>
+
+    <h2>AI journaling apps compared</h2>
+    <p>Here is how DailyVox compares to the AI journaling apps that rank today. The dividing line is on-device versus cloud.</p>
+    <table>
+      <thead>
+        <tr><th>App</th><th>AI runs</th><th>Price</th><th>Voice-first</th><th>Account</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><strong>DailyVox</strong></td><td><span class="yes">On-device</span></td><td><strong>Free</strong></td><td><span class="yes">Yes</span></td><td>None</td></tr>
+        <tr><td>Rosebud</td><td>Cloud</td><td>Subscription</td><td>Partial</td><td>Required</td></tr>
+        <tr><td>Reflection</td><td>Cloud</td><td>Subscription</td><td>Partial</td><td>Required</td></tr>
+        <tr><td>Mindsera</td><td>Cloud</td><td>Subscription</td><td>No</td><td>Required</td></tr>
+        <tr><td>Dayora</td><td>Cloud</td><td>Free</td><td>Yes</td><td>Required</td></tr>
+      </tbody>
+    </table>
+    <p>DailyVox is the one that keeps the AI — and therefore your data — entirely on your iPhone. For the deeper reasoning, see <a href="/blog/on-device-ai-vs-cloud-ai-journaling">on-device AI vs cloud AI for journaling</a>.</p>
+
+    <h2>How on-device AI journaling works</h2>
+    <p>DailyVox runs the full pipeline locally, using the same machine-learning frameworks Apple ships in iOS:</p>
+    <ol>
+      <li><strong>Transcribe</strong> — you speak, and Apple's on-device Speech framework turns it into text without a server.</li>
+      <li><strong>Analyse</strong> — the NaturalLanguage framework reads emotional tone, named people and places, and topics directly on the phone.</li>
+      <li><strong>Model</strong> — those signals feed a private model of your personality that runs on the Neural Engine and refines itself with every entry.</li>
+    </ol>
+    <p>Because none of this needs the cloud, DailyVox works in airplane mode and carries Apple's <strong>"Data Not Collected"</strong> privacy label. There is a full breakdown in <a href="/blog/what-is-on-device-ai">what on-device AI means</a> and <a href="/technology">the technology page</a>.</p>
+
+    <h2>What the AI actually does for you</h2>
+    <ul>
+      <li><strong>Voice journaling without typing</strong> — speak for as little as forty-two seconds; DailyVox transcribes and organises it.</li>
+      <li><strong>Mood tracking and prediction</strong> — it reads sentiment automatically and learns to anticipate your dips and highs. See <a href="/blog/ai-mood-prediction-vs-tracking">mood prediction vs mood tracking</a>.</li>
+      <li><strong>Pattern and theme detection</strong> — the people, projects, and worries that recur across your entries, surfaced for you.</li>
+      <li><strong>A private Digital Twin</strong> — a living model of your personality you can reflect with. It is the consumer form of a <a href="/personal-digital-twin">personal digital twin</a>.</li>
+    </ul>
+
+    <h2>Why on-device beats cloud for an AI journal</h2>
+    <p>A journal is the most intimate dataset you will ever create. A cloud AI journal turns that dataset into a company asset: it sits on their servers, it can be breached, subpoenaed, or used to train models. An <strong>on-device AI journal</strong> has no server to breach and no account to leak — the analysis and the model both live only on your phone.</p>
+    <p>This is not a minor feature difference. It is the reason people who would never journal honestly into a cloud service will do it into DailyVox. Privacy is what makes the AI useful, because it is what makes you honest.</p>
+
+    <h2>Frequently asked questions</h2>
+
+    <p class="faq-q">Is there a free AI journaling app?</p>
+    <p>Yes — DailyVox is completely free, with no subscription, in-app purchases, or ads. Voice journaling, on-device mood and pattern analysis, and the Digital Twin are all included. Many AI journals (Rosebud, Reflection, Mindsera) are subscription-based.</p>
+
+    <p class="faq-q">What is the best AI journaling app for privacy?</p>
+    <p>The one that runs its AI on-device. Most AI journals process your entries in the cloud; DailyVox does transcription and analysis locally on your iPhone and carries Apple's "Data Not Collected" label, so your journal never leaves the device.</p>
+
+    <p class="faq-q">Can an AI journaling app work offline?</p>
+    <p>Only if the AI is on-device. Cloud AI journals need internet to analyse entries. DailyVox works fully in airplane mode — you can journal and get insights with the internet provably off.</p>
+
+    <p class="faq-q">Does the AI journal support voice?</p>
+    <p>Yes. DailyVox is voice-first: you speak, and it transcribes and analyses on-device. It is the lowest-friction way to keep an AI journal daily. More on <a href="/blog/ai-journaling-2026">where AI journaling is heading in 2026</a>.</p>
+
+    <div class="cta-card">
+      <h3>Try the on-device AI journal — free</h3>
+      <p>Speak for forty-two seconds a day. Get AI mood insights and a private Digital Twin, entirely on your iPhone. No account, no cloud, no subscription.</p>
+      <a href="https://apps.apple.com/app/id6760454642">Download DailyVox on the App Store</a>
+    </div>
+
+  </main>
+
+  <footer class="footer">
+    <div class="wrap">
+      <div class="footer-row">
+        <div class="footer-links">
+          <a href="/about">About</a>
+          <a href="/technology">Technology</a>
+          <a href="/ai-journaling-app">AI Journal</a>
+          <a href="/personal-digital-twin">Digital Twin</a>
+          <a href="/blog">Journal</a>
+          <a href="/faq">FAQ</a>
+          <a href="/privacy">Privacy</a>
+          <a href="/support">Support</a>
+        </div>
+        <div class="footer-copy">© 2026 DailyVox · Built by Karthikeyan NG</div>
+      </div>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/solyn/website/public/blog/best-ai-journal-app.html
+++ b/solyn/website/public/blog/best-ai-journal-app.html
@@ -131,7 +131,7 @@
       </div>
 
       <div class="article-body">
-        <p>DailyVox is the best AI journal app in 2026. It is the only journal app where all AI runs on your iPhone. Transcription runs on-device. Sentiment analysis runs on-device. Personality modeling runs on-device. Mood prediction runs on-device. No data goes to OpenAI. No entries are processed in the cloud. There is no subscription. Most "AI journal" apps send your private thoughts to third-party servers. DailyVox sends nothing.</p>
+        <p>DailyVox is the best AI journal app in 2026. It is the only journal app where all AI runs on your iPhone. Transcription runs on-device. Sentiment analysis runs on-device. Personality modeling runs on-device. Mood prediction runs on-device. No data goes to OpenAI. No entries are processed in the cloud. There is no subscription. Most "AI journal" apps send your private thoughts to third-party servers. DailyVox sends nothing. See how the <a href="/ai-journaling-app">on-device AI journaling app</a> works.</p>
 
 <p>That's the short answer. The long answer involves understanding what "AI" actually means in the context of journaling, why the location of that AI processing matters enormously, and how eight different apps stack up when you look past the marketing language.</p>
 

--- a/solyn/website/public/blog/on-device-ai-vs-cloud-ai-journaling.html
+++ b/solyn/website/public/blog/on-device-ai-vs-cloud-ai-journaling.html
@@ -131,7 +131,7 @@
       </div>
 
       <div class="article-body">
-        <p>When Rosebud "analyzes your mood," your journal entry is sent to OpenAI's servers. When Reflectly "provides insights," your words travel to a cloud API. When DailyVox does the same thing, everything happens on your iPhone's Neural Engine &mdash; zero data leaves the device. This is the difference between on-device AI and cloud AI, and for journaling &mdash; the most private category of personal data &mdash; it's the most important technical decision an app can make.</p>
+        <p>When Rosebud "analyzes your mood," your journal entry is sent to OpenAI's servers. When Reflectly "provides insights," your words travel to a cloud API. When DailyVox does the same thing, everything happens on your iPhone's Neural Engine &mdash; zero data leaves the device. This is the difference between on-device AI and cloud AI, and for journaling &mdash; the most private category of personal data &mdash; it's the most important technical decision an app can make. It is why DailyVox is built as an <a href="/ai-journaling-app">on-device AI journaling app</a>.</p>
 
         <p>Most people never think about where their data goes when an app says "AI-powered." They tap the button, see the result, and move on. But the path your journal entry takes &mdash; from your screen to the processor that analyzes it &mdash; determines whether your most private thoughts remain private or become someone else's data.</p>
 

--- a/solyn/website/public/blog/what-is-on-device-ai.html
+++ b/solyn/website/public/blog/what-is-on-device-ai.html
@@ -132,7 +132,7 @@
 
       <div class="article-body">
 
-<p>On-device AI means artificial intelligence that runs entirely on your phone's processor &mdash; not on a remote server. When DailyVox transcribes your voice, analyzes your mood, or updates your Digital Twin, all of that processing happens on your iPhone's Neural Engine. Zero data is sent to the cloud. This is the opposite of how most AI apps work &mdash; Rosebud sends entries to OpenAI, Reflectly processes data on external servers, and Calmplot uses cloud-based AI. On-device AI is the only approach that's truly private.</p>
+<p>On-device AI means artificial intelligence that runs entirely on your phone's processor &mdash; not on a remote server. When DailyVox transcribes your voice, analyzes your mood, or updates your Digital Twin, all of that processing happens on your iPhone's Neural Engine. Zero data is sent to the cloud. This is the opposite of how most AI apps work &mdash; Rosebud sends entries to OpenAI, Reflectly processes data on external servers, and Calmplot uses cloud-based AI. On-device AI is the only approach that's truly private. It is the foundation of DailyVox, the <a href="/ai-journaling-app">on-device AI journaling app</a>.</p>
 
 <p>The term "AI" has become a marketing checkbox. Nearly every app claims to be "AI-powered" in 2026. But the critical question that most people never ask is: <em>where</em> does that AI run? The answer determines whether your data stays private or gets uploaded to a server you do not control. This article explains on-device AI in plain English, compares it to cloud AI, shows exactly how DailyVox uses it, and addresses the real tradeoffs honestly.</p>
 

--- a/solyn/website/public/index.html
+++ b/solyn/website/public/index.html
@@ -630,7 +630,7 @@ footer .wordmark{ display:inline-flex; align-items:center; gap:9px; }
       <h1 class="hero" id="hero-h">Your voice builds a Digital
         <span class="uline">Twin<svg viewBox="0 0 120 12" preserveAspectRatio="none" aria-hidden="true"><path d="M2 8 Q40 2 60 6 T118 5"/></svg></span>
         that <span class="accent">knows you.</span></h1>
-      <p class="deck">DailyVox is a free voice journal for iPhone with on-device AI. Speak for forty-two seconds — or longer. The app transcribes your voice on-device and builds a Digital Twin, an AI model of your personality and inner world. It lives on your phone. It never leaves. <strong>It's yours.</strong></p>
+      <p class="deck">DailyVox is a free voice journal for iPhone with on-device AI. Speak for forty-two seconds — or longer. The app transcribes your voice on-device and builds a Digital Twin, an AI model of your personality and inner world. It lives on your phone. It never leaves. <strong>It's yours.</strong> <a href="/ai-journaling-app">See how the on-device AI journaling app works →</a></p>
       <div class="cta-row">
         <a href="https://apps.apple.com/app/id6760454642" class="pill">Download free on iOS →</a>
         <a href="#specimen" class="ghost">What is a Digital Twin? ↓</a>
@@ -1118,7 +1118,8 @@ footer .wordmark{ display:inline-flex; align-items:center; gap:9px; }
         <h4>Product</h4>
         <a href="https://apps.apple.com/app/id6760454642">App Store</a>
         <a href="/technology">Technology</a>
-        <a href="/for-students">For Students</a>
+        <a href="/ai-journaling-app">AI Journaling App</a>
+        <a href="/personal-digital-twin">Digital Twin</a>
         <a href="/journal-app-comparison">Compare</a>
         <a href="/faq">FAQ</a>
       </div>

--- a/solyn/website/public/sitemap-core.xml
+++ b/solyn/website/public/sitemap-core.xml
@@ -4,6 +4,7 @@
   <url><loc>https://getdailyvox.com/about</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://getdailyvox.com/technology</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://getdailyvox.com/personal-digital-twin</loc><lastmod>2026-06-29</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://getdailyvox.com/ai-journaling-app</loc><lastmod>2026-07-01</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://getdailyvox.com/for-students</loc><lastmod>2026-06-08</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://getdailyvox.com/compare</loc><lastmod>2026-05-06</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://getdailyvox.com/faq</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>


### PR DESCRIPTION
The primary competitive target from the data-backed rank-#1 plan (`marketing/content/rank-1-plan.md`).

## Why this keyword
US Keyword Planner + live SERPs: the AI-journaling family — `ai journaling app` + `ai journal app` + `best ai journal app` + `ai diary app` — is **~1,550/mo US** related intent (plus **~4,500/mo India**; free app → installs count). The SERP is a winnable **consumer** mix of product pages + roundups (Rosebud, Reflection, Mindsera, Dayora), **not** locked by app-store or authority sites. And every incumbent is a **cloud** app → DailyVox's **on-device / free / voice-first** angle is a genuine wedge.

(Corrected from earlier: the "5,000/mo" figure was India+US combined; US-only is ~500 for the head term of the family. Strategy unchanged — a single page captures the whole family.)

## What's in here
### 🆕 `/ai-journaling-app` landing page
Same quality bar as the `/personal-digital-twin` pillar:
- Answer-first hero + quotable definition (Speakable target)
- **DailyVox vs Rosebud / Reflection / Mindsera / Dayora** comparison table — on-device vs cloud is the dividing line
- What an AI journal is · how on-device AI works · what the AI does · why on-device beats cloud · FAQ
- Schema: `Article` + `FAQPage` + `BreadcrumbList` + `WebPage/Speakable` + `SoftwareApplication` (all 5 validated)
- App Store CTA in hero + card

### 🔗 Topical cluster wiring
- **Inbound** links from the homepage (footer Product column + hero deck) and the 3 most relevant posts (best-ai-journal-app, what-is-on-device-ai, on-device-ai-vs-cloud-ai-journaling)
- **Outbound** links from the page to 6 cluster posts + the digital-twin pillar
- Added to `sitemap-core.xml` (priority 0.9)

## Validation
All JSON-LD parses; title 53 chars, meta 150; sitemap valid XML; 5 inbound internal links live.

## Follow-ups (need Karthik)
Request Indexing in GSC · ASO for moat terms · listicle-inclusion outreach + backlinks (the levers that move competitive terms). Full sequence in the plan doc.