### PR TITLE
Onboarding: 'Speak your first star' — voice-first signature (+ persistence, escape hatch)

### DIFF
--- a/solyn/solyn/OnboardingView.swift
+++ b/solyn/solyn/OnboardingView.swift
@@ -94,7 +94,7 @@ private struct InviteScreen: View {
                     .foregroundColor(OB.ink)
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
-                Text("Not a form. Not a tour. Just say one\ntrue thing — and watch it become the\nfirst star in a sky only you can see.")
+                Text("No forms, no sign-up. Just talk about\nyour day — and watch your voice become\nthe first star in a sky only you can see.")
                     .font(.system(size: 16, weight: .regular, design: .rounded))
                     .foregroundColor(OB.inkDim)
                     .multilineTextAlignment(.center)
@@ -194,12 +194,12 @@ private struct SpeakScreen: View {
         switch phase {
         case .born: return "A star is born."
         case .processing: return "Finding your words…"
-        default: return "Say one true thing\nabout today."
+        default: return "How was your day,\nreally?"
         }
     }
     private var subhead: String {
         switch phase {
-        case .idle: return "Out loud. Anything. It stays on your phone."
+        case .idle: return "Speak, don't type. DailyVox turns it into your private journal — kept on your phone."
         case .recording: return "Listening… speak as long as you like."
         case .processing: return "On-device. Nothing left your phone."
         case .born: return "Your voice, now a light in your sky."

--- a/solyn/solyn/OnboardingView.swift
+++ b/solyn/solyn/OnboardingView.swift
@@ -78,13 +78,13 @@ struct OnboardingView: View {
                         .tag(Step.name.rawValue)
                     MessageStep(
                         symbol: "mic.fill", tint: OB.gold,
-                        title: "Your voice builds a\nDigital Twin",
+                        title: "Your voice builds a Digital Twin",
                         message: "Speak about 42 seconds a day. Your Twin learns your personality, moods, and the people in your life — all on your phone.",
                         isIPad: isIPad
                     ).tag(Step.twin.rawValue)
                     MessageStep(
                         symbol: "lock.shield.fill", tint: OB.sage,
-                        title: "A sky no one else\ncan see",
+                        title: "A sky no one else can see",
                         message: "Everything runs on your device. No account, no cloud, no one watching. Apple's privacy label: Data Not Collected.",
                         isIPad: isIPad
                     ).tag(Step.privacy.rawValue)
@@ -321,6 +321,8 @@ private struct MessageStep: View {
                     .tracking(-0.4)
                     .foregroundColor(OB.ink)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .minimumScaleFactor(0.85)
                 Text(message)
                     .font(.system(size: 15, weight: .regular, design: .rounded))
                     .foregroundColor(OB.inkDim)

--- a/solyn/solyn/OnboardingView.swift
+++ b/solyn/solyn/OnboardingView.swift
@@ -2,530 +2,475 @@
 //  OnboardingView.swift
 //  solyn
 //
-//  Warm, ivory-light onboarding — constellation / "inner sky" language.
-//  Flow: Welcome → Name yourself (optional) → Your Twin → Private →
-//  Name your planets → Ready to record.
+//  Signature onboarding — "Speak your first star into being."
+//  Three beats: invite → speak (live waveform, on-device) → your star is born.
+//  The product's magic (voice → a private star that never leaves the phone)
+//  is *experienced* in the first 30 seconds, not explained.
 //
 
 import SwiftUI
 
-// MARK: - Palette (warm ivory, matches the app theme)
+// MARK: - Palette
 
 private enum OB {
-    static let paper   = Color(red: 0.980, green: 0.972, blue: 0.961)  // #FAF8F5
-    static let paper2  = Color(red: 0.949, green: 0.929, blue: 0.910)  // warm dusk paper
+    static let paper   = Color(red: 0.980, green: 0.972, blue: 0.961)
+    static let paper2  = Color(red: 0.949, green: 0.929, blue: 0.910)
     static let card    = Color.white
-    static let ink     = Color(red: 0.102, green: 0.102, blue: 0.180)  // #1A1A2E
+    static let ink     = Color(red: 0.102, green: 0.102, blue: 0.180)
     static let inkDim  = Color(red: 0.102, green: 0.102, blue: 0.180).opacity(0.62)
     static let inkMute = Color(red: 0.102, green: 0.102, blue: 0.180).opacity(0.40)
     static let rule    = Color(red: 0.102, green: 0.102, blue: 0.180).opacity(0.10)
     static let gold    = Color(red: 0.831, green: 0.647, blue: 0.278)
     static let sage    = Color(red: 0.357, green: 0.486, blue: 0.420)
     static let forest  = Color(red: 0.420, green: 0.620, blue: 0.482)
-    static let coral   = Color(red: 0.769, green: 0.451, blue: 0.420)
 }
+
+// MARK: - Container
 
 struct OnboardingView: View {
     @Binding var hasCompletedOnboarding: Bool
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
-    @State private var currentPage = 0
-    @State private var userName = ""
-    @State private var selectedIntentions: Set<String> = []
-    @FocusState private var nameFocused: Bool
+    @State private var screen = 0          // 0 invite, 1 speak, 2 claim
+    @State private var starBorn = false
+    @State private var transcript = ""
 
-    private var isIPad: Bool { horizontalSizeClass == .regular }
-
-    // Ordered steps
-    private enum Step: Int, CaseIterable {
-        case welcome, name, twin, privacy, intention, ready
-    }
-    private var totalSteps: Int { Step.allCases.count }
-    private var isLast: Bool { currentPage == totalSteps - 1 }
+    private var demo: Bool { ProcessInfo.processInfo.arguments.contains("-OnboardingDemo") }
 
     var body: some View {
         ZStack {
-            // Warm ivory background
-            LinearGradient(
-                colors: [OB.paper, OB.paper2],
-                startPoint: .top, endPoint: .bottom
-            )
-            .ignoresSafeArea()
+            LinearGradient(colors: [OB.paper, OB.paper2], startPoint: .top, endPoint: .bottom)
+                .ignoresSafeArea()
+            LivingSky(bright: starBorn ? 1 : 0)
 
-            IvorySky()
-
-            VStack(spacing: 0) {
-                // Top bar — Skip (hidden on the final page)
-                HStack {
-                    Spacer()
-                    if !isLast {
-                        Button("Skip") {
-                            nameFocused = false
-                            withAnimation(.spring(response: 0.4)) {
-                                currentPage = totalSteps - 1
-                            }
-                        }
-                        .font(.system(size: 15, weight: .medium, design: .rounded))
-                        .foregroundColor(OB.inkMute)
-                        .padding()
+            Group {
+                switch screen {
+                case 0:
+                    InviteScreen(demo: demo) { advance() }
+                case 1:
+                    SpeakScreen(demo: demo) { text in
+                        transcript = text
+                        withAnimation(.easeInOut(duration: 0.8)) { starBorn = true }
+                        advance()
                     }
+                default:
+                    ClaimScreen(transcript: transcript, onEnter: complete)
                 }
-
-                // Pages
-                TabView(selection: $currentPage) {
-                    WelcomeStep(isIPad: isIPad).tag(Step.welcome.rawValue)
-                    NameStep(userName: $userName, focused: $nameFocused, isIPad: isIPad)
-                        .tag(Step.name.rawValue)
-                    MessageStep(
-                        symbol: "mic.fill", tint: OB.gold,
-                        title: "Your voice builds a Digital Twin",
-                        message: "Speak about 42 seconds a day. Your Twin learns your personality, moods, and the people in your life — all on your phone.",
-                        isIPad: isIPad
-                    ).tag(Step.twin.rawValue)
-                    MessageStep(
-                        symbol: "lock.shield.fill", tint: OB.sage,
-                        title: "A sky no one else can see",
-                        message: "Everything runs on your device. No account, no cloud, no one watching. Apple's privacy label: Data Not Collected.",
-                        isIPad: isIPad
-                    ).tag(Step.privacy.rawValue)
-                    IntentionCheckInView(selectedIntentions: $selectedIntentions, isIPad: isIPad)
-                        .tag(Step.intention.rawValue)
-                    ReadyStep(name: trimmedName, isIPad: isIPad).tag(Step.ready.rawValue)
-                }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .animation(.spring(response: 0.4), value: currentPage)
-
-                // Constellation progress dots
-                HStack(spacing: 12) {
-                    ForEach(0..<totalSteps, id: \.self) { index in
-                        Image(systemName: index <= currentPage ? "star.fill" : "star")
-                            .font(.system(size: index == currentPage ? 10 : 8))
-                            .foregroundColor(index <= currentPage ? OB.gold : OB.inkMute.opacity(0.5))
-                            .animation(.spring(response: 0.3), value: currentPage)
-                    }
-                }
-                .padding(.bottom, 24)
-
-                // Primary action
-                Button(action: advance) {
-                    HStack(spacing: 8) {
-                        if isLast {
-                            Image(systemName: "mic.fill").font(.system(size: 16, weight: .semibold))
-                        }
-                        Text(primaryTitle)
-                            .font(.system(size: 17, weight: .semibold, design: .rounded))
-                        if !isLast {
-                            Image(systemName: "arrow.right").font(.system(size: 15, weight: .semibold))
-                        }
-                    }
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 17)
-                    .background(
-                        LinearGradient(colors: [OB.sage, OB.sage.opacity(0.85)],
-                                       startPoint: .leading, endPoint: .trailing)
-                    )
-                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-                    .shadow(color: OB.sage.opacity(0.28), radius: 12, y: 6)
-                }
-                .frame(maxWidth: isIPad ? 500 : .infinity)
-                .padding(.horizontal, isIPad ? 60 : 28)
-                .padding(.bottom, 44)
             }
+            .transition(.opacity)
         }
     }
 
-    private var trimmedName: String {
-        userName.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
+    private func advance() { withAnimation(.easeInOut(duration: 0.6)) { screen += 1 } }
 
-    private var primaryTitle: String {
-        switch Step(rawValue: currentPage) {
-        case .name: return trimmedName.isEmpty ? "Skip for now" : "Continue"
-        case .ready: return "Record my first star"
-        default: return "Next"
-        }
-    }
-
-    private func advance() {
-        nameFocused = false
-        if isLast {
-            completeOnboarding()
-        } else {
-            withAnimation(.spring(response: 0.4)) { currentPage += 1 }
-        }
-    }
-
-    private func completeOnboarding() {
-        if !trimmedName.isEmpty {
-            UserDefaults.standard.set(trimmedName, forKey: "userName")
-        }
-        UserDefaults.standard.set(Array(selectedIntentions), forKey: "onboardingIntentions")
+    private func complete() {
         UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
-        withAnimation(.easeInOut(duration: 0.3)) {
-            hasCompletedOnboarding = true
-        }
+        withAnimation(.easeInOut(duration: 0.4)) { hasCompletedOnboarding = true }
     }
 }
 
-// MARK: - Welcome (breathing gold star on ivory)
+// MARK: - Beat 1: Invite
 
-private struct WelcomeStep: View {
-    let isIPad: Bool
-    @State private var starScale: CGFloat = 0.3
-    @State private var glow: Double = 0
-    @State private var textOpacity: Double = 0
-    @State private var breathe = false
-    @State private var drift = false
+private struct InviteScreen: View {
+    let demo: Bool
+    let onBegin: () -> Void
+    @State private var appear = false
 
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
-
             ZStack {
-                Circle()
-                    .fill(OB.gold.opacity(glow * 0.18))
-                    .frame(width: 200, height: 200)
-                    .scaleEffect(breathe ? 1.12 : 0.94)
-                Circle()
-                    .fill(OB.gold.opacity(glow * 0.28))
-                    .frame(width: 118, height: 118)
-                    .scaleEffect(breathe ? 1.08 : 0.96)
-                Circle()
-                    .fill(OB.gold)
-                    .frame(width: 22, height: 22)
-                    .scaleEffect(starScale * (breathe ? 1.08 : 1.0))
-                    .shadow(color: OB.gold.opacity(0.6), radius: 18)
-                Circle()
-                    .fill(Color.white)
-                    .frame(width: 7, height: 7)
-                    .scaleEffect(starScale)
-
-                // Ambient drifting stars
-                ForEach(0..<8, id: \.self) { i in
-                    let angle = Double(i) * (.pi * 2 / 8)
-                    let radius: CGFloat = 85 + CGFloat(i % 3) * 20
-                    Circle()
-                        .fill(OB.sage.opacity(glow * (0.30 + Double(i % 3) * 0.10)))
-                        .frame(width: CGFloat(3 + i % 2), height: CGFloat(3 + i % 2))
-                        .offset(x: cos(angle) * radius, y: sin(angle) * radius)
-                }
-                .rotationEffect(.degrees(drift ? 360 : 0))
-                .animation(.linear(duration: 90).repeatForever(autoreverses: false), value: drift)
+                Circle().fill(OB.gold.opacity(appear ? 0.14 : 0)).frame(width: 140, height: 140)
+                Circle().fill(OB.gold.opacity(appear ? 0.22 : 0)).frame(width: 84, height: 84)
+                Image(systemName: "waveform")
+                    .font(.system(size: 34, weight: .semibold))
+                    .foregroundColor(OB.gold)
             }
-
-            Spacer().frame(height: 56)
+            .scaleEffect(appear ? 1 : 0.7)
 
             VStack(spacing: 14) {
-                Text("Your inner sky\nis waiting")
-                    .font(.system(size: isIPad ? 44 : 38, weight: .bold, design: .rounded))
-                    .tracking(-0.6)
+                Text("Your sky starts\nwith your voice")
+                    .font(.system(size: 36, weight: .bold, design: .rounded))
+                    .tracking(-0.5)
                     .foregroundColor(OB.ink)
                     .multilineTextAlignment(.center)
-                Text("Every thought you speak becomes a star.\nOver time, constellations form — patterns\nonly you can see.")
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("Not a form. Not a tour. Just say one\ntrue thing — and watch it become the\nfirst star in a sky only you can see.")
                     .font(.system(size: 16, weight: .regular, design: .rounded))
                     .foregroundColor(OB.inkDim)
                     .multilineTextAlignment(.center)
                     .lineSpacing(5)
             }
+            .padding(.top, 32)
             .padding(.horizontal, 30)
-            .opacity(textOpacity)
+            .opacity(appear ? 1 : 0)
+            .offset(y: appear ? 0 : 16)
 
             Spacer()
             Spacer()
+
+            PrimaryButton(title: "I'm ready", filled: true, action: onBegin)
+                .padding(.horizontal, 28)
+                .padding(.bottom, 44)
         }
         .onAppear {
-            withAnimation(.easeOut(duration: 1.4)) { starScale = 1.0; glow = 1.0 }
-            withAnimation(.easeOut(duration: 1.0).delay(0.7)) { textOpacity = 1.0 }
-            withAnimation(.easeInOut(duration: 3.2).repeatForever(autoreverses: true).delay(0.5)) { breathe = true }
-            drift = true
+            withAnimation(.easeOut(duration: 0.9).delay(0.15)) { appear = true }
+            if demo {
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 2_200_000_000)
+                    onBegin()
+                }
+            }
         }
     }
 }
 
-// MARK: - Name yourself (optional, sage focus ring)
+// MARK: - Beat 2: Speak (the heart)
 
-private struct NameStep: View {
-    @Binding var userName: String
-    var focused: FocusState<Bool>.Binding
-    let isIPad: Bool
+private struct SpeakScreen: View {
+    let demo: Bool
+    let onBorn: (String) -> Void
+
+    @StateObject private var recorder = AudioRecorder()
+    @State private var phase: Phase = .idle
+    @State private var level: CGFloat = 0
+    @State private var elapsed: Double = 0
+    @State private var transcript = ""
+    @State private var flare: CGFloat = 0
+
+    enum Phase { case idle, recording, processing, born }
+    private let softTarget: Double = 42
 
     var body: some View {
         VStack(spacing: 0) {
-            Spacer()
-
-            IconBadge(symbol: "sparkle", tint: OB.gold)
-
-            VStack(spacing: 12) {
-                Text("Let's get to know you")
-                    .font(.system(size: isIPad ? 34 : 28, weight: .bold, design: .rounded))
-                    .foregroundColor(OB.ink)
-                    .multilineTextAlignment(.center)
-                Text("DailyVox becomes more yours with every word.")
-                    .font(.system(size: 15, weight: .regular, design: .rounded))
-                    .foregroundColor(OB.inkDim)
-                    .multilineTextAlignment(.center)
-            }
-            .padding(.top, 24)
-            .padding(.horizontal, 32)
-
-            TextField("Your name", text: $userName)
-                .font(.system(size: 17, weight: .medium, design: .rounded))
-                .foregroundColor(OB.ink)
-                .multilineTextAlignment(.center)
-                .textInputAutocapitalization(.words)
-                .submitLabel(.done)
-                .focused(focused)
-                .padding(.vertical, 16)
-                .padding(.horizontal, 20)
-                .background(OB.card)
-                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(focused.wrappedValue ? OB.sage : OB.rule,
-                                lineWidth: focused.wrappedValue ? 2 : 1)
-                )
-                .shadow(color: OB.ink.opacity(0.04), radius: 6, y: 3)
-                .padding(.top, 28)
-                .padding(.horizontal, 32)
-                .frame(maxWidth: isIPad ? 460 : .infinity)
-                .animation(.easeInOut(duration: 0.2), value: focused.wrappedValue)
-
-            Text("Optional — stored only on your phone.")
-                .font(.system(size: 12, weight: .regular, design: .rounded))
-                .foregroundColor(OB.inkMute)
-                .padding(.top, 12)
-
-            Spacer()
-            Spacer()
-        }
-    }
-}
-
-// MARK: - Message step (icon + title + body)
-
-private struct MessageStep: View {
-    let symbol: String
-    let tint: Color
-    let title: String
-    let message: String
-    let isIPad: Bool
-
-    var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            IconBadge(symbol: symbol, tint: tint)
-            VStack(spacing: 14) {
-                Text(title)
-                    .font(.system(size: isIPad ? 36 : 30, weight: .bold, design: .rounded))
-                    .tracking(-0.4)
-                    .foregroundColor(OB.ink)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .minimumScaleFactor(0.85)
-                Text(message)
-                    .font(.system(size: 15, weight: .regular, design: .rounded))
-                    .foregroundColor(OB.inkDim)
-                    .multilineTextAlignment(.center)
-                    .lineSpacing(5)
-                    .padding(.horizontal, 8)
-            }
-            .padding(.top, 28)
-            .padding(.horizontal, isIPad ? 60 : 30)
-            .frame(maxWidth: isIPad ? 600 : .infinity)
-            Spacer()
-            Spacer()
-        }
-    }
-}
-
-// MARK: - Ready to record (personalised)
-
-private struct ReadyStep: View {
-    let name: String
-    let isIPad: Bool
-    @State private var pop = false
-
-    var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            ZStack {
-                Circle().fill(OB.sage.opacity(0.12)).frame(width: 128, height: 128)
-                Circle().fill(OB.sage).frame(width: 76, height: 76)
-                    .shadow(color: OB.sage.opacity(0.4), radius: 16)
-                Image(systemName: "checkmark")
-                    .font(.system(size: 34, weight: .bold))
-                    .foregroundColor(.white)
-            }
-            .scaleEffect(pop ? 1.0 : 0.6)
-            .opacity(pop ? 1 : 0)
-
-            VStack(spacing: 14) {
-                Text(name.isEmpty ? "Ready to be heard" : "Ready when you are,\n\(name).")
-                    .font(.system(size: isIPad ? 36 : 30, weight: .bold, design: .rounded))
-                    .foregroundColor(OB.ink)
-                    .multilineTextAlignment(.center)
-                Text("Your inner sky is ready. Speak your first star — 42 seconds is all it takes.")
-                    .font(.system(size: 15, weight: .regular, design: .rounded))
-                    .foregroundColor(OB.inkDim)
-                    .multilineTextAlignment(.center)
-                    .lineSpacing(5)
-                    .padding(.horizontal, 12)
-            }
-            .padding(.top, 28)
-            .padding(.horizontal, isIPad ? 60 : 30)
-
-            Spacer()
-            Spacer()
-        }
-        .onAppear {
-            withAnimation(.spring(response: 0.5, dampingFraction: 0.6).delay(0.1)) { pop = true }
-        }
-    }
-}
-
-// MARK: - Shared icon badge
-
-private struct IconBadge: View {
-    let symbol: String
-    let tint: Color
-    @State private var appear = false
-
-    var body: some View {
-        ZStack {
-            Circle().fill(tint.opacity(0.12)).frame(width: 104, height: 104)
-            Circle().fill(tint.opacity(0.20)).frame(width: 74, height: 74)
-            Image(systemName: symbol)
-                .font(.system(size: 30, weight: .semibold))
-                .foregroundColor(tint)
-        }
-        .scaleEffect(appear ? 1.0 : 0.6)
-        .opacity(appear ? 1 : 0)
-        .onAppear { withAnimation(.spring(response: 0.5, dampingFraction: 0.65)) { appear = true } }
-    }
-}
-
-// MARK: - Intention Check-In ("Name your planets")
-
-struct IntentionCheckInView: View {
-    @Binding var selectedIntentions: Set<String>
-    var isIPad: Bool
-
-    private let intentions: [(title: String, icon: String, planet: String)] = [
-        ("Track my thoughts", "brain.head.profile", "Mercury"),
-        ("Understand my emotions", "heart.text.square", "Venus"),
-        ("Build a daily habit", "calendar.badge.clock", "Mars"),
-        ("Remember my life", "book.pages", "Jupiter"),
-        ("Create my Digital Twin", "person.crop.circle.badge.plus", "Saturn")
-    ]
-
-    var body: some View {
-        VStack(spacing: isIPad ? 28 : 22) {
             Spacer()
 
             VStack(spacing: 10) {
-                Text("Name your planets")
-                    .font(.system(size: isIPad ? 38 : 30, weight: .bold, design: .rounded))
+                Text(headline)
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
                     .foregroundColor(OB.ink)
                     .multilineTextAlignment(.center)
-                Text("Each intention becomes a planet in your sky. Pick the ones that matter.")
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(subhead)
                     .font(.system(size: 15, weight: .regular, design: .rounded))
                     .foregroundColor(OB.inkDim)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 20)
             }
-            .padding(.horizontal, isIPad ? 80 : 28)
+            .padding(.horizontal, 32)
 
+            Spacer().frame(height: 40)
+
+            ZStack {
+                Circle()
+                    .fill(RadialGradient(colors: [OB.gold.opacity(0.16), .clear],
+                                         center: .center, startRadius: 6, endRadius: 130))
+                    .frame(width: 260, height: 260)
+
+                if phase == .born {
+                    BornStar(flare: flare)
+                } else {
+                    WaveOrb(level: level, active: phase == .recording)
+                }
+            }
+            .frame(height: 260)
+
+            Spacer().frame(height: 36)
+
+            control
+                .frame(height: 96)
+
+            Spacer()
+        }
+        .onReceive(recorder.$level) { l in
+            withAnimation(.easeOut(duration: 0.08)) { level = CGFloat(l) }
+        }
+        .onReceive(recorder.$currentTime) { t in
+            elapsed = t
+            if t >= softTarget { finish() }
+        }
+        .onAppear(perform: autoDemo)
+    }
+
+    private var headline: String {
+        switch phase {
+        case .born: return "A star is born."
+        case .processing: return "Finding your words…"
+        default: return "Say one true thing\nabout today."
+        }
+    }
+    private var subhead: String {
+        switch phase {
+        case .idle: return "Out loud. Anything. It stays on your phone."
+        case .recording: return "Listening… speak as long as you like."
+        case .processing: return "On-device. Nothing left your phone."
+        case .born: return "Your voice, now a light in your sky."
+        }
+    }
+
+    @ViewBuilder private var control: some View {
+        switch phase {
+        case .idle:
             VStack(spacing: 12) {
-                ForEach(intentions, id: \.title) { intention in
-                    IntentionCard(
-                        title: intention.title,
-                        icon: intention.icon,
-                        planet: intention.planet,
-                        isSelected: selectedIntentions.contains(intention.title),
-                        isIPad: isIPad
-                    ) {
-                        if selectedIntentions.contains(intention.title) {
-                            selectedIntentions.remove(intention.title)
-                        } else {
-                            selectedIntentions.insert(intention.title)
-                        }
+                Button(action: start) {
+                    ZStack {
+                        Circle().fill(LinearGradient(colors: [OB.sage, OB.sage.opacity(0.85)],
+                                                     startPoint: .top, endPoint: .bottom))
+                            .frame(width: 76, height: 76)
+                            .shadow(color: OB.sage.opacity(0.35), radius: 14, y: 6)
+                        Image(systemName: "mic.fill").font(.system(size: 28, weight: .semibold))
+                            .foregroundColor(.white)
                     }
                 }
+                Text("Tap to speak").font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundColor(OB.inkMute)
             }
-            .padding(.horizontal, isIPad ? 80 : 28)
-            .frame(maxWidth: isIPad ? 600 : .infinity)
+        case .recording:
+            Button(action: finish) {
+                HStack(spacing: 8) {
+                    Circle().fill(OB.forest).frame(width: 8, height: 8)
+                    Text("Done · \(Int(elapsed))s")
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                }
+                .foregroundColor(.white)
+                .padding(.vertical, 15).padding(.horizontal, 34)
+                .background(Capsule().fill(OB.ink))
+            }
+        case .processing:
+            HStack(spacing: 10) {
+                ProgressView().tint(OB.sage)
+                Text("finding your words…").font(.system(size: 14, design: .rounded))
+                    .foregroundColor(OB.inkMute)
+            }
+        case .born:
+            Color.clear
+        }
+    }
 
-            Spacer()
-            Spacer()
+    // MARK: Actions
+
+    private func start() {
+        withAnimation(.easeInOut(duration: 0.3)) { phase = .recording }
+        guard !demo else { return }
+        do { try recorder.startRecording() } catch { finish() }
+    }
+
+    private func finish() {
+        guard phase == .recording else { return }
+        if demo {
+            transcript = "Today felt lighter than yesterday. I paused for a minute and just breathed."
+            born(); return
+        }
+        withAnimation(.easeInOut(duration: 0.3)) { phase = .processing }
+        guard let res = recorder.stopRecording() else { transcript = ""; born(); return }
+        SpeechTranscriber.shared.transcribe(from: res.url) { result in
+            DispatchQueue.main.async {
+                if case .success(let t) = result { transcript = t }
+                born()
+            }
+        }
+    }
+
+    private func born() {
+        withAnimation(.spring(response: 0.6, dampingFraction: 0.58)) { phase = .born }
+        withAnimation(.easeOut(duration: 0.8)) { flare = 1 }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.1) { onBorn(transcript) }
+    }
+
+    private func autoDemo() {
+        guard demo else { return }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_300_000_000)
+            withAnimation(.easeInOut(duration: 0.3)) { phase = .recording }
+            let began = Date()
+            while phase == .recording && Date().timeIntervalSince(began) < 5.2 {
+                let e = Date().timeIntervalSince(began)
+                let env = 0.55 + 0.45 * sin(e * 2.1)
+                level = CGFloat(max(0.06, abs(sin(e * 7.5)) * env))
+                elapsed = e
+                try? await Task.sleep(nanoseconds: 45_000_000)
+            }
+            finish()
         }
     }
 }
 
-struct IntentionCard: View {
-    let title: String
-    let icon: String
-    let planet: String
-    let isSelected: Bool
-    var isIPad: Bool
-    let onTap: () -> Void
+// MARK: - Live waveform orb (bars radiating; amplitude follows the mic level)
+
+private struct WaveOrb: View {
+    let level: CGFloat
+    let active: Bool
+    private let bars = 40
 
     var body: some View {
-        Button(action: onTap) {
-            HStack(spacing: 14) {
-                Image(systemName: icon)
-                    .font(.system(size: isIPad ? 22 : 19))
-                    .foregroundColor(isSelected ? OB.sage : OB.inkMute)
-                    .frame(width: 30)
+        SwiftUI.TimelineView(.animation) { tl in
+            let t: Double = tl.date.timeIntervalSinceReferenceDate
+            ZStack {
+                Circle()
+                    .fill(OB.card)
+                    .frame(width: 96, height: 96)
+                    .shadow(color: OB.ink.opacity(0.05), radius: 8, y: 3)
+                Circle()
+                    .fill(OB.gold.opacity(0.9))
+                    .frame(width: 14, height: 14)
+                    .scaleEffect(1 + (active ? level * 0.8 : 0))
 
-                Text(title)
-                    .font(.system(size: isIPad ? 18 : 16, weight: .medium, design: .rounded))
-                    .foregroundColor(isSelected ? OB.ink : OB.inkDim)
-
-                Spacer()
-
-                Text(planet.uppercased())
-                    .font(.system(size: 9, weight: .bold, design: .rounded))
-                    .tracking(1.5)
-                    .foregroundColor(isSelected ? OB.gold : OB.inkMute.opacity(0.6))
-
-                if isSelected {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 20))
-                        .foregroundColor(OB.forest)
+                ForEach(0..<bars, id: \.self) { i in
+                    bar(i: i, t: t)
                 }
             }
-            .padding(.horizontal, 18)
-            .padding(.vertical, 15)
-            .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(isSelected ? OB.sage.opacity(0.10) : OB.card)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(isSelected ? OB.sage.opacity(0.7) : OB.rule, lineWidth: isSelected ? 1.5 : 1)
-            )
-            .shadow(color: OB.ink.opacity(isSelected ? 0 : 0.03), radius: 5, y: 2)
         }
-        .buttonStyle(.plain)
-        .animation(.easeInOut(duration: 0.2), value: isSelected)
+    }
+
+    private func bar(i: Int, t: Double) -> some View {
+        let angle: Double = Double(i) / Double(bars) * 360.0
+        let wobble: Double = 0.5 + 0.5 * sin(t * 3.0 + Double(i) * 0.7)
+        let amp: CGFloat = active ? level * CGFloat(wobble) : 0.04
+        let h: CGFloat = 10 + amp * 64
+        return Capsule()
+            .fill(LinearGradient(colors: [OB.gold, OB.sage], startPoint: .top, endPoint: .bottom))
+            .frame(width: 3.2, height: h)
+            .offset(y: -70)
+            .rotationEffect(.degrees(angle))
+            .opacity(active ? 0.9 : 0.35)
     }
 }
 
-// MARK: - Ivory constellation field (soft sage/gold dots on light)
+// MARK: - The born star (flare + rays)
 
-private struct IvorySky: View {
+private struct BornStar: View {
+    let flare: CGFloat
+
     var body: some View {
-        Canvas { context, size in
-            for i in 0..<44 {
-                let seed = UInt64(i) &* 6364136223846793005 &+ 1442695040888963407
-                let x = Double((seed >> 16) % 10000) / 10000.0 * size.width
-                let y = Double((seed >> 32) % 10000) / 10000.0 * size.height
-                let r = Double((seed >> 48) % 100) / 100.0 * 1.6 + 0.4
-                let useGold = (seed >> 4) % 5 == 0
-                let opacity = Double((seed >> 8) % 100) / 100.0 * 0.14 + 0.05
-                let dot = Path(ellipseIn: CGRect(x: x - r, y: y - r, width: r * 2, height: r * 2))
-                context.fill(dot, with: .color((useGold ? OB.gold : OB.sage).opacity(opacity)))
+        ZStack {
+            Circle().fill(OB.gold.opacity(0.18 * Double(flare))).frame(width: 200, height: 200)
+                .scaleEffect(0.6 + flare * 0.6)
+            ForEach(0..<8, id: \.self) { i in
+                Capsule()
+                    .fill(OB.gold.opacity(0.5 * Double(flare)))
+                    .frame(width: 2, height: 60)
+                    .offset(y: -46)
+                    .rotationEffect(.degrees(Double(i) / 8 * 360))
+                    .scaleEffect(y: flare)
+            }
+            Circle().fill(OB.gold).frame(width: 26, height: 26)
+                .shadow(color: OB.gold.opacity(0.7), radius: 16)
+                .scaleEffect(0.4 + flare * 0.9)
+            Circle().fill(.white).frame(width: 10, height: 10)
+                .scaleEffect(flare)
+        }
+    }
+}
+
+// MARK: - Beat 3: Claim
+
+private struct ClaimScreen: View {
+    let transcript: String
+    let onEnter: () -> Void
+    @State private var appear = false
+
+    private var words: String {
+        let t = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        return t.isEmpty ? "your first words" : t
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            ZStack {
+                Circle().fill(OB.gold.opacity(0.14)).frame(width: 120, height: 120)
+                Circle().fill(OB.gold).frame(width: 24, height: 24)
+                    .shadow(color: OB.gold.opacity(0.6), radius: 14)
+                Circle().fill(.white).frame(width: 8, height: 8)
+            }
+            .scaleEffect(appear ? 1 : 0.6).opacity(appear ? 1 : 0)
+
+            VStack(spacing: 16) {
+                Text("That star is yours.")
+                    .font(.system(size: 32, weight: .bold, design: .rounded))
+                    .foregroundColor(OB.ink)
+                    .multilineTextAlignment(.center)
+
+                Text("“\(words)”")
+                    .font(.system(size: 16, weight: .medium, design: .rounded))
+                    .italic()
+                    .foregroundColor(OB.inkDim)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(4)
+                    .padding(.horizontal, 22)
+                    .padding(.vertical, 16)
+                    .frame(maxWidth: .infinity)
+                    .background(RoundedRectangle(cornerRadius: 16, style: .continuous).fill(OB.card))
+                    .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous).stroke(OB.rule, lineWidth: 1))
+                    .padding(.horizontal, 26)
+
+                Text("It lives on your phone — nowhere else.\nSpeak again tomorrow, and your sky grows.")
+                    .font(.system(size: 15, weight: .regular, design: .rounded))
+                    .foregroundColor(OB.inkDim)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(4)
+            }
+            .padding(.top, 28)
+            .padding(.horizontal, 24)
+            .opacity(appear ? 1 : 0)
+            .offset(y: appear ? 0 : 16)
+
+            Spacer()
+            Spacer()
+
+            PrimaryButton(title: "Enter my sky", filled: true, action: onEnter)
+                .padding(.horizontal, 28)
+                .padding(.bottom, 44)
+        }
+        .onAppear { withAnimation(.spring(response: 0.6, dampingFraction: 0.7).delay(0.15)) { appear = true } }
+    }
+}
+
+// MARK: - Primary button
+
+private struct PrimaryButton: View {
+    let title: String
+    var filled: Bool = true
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 17, weight: .semibold, design: .rounded))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 17)
+                .background(LinearGradient(colors: [OB.sage, OB.sage.opacity(0.85)],
+                                           startPoint: .leading, endPoint: .trailing))
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .shadow(color: OB.sage.opacity(0.28), radius: 12, y: 6)
+        }
+    }
+}
+
+// MARK: - Living sky
+
+private struct LivingSky: View {
+    let bright: Int   // number of hero stars lit (after the first is born)
+
+    var body: some View {
+        SwiftUI.TimelineView(.animation) { tl in
+            Canvas { ctx, size in
+                let t: Double = tl.date.timeIntervalSinceReferenceDate
+                let w: Double = size.width
+                let h: Double = size.height
+                for i in 0..<64 {
+                    let seed: UInt64 = UInt64(i) &* 6364136223846793005 &+ 1442695040888963407
+                    let x: Double = Double((seed >> 16) % 10000) / 10000.0 * w
+                    let y: Double = Double((seed >> 32) % 10000) / 10000.0 * h
+                    let r: Double = Double((seed >> 48) % 100) / 100.0 * 1.5 + 0.4
+                    let phase: Double = Double((seed >> 8) % 628) / 100.0
+                    let tw: Double = 0.55 + 0.45 * sin(t * 1.1 + phase)
+                    let isGold: Bool = (seed >> 4) % 6 == 0
+                    let base: Double = Double((seed >> 12) % 100) / 100.0 * 0.10 + 0.04
+                    let rect = CGRect(x: x - r, y: y - r, width: r * 2, height: r * 2)
+                    let col: Color = (isGold ? OB.gold : OB.sage).opacity(base * tw)
+                    ctx.fill(Path(ellipseIn: rect), with: .color(col))
+                }
             }
         }
         .ignoresSafeArea()
@@ -537,21 +482,16 @@ private struct IvorySky: View {
 
 struct PrivacyBadge: View {
     var compact: Bool = false
-
     var body: some View {
         HStack(spacing: 6) {
             Image(systemName: "lock.shield.fill")
                 .font(compact ? .caption : .subheadline)
                 .foregroundColor(Color(red: 0.420, green: 0.620, blue: 0.482))
-
             if !compact {
-                Text("100% Private")
-                    .font(.caption.weight(.medium))
-                    .foregroundColor(.secondary)
+                Text("100% Private").font(.caption.weight(.medium)).foregroundColor(.secondary)
             }
         }
-        .padding(.horizontal, compact ? 8 : 12)
-        .padding(.vertical, compact ? 4 : 6)
+        .padding(.horizontal, compact ? 8 : 12).padding(.vertical, compact ? 4 : 6)
         .background(Color(red: 0.420, green: 0.620, blue: 0.482).opacity(0.1))
         .clipShape(Capsule())
     }
@@ -560,24 +500,16 @@ struct PrivacyBadge: View {
 struct OfflineIndicator: View {
     var body: some View {
         HStack(spacing: 4) {
-            Circle()
-                .fill(Color(red: 0.420, green: 0.620, blue: 0.482))
-                .frame(width: 6, height: 6)
-            Text("Offline")
-                .font(.caption2.weight(.medium))
-                .foregroundColor(.secondary)
+            Circle().fill(Color(red: 0.420, green: 0.620, blue: 0.482)).frame(width: 6, height: 6)
+            Text("Offline").font(.caption2.weight(.medium)).foregroundColor(.secondary)
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(Color(.tertiarySystemBackground))
-        .clipShape(Capsule())
+        .padding(.horizontal, 8).padding(.vertical, 4)
+        .background(Color(.tertiarySystemBackground)).clipShape(Capsule())
     }
 }
 
-/// Ambient star field used by empty states / recording screens (white on dark).
 struct StarFieldView: View {
     let count: Int
-
     var body: some View {
         Canvas { context, size in
             for i in 0..<count {
@@ -586,7 +518,6 @@ struct StarFieldView: View {
                 let y = Double((seed >> 32) % 10000) / 10000.0 * size.height
                 let r = Double((seed >> 48) % 100) / 100.0 * 1.5 + 0.3
                 let opacity = Double((seed >> 8) % 100) / 100.0 * 0.4 + 0.1
-
                 let star = Path(ellipseIn: CGRect(x: x - r, y: y - r, width: r * 2, height: r * 2))
                 context.fill(star, with: .color(Color.white.opacity(opacity)))
             }

--- a/solyn/solyn/OnboardingView.swift
+++ b/solyn/solyn/OnboardingView.swift
@@ -165,11 +165,7 @@ private struct SpeakScreen: View {
                                          center: .center, startRadius: 6, endRadius: 130))
                     .frame(width: 260, height: 260)
 
-                if phase == .born {
-                    BornStar(flare: flare)
-                } else {
-                    WaveOrb(level: level, active: phase == .recording)
-                }
+                VoiceStar(level: level, active: phase == .recording, born: flare)
             }
             .frame(height: 260)
 
@@ -270,8 +266,9 @@ private struct SpeakScreen: View {
     }
 
     private func born() {
-        withAnimation(.spring(response: 0.6, dampingFraction: 0.58)) { phase = .born }
-        withAnimation(.easeOut(duration: 0.8)) { flare = 1 }
+        withAnimation(.easeInOut(duration: 0.25)) { phase = .born }
+        // Springy overshoot = the waveform collapses and the star pops into being.
+        withAnimation(.spring(response: 0.7, dampingFraction: 0.52).delay(0.05)) { flare = 1 }
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.1) { onBorn(transcript) }
     }
 
@@ -293,29 +290,59 @@ private struct SpeakScreen: View {
     }
 }
 
-// MARK: - Live waveform orb (bars radiating; amplitude follows the mic level)
+// MARK: - Voice star (waveform that collapses & coalesces into a star)
 
-private struct WaveOrb: View {
+private struct VoiceStar: View {
     let level: CGFloat
     let active: Bool
+    let born: CGFloat   // 0 = live waveform, 1 = ignited star
     private let bars = 40
 
     var body: some View {
         SwiftUI.TimelineView(.animation) { tl in
             let t: Double = tl.date.timeIntervalSinceReferenceDate
+            let b: Double = Double(born)
             ZStack {
+                // Ignition shockwave — expands and fades as the star is born
+                Circle()
+                    .fill(OB.gold.opacity(0.35 * (1 - b)))
+                    .frame(width: 60, height: 60)
+                    .scaleEffect(0.4 + born * 3.4)
+                    .opacity(b > 0.001 ? 1 : 0)
+
+                // Soft recording disc (dissolves into the star)
                 Circle()
                     .fill(OB.card)
                     .frame(width: 96, height: 96)
-                    .shadow(color: OB.ink.opacity(0.05), radius: 8, y: 3)
-                Circle()
-                    .fill(OB.gold.opacity(0.9))
-                    .frame(width: 14, height: 14)
-                    .scaleEffect(1 + (active ? level * 0.8 : 0))
+                    .shadow(color: OB.ink.opacity(0.05 * (1 - b)), radius: 8, y: 3)
+                    .opacity(1 - b)
+                    .scaleEffect(1 - born * 0.45)
 
+                // Collapsing waveform bars
                 ForEach(0..<bars, id: \.self) { i in
                     bar(i: i, t: t)
                 }
+
+                // Flare rays (extend as it ignites)
+                ForEach(0..<8, id: \.self) { i in
+                    Capsule()
+                        .fill(OB.gold.opacity(0.55 * b))
+                        .frame(width: 2.4, height: 66)
+                        .offset(y: -44)
+                        .scaleEffect(x: 1, y: born, anchor: .bottom)
+                        .rotationEffect(.degrees(Double(i) / 8.0 * 360.0))
+                }
+
+                // Star core (glows into being; also the live recording pulse)
+                Circle()
+                    .fill(OB.gold)
+                    .frame(width: 16, height: 16)
+                    .scaleEffect(1 + (active ? level * 0.7 : 0) + born * 0.9)
+                    .shadow(color: OB.gold.opacity(0.7 * b), radius: 18 * born)
+                Circle()
+                    .fill(.white)
+                    .frame(width: 7, height: 7)
+                    .scaleEffect(0.6 + born * 1.1 + (active ? level * 0.4 : 0))
             }
         }
     }
@@ -324,39 +351,16 @@ private struct WaveOrb: View {
         let angle: Double = Double(i) / Double(bars) * 360.0
         let wobble: Double = 0.5 + 0.5 * sin(t * 3.0 + Double(i) * 0.7)
         let amp: CGFloat = active ? level * CGFloat(wobble) : 0.04
-        let h: CGFloat = 10 + amp * 64
+        let baseH: CGFloat = 10 + amp * 64
+        let h: CGFloat = max(0.5, baseH * (1 - born))     // shrink as they collapse
+        let outward: CGFloat = 70 * (1 - born)            // pull inward on birth
+        let op: Double = (active ? 0.9 : 0.35) * Double(1 - born)
         return Capsule()
             .fill(LinearGradient(colors: [OB.gold, OB.sage], startPoint: .top, endPoint: .bottom))
             .frame(width: 3.2, height: h)
-            .offset(y: -70)
+            .offset(y: -outward)
             .rotationEffect(.degrees(angle))
-            .opacity(active ? 0.9 : 0.35)
-    }
-}
-
-// MARK: - The born star (flare + rays)
-
-private struct BornStar: View {
-    let flare: CGFloat
-
-    var body: some View {
-        ZStack {
-            Circle().fill(OB.gold.opacity(0.18 * Double(flare))).frame(width: 200, height: 200)
-                .scaleEffect(0.6 + flare * 0.6)
-            ForEach(0..<8, id: \.self) { i in
-                Capsule()
-                    .fill(OB.gold.opacity(0.5 * Double(flare)))
-                    .frame(width: 2, height: 60)
-                    .offset(y: -46)
-                    .rotationEffect(.degrees(Double(i) / 8 * 360))
-                    .scaleEffect(y: flare)
-            }
-            Circle().fill(OB.gold).frame(width: 26, height: 26)
-                .shadow(color: OB.gold.opacity(0.7), radius: 16)
-                .scaleEffect(0.4 + flare * 0.9)
-            Circle().fill(.white).frame(width: 10, height: 10)
-                .scaleEffect(flare)
-        }
+            .opacity(op)
     }
 }
 
@@ -470,6 +474,17 @@ private struct LivingSky: View {
                     let rect = CGRect(x: x - r, y: y - r, width: r * 2, height: r * 2)
                     let col: Color = (isGold ? OB.gold : OB.sage).opacity(base * tw)
                     ctx.fill(Path(ellipseIn: rect), with: .color(col))
+                }
+
+                // The sky gains your star once it's born
+                if bright > 0 {
+                    let hx: Double = w * 0.5
+                    let hy: Double = h * 0.26
+                    let pulse: Double = 0.7 + 0.3 * sin(t * 1.6)
+                    let halo = CGRect(x: hx - 10, y: hy - 10, width: 20, height: 20)
+                    ctx.fill(Path(ellipseIn: halo), with: .color(OB.gold.opacity(0.20 * pulse)))
+                    let core = CGRect(x: hx - 3, y: hy - 3, width: 6, height: 6)
+                    ctx.fill(Path(ellipseIn: core), with: .color(OB.gold.opacity(0.95)))
                 }
             }
         }

--- a/solyn/solyn/OnboardingView.swift
+++ b/solyn/solyn/OnboardingView.swift
@@ -2,653 +2,408 @@
 //  OnboardingView.swift
 //  solyn
 //
-//  Privacy-focused onboarding experience
+//  Warm, ivory-light onboarding — constellation / "inner sky" language.
+//  Flow: Welcome → Name yourself (optional) → Your Twin → Private →
+//  Name your planets → Ready to record.
 //
 
 import SwiftUI
 
+// MARK: - Palette (warm ivory, matches the app theme)
+
+private enum OB {
+    static let paper   = Color(red: 0.980, green: 0.972, blue: 0.961)  // #FAF8F5
+    static let paper2  = Color(red: 0.949, green: 0.929, blue: 0.910)  // warm dusk paper
+    static let card    = Color.white
+    static let ink     = Color(red: 0.102, green: 0.102, blue: 0.180)  // #1A1A2E
+    static let inkDim  = Color(red: 0.102, green: 0.102, blue: 0.180).opacity(0.62)
+    static let inkMute = Color(red: 0.102, green: 0.102, blue: 0.180).opacity(0.40)
+    static let rule    = Color(red: 0.102, green: 0.102, blue: 0.180).opacity(0.10)
+    static let gold    = Color(red: 0.831, green: 0.647, blue: 0.278)
+    static let sage    = Color(red: 0.357, green: 0.486, blue: 0.420)
+    static let forest  = Color(red: 0.420, green: 0.620, blue: 0.482)
+    static let coral   = Color(red: 0.769, green: 0.451, blue: 0.420)
+}
+
 struct OnboardingView: View {
     @Binding var hasCompletedOnboarding: Bool
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     @State private var currentPage = 0
+    @State private var userName = ""
     @State private var selectedIntentions: Set<String> = []
+    @FocusState private var nameFocused: Bool
 
     private var isIPad: Bool { horizontalSizeClass == .regular }
-    private var totalPageCount: Int { pages.count + 2 } // welcome + feature pages + intention
 
-    private let pages: [OnboardingPage] = [
-        OnboardingPage(
-            icon: "person.crop.circle.fill",
-            iconColor: Color(red: 0.831, green: 0.647, blue: 0.278),  // warm gold — the sun at the centre
-            title: "Meet Your Digital Twin",
-            subtitle: "The sun at the center of your sky",
-            description: "Your Digital Twin orbits your inner world — learning your personality, emotional patterns, and the people in your life. Four planets emerge: Mind, Heart, Voice, and Graph.",
-            gradient: [
-                Color(red: 38/255, green: 30/255, blue: 22/255),    // deep warm espresso
-                Color(red: 92/255, green: 68/255, blue: 38/255)     // warm amber-bronze
-            ]
-        ),
-        OnboardingPage(
-            icon: "chart.bar.fill",
-            iconColor: Color(red: 0.769, green: 0.584, blue: 0.416),
-            title: "Insights That Matter",
-            subtitle: "Patterns written in light",
-            description: "Like an aurora forming in your night sky, insights emerge from your journal entries. Mood trends, streaks, and emotional patterns — visible only when you look up.",
-            gradient: [
-                Color(red: 50/255, green: 38/255, blue: 30/255),    // Deep brown
-                Color(red: 120/255, green: 80/255, blue: 55/255)    // Warm amber
-            ]
-        ),
-        OnboardingPage(
-            icon: "lock.shield",
-            iconColor: Color(red: 0.420, green: 0.620, blue: 0.482),
-            title: "100% Private. Always.",
-            subtitle: "A constellation no one else can see",
-            description: "Your stars are protected by an unbreakable shield. All AI runs on your device. No servers. No accounts. No one watches your sky but you.",
-            gradient: [
-                Color(red: 25/255, green: 40/255, blue: 38/255),    // Deep teal-green
-                Color(red: 50/255, green: 80/255, blue: 70/255)     // Forest green
-            ]
-        )
-    ]
-
-    private var backgroundGradient: [Color] {
-        if currentPage == 0 {
-            // Warm night sky for the welcome star (matches the app's warm theme)
-            return [
-                Color(red: 26/255, green: 21/255, blue: 18/255),   // warm espresso night
-                Color(red: 42/255, green: 32/255, blue: 26/255)    // warm dusk
-            ]
-        } else if currentPage <= pages.count {
-            // Feature pages (1-based index, so subtract 1 for array)
-            return pages[currentPage - 1].gradient
-        } else {
-            // Intention check-in page — deep sage close (warm, on-brand)
-            return [
-                Color(red: 28/255, green: 38/255, blue: 32/255),    // deep sage night
-                Color(red: 56/255, green: 78/255, blue: 64/255)     // warm sage
-            ]
-        }
+    // Ordered steps
+    private enum Step: Int, CaseIterable {
+        case welcome, name, twin, privacy, intention, ready
     }
-
-    private var buttonGradientColors: [Color] {
-        if currentPage == 0 {
-            return [Color(red: 0.831, green: 0.647, blue: 0.278), Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.8)]
-        } else if currentPage <= pages.count {
-            let page = pages[currentPage - 1]
-            return [page.iconColor, page.iconColor.opacity(0.8)]
-        } else {
-            // Last page: sage green
-            return [Color(red: 0.357, green: 0.486, blue: 0.420), Color(red: 0.357, green: 0.486, blue: 0.420).opacity(0.8)]
-        }
-    }
-
-    private var buttonShadowColor: Color {
-        if currentPage == 0 {
-            return Color(red: 0.831, green: 0.647, blue: 0.278)
-        } else if currentPage <= pages.count {
-            return pages[currentPage - 1].iconColor
-        } else {
-            return Color(red: 0.357, green: 0.486, blue: 0.420)
-        }
-    }
+    private var totalSteps: Int { Step.allCases.count }
+    private var isLast: Bool { currentPage == totalSteps - 1 }
 
     var body: some View {
         ZStack {
-            // Background
+            // Warm ivory background
             LinearGradient(
-                colors: backgroundGradient,
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
+                colors: [OB.paper, OB.paper2],
+                startPoint: .top, endPoint: .bottom
             )
             .ignoresSafeArea()
-            .animation(.easeInOut(duration: 0.5), value: currentPage)
 
-            StarFieldView(count: 60)
+            IvorySky()
 
             VStack(spacing: 0) {
-                // Skip button
+                // Top bar — Skip (hidden on the final page)
                 HStack {
                     Spacer()
-                    if currentPage < totalPageCount - 1 {
+                    if !isLast {
                         Button("Skip") {
-                            withAnimation {
-                                currentPage = totalPageCount - 1
+                            nameFocused = false
+                            withAnimation(.spring(response: 0.4)) {
+                                currentPage = totalSteps - 1
                             }
                         }
-                        .font(.subheadline.weight(.medium))
-                        .foregroundColor(.white.opacity(0.6))
+                        .font(.system(size: 15, weight: .medium, design: .rounded))
+                        .foregroundColor(OB.inkMute)
                         .padding()
                     }
                 }
 
-                // Page content
+                // Pages
                 TabView(selection: $currentPage) {
-                    // Page 0: Welcome star moment
-                    OnboardingWelcomeView()
-                        .tag(0)
-
-                    // Pages 1-3: Feature pages
-                    ForEach(0..<pages.count, id: \.self) { index in
-                        OnboardingPageView(page: pages[index])
-                            .tag(index + 1)
-                    }
-
-                    // Last page: Intention check-in
+                    WelcomeStep(isIPad: isIPad).tag(Step.welcome.rawValue)
+                    NameStep(userName: $userName, focused: $nameFocused, isIPad: isIPad)
+                        .tag(Step.name.rawValue)
+                    MessageStep(
+                        symbol: "mic.fill", tint: OB.gold,
+                        title: "Your voice builds a\nDigital Twin",
+                        message: "Speak about 42 seconds a day. Your Twin learns your personality, moods, and the people in your life — all on your phone.",
+                        isIPad: isIPad
+                    ).tag(Step.twin.rawValue)
+                    MessageStep(
+                        symbol: "lock.shield.fill", tint: OB.sage,
+                        title: "A sky no one else\ncan see",
+                        message: "Everything runs on your device. No account, no cloud, no one watching. Apple's privacy label: Data Not Collected.",
+                        isIPad: isIPad
+                    ).tag(Step.privacy.rawValue)
                     IntentionCheckInView(selectedIntentions: $selectedIntentions, isIPad: isIPad)
-                        .tag(pages.count + 1)
+                        .tag(Step.intention.rawValue)
+                    ReadyStep(name: trimmedName, isIPad: isIPad).tag(Step.ready.rawValue)
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
+                .animation(.spring(response: 0.4), value: currentPage)
 
-                // Constellation-themed progress indicator
+                // Constellation progress dots
                 HStack(spacing: 12) {
-                    ForEach(0..<totalPageCount, id: \.self) { index in
+                    ForEach(0..<totalSteps, id: \.self) { index in
                         Image(systemName: index <= currentPage ? "star.fill" : "star")
                             .font(.system(size: index == currentPage ? 10 : 8))
-                            .foregroundColor(index <= currentPage ? Color(red: 0.831, green: 0.647, blue: 0.278) : .white.opacity(0.25))
+                            .foregroundColor(index <= currentPage ? OB.gold : OB.inkMute.opacity(0.5))
                             .animation(.spring(response: 0.3), value: currentPage)
                     }
                 }
-                .padding(.bottom, 30)
+                .padding(.bottom, 24)
 
-                // Action button
-                Button(action: {
-                    if currentPage < totalPageCount - 1 {
-                        withAnimation(.spring(response: 0.4)) {
-                            currentPage += 1
+                // Primary action
+                Button(action: advance) {
+                    HStack(spacing: 8) {
+                        if isLast {
+                            Image(systemName: "mic.fill").font(.system(size: 16, weight: .semibold))
                         }
-                    } else {
-                        completeOnboarding()
-                    }
-                }) {
-                    HStack {
-                        Text(currentPage == totalPageCount - 1 ? "Begin my journey" : "Next")
-                            .font(.headline)
-                        if currentPage == totalPageCount - 1 {
-                            Image(systemName: "sparkles")
-                                .font(.headline)
+                        Text(primaryTitle)
+                            .font(.system(size: 17, weight: .semibold, design: .rounded))
+                        if !isLast {
+                            Image(systemName: "arrow.right").font(.system(size: 15, weight: .semibold))
                         }
                     }
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 18)
+                    .padding(.vertical, 17)
                     .background(
-                        LinearGradient(
-                            colors: buttonGradientColors,
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
+                        LinearGradient(colors: [OB.sage, OB.sage.opacity(0.85)],
+                                       startPoint: .leading, endPoint: .trailing)
                     )
-                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-                    .shadow(color: buttonShadowColor.opacity(0.3), radius: 10, y: 5)
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .shadow(color: OB.sage.opacity(0.28), radius: 12, y: 6)
                 }
                 .frame(maxWidth: isIPad ? 500 : .infinity)
-                .padding(.horizontal, isIPad ? 60 : 30)
-                .padding(.bottom, 50)
+                .padding(.horizontal, isIPad ? 60 : 28)
+                .padding(.bottom, 44)
             }
         }
     }
 
+    private var trimmedName: String {
+        userName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var primaryTitle: String {
+        switch Step(rawValue: currentPage) {
+        case .name: return trimmedName.isEmpty ? "Skip for now" : "Continue"
+        case .ready: return "Record my first star"
+        default: return "Next"
+        }
+    }
+
+    private func advance() {
+        nameFocused = false
+        if isLast {
+            completeOnboarding()
+        } else {
+            withAnimation(.spring(response: 0.4)) { currentPage += 1 }
+        }
+    }
+
     private func completeOnboarding() {
+        if !trimmedName.isEmpty {
+            UserDefaults.standard.set(trimmedName, forKey: "userName")
+        }
         UserDefaults.standard.set(Array(selectedIntentions), forKey: "onboardingIntentions")
+        UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
         withAnimation(.easeInOut(duration: 0.3)) {
             hasCompletedOnboarding = true
         }
-        UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
     }
 }
 
-// MARK: - Welcome Star Moment
+// MARK: - Welcome (breathing gold star on ivory)
 
-struct OnboardingWelcomeView: View {
+private struct WelcomeStep: View {
+    let isIPad: Bool
     @State private var starScale: CGFloat = 0.3
-    @State private var glowOpacity: Double = 0
+    @State private var glow: Double = 0
     @State private var textOpacity: Double = 0
-    @State private var breathe = false   // continuous glow pulse
-    @State private var drift = false     // slow ambient-star rotation
+    @State private var breathe = false
+    @State private var drift = false
 
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
 
-            // Constellation star animation
             ZStack {
-                // Outer glow — gently breathing
                 Circle()
-                    .fill(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(glowOpacity * 0.15))
+                    .fill(OB.gold.opacity(glow * 0.18))
                     .frame(width: 200, height: 200)
                     .scaleEffect(breathe ? 1.12 : 0.94)
-
                 Circle()
-                    .fill(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(glowOpacity * 0.25))
-                    .frame(width: 120, height: 120)
+                    .fill(OB.gold.opacity(glow * 0.28))
+                    .frame(width: 118, height: 118)
                     .scaleEffect(breathe ? 1.08 : 0.96)
-
-                // Core star
                 Circle()
-                    .fill(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.8))
-                    .frame(width: 20, height: 20)
+                    .fill(OB.gold)
+                    .frame(width: 22, height: 22)
                     .scaleEffect(starScale * (breathe ? 1.08 : 1.0))
-                    .shadow(color: Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.6), radius: 20)
-
-                // White hot center
+                    .shadow(color: OB.gold.opacity(0.6), radius: 18)
                 Circle()
-                    .fill(Color(red: 0.957, green: 0.933, blue: 0.878))
-                    .frame(width: 8, height: 8)
+                    .fill(Color.white)
+                    .frame(width: 7, height: 7)
                     .scaleEffect(starScale)
 
-                // Ambient stars around core — slowly drifting as a ring
-                ZStack {
-                    ForEach(0..<8, id: \.self) { i in
-                        let angle = Double(i) * (.pi * 2 / 8)
-                        let radius: CGFloat = 85 + CGFloat(i % 3) * 20
-                        Circle()
-                            .fill(Color.white.opacity(glowOpacity * (0.15 + Double(i % 3) * 0.1)))
-                            .frame(width: CGFloat(2 + i % 3), height: CGFloat(2 + i % 3))
-                            .offset(
-                                x: cos(angle) * radius,
-                                y: sin(angle) * radius
-                            )
-                    }
+                // Ambient drifting stars
+                ForEach(0..<8, id: \.self) { i in
+                    let angle = Double(i) * (.pi * 2 / 8)
+                    let radius: CGFloat = 85 + CGFloat(i % 3) * 20
+                    Circle()
+                        .fill(OB.sage.opacity(glow * (0.30 + Double(i % 3) * 0.10)))
+                        .frame(width: CGFloat(3 + i % 2), height: CGFloat(3 + i % 2))
+                        .offset(x: cos(angle) * radius, y: sin(angle) * radius)
                 }
                 .rotationEffect(.degrees(drift ? 360 : 0))
                 .animation(.linear(duration: 90).repeatForever(autoreverses: false), value: drift)
             }
 
-            Spacer()
-                .frame(height: 60)
+            Spacer().frame(height: 56)
 
-            VStack(spacing: 16) {
+            VStack(spacing: 14) {
                 Text("Your inner sky\nis waiting")
-                    .font(.system(size: 38, weight: .bold, design: .rounded))
+                    .font(.system(size: isIPad ? 44 : 38, weight: .bold, design: .rounded))
                     .tracking(-0.6)
-                    .lineSpacing(2)
-                    .foregroundColor(.white)
+                    .foregroundColor(OB.ink)
                     .multilineTextAlignment(.center)
-                    .opacity(textOpacity)
-
                 Text("Every thought you speak becomes a star.\nOver time, constellations form — patterns\nonly you can see.")
                     .font(.system(size: 16, weight: .regular, design: .rounded))
-                    .foregroundColor(.white.opacity(0.65))
+                    .foregroundColor(OB.inkDim)
                     .multilineTextAlignment(.center)
                     .lineSpacing(5)
-                    .opacity(textOpacity)
             }
             .padding(.horizontal, 30)
+            .opacity(textOpacity)
 
             Spacer()
             Spacer()
         }
         .onAppear {
-            withAnimation(.easeOut(duration: 1.5)) {
-                starScale = 1.0
-                glowOpacity = 1.0
-            }
-            withAnimation(.easeOut(duration: 1.0).delay(0.8)) {
-                textOpacity = 1.0
-            }
-            // Ongoing living motion (so the welcome screen isn't static like before)
-            withAnimation(.easeInOut(duration: 3.2).repeatForever(autoreverses: true).delay(0.6)) {
-                breathe = true
-            }
+            withAnimation(.easeOut(duration: 1.4)) { starScale = 1.0; glow = 1.0 }
+            withAnimation(.easeOut(duration: 1.0).delay(0.7)) { textOpacity = 1.0 }
+            withAnimation(.easeInOut(duration: 3.2).repeatForever(autoreverses: true).delay(0.5)) { breathe = true }
             drift = true
         }
     }
 }
 
-struct OnboardingPage {
-    let icon: String
-    let iconColor: Color
-    let title: String
-    let subtitle: String
-    let description: String
-    let gradient: [Color]
-}
+// MARK: - Name yourself (optional, sage focus ring)
 
-struct OnboardingPageView: View {
-    let page: OnboardingPage
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @State private var animate1 = false
-    @State private var animate2 = false
-    @State private var animate3 = false
-    @State private var textOpacity: Double = 0
-
-    private var isIPad: Bool { horizontalSizeClass == .regular }
-
-    // Warm palette
-    private let warmGold = Color(red: 0.831, green: 0.647, blue: 0.278)
-    private let sageGreen = Color(red: 0.357, green: 0.486, blue: 0.420)
-    private let softCoral = Color(red: 0.769, green: 0.451, blue: 0.420)
-    private let forestGreen = Color(red: 0.420, green: 0.620, blue: 0.482)
-    private let ivory = Color(red: 0.957, green: 0.933, blue: 0.878)
+private struct NameStep: View {
+    @Binding var userName: String
+    var focused: FocusState<Bool>.Binding
+    let isIPad: Bool
 
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
 
-            // Each page gets a unique celestial visual
-            Group {
-                switch page.icon {
-                case "person.crop.circle.fill":
-                    twinPlanetSystem
-                case "chart.bar.fill":
-                    auroraInsights
-                case "lock.shield":
-                    shieldConstellation
-                default:
-                    twinPlanetSystem
-                }
+            IconBadge(symbol: "sparkle", tint: OB.gold)
+
+            VStack(spacing: 12) {
+                Text("Let's get to know you")
+                    .font(.system(size: isIPad ? 34 : 28, weight: .bold, design: .rounded))
+                    .foregroundColor(OB.ink)
+                    .multilineTextAlignment(.center)
+                Text("DailyVox becomes more yours with every word.")
+                    .font(.system(size: 15, weight: .regular, design: .rounded))
+                    .foregroundColor(OB.inkDim)
+                    .multilineTextAlignment(.center)
             }
-            .frame(height: isIPad ? 280 : 220)
-            .padding(.bottom, 24)
+            .padding(.top, 24)
+            .padding(.horizontal, 32)
 
-            // Text with staggered fade
+            TextField("Your name", text: $userName)
+                .font(.system(size: 17, weight: .medium, design: .rounded))
+                .foregroundColor(OB.ink)
+                .multilineTextAlignment(.center)
+                .textInputAutocapitalization(.words)
+                .submitLabel(.done)
+                .focused(focused)
+                .padding(.vertical, 16)
+                .padding(.horizontal, 20)
+                .background(OB.card)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(focused.wrappedValue ? OB.sage : OB.rule,
+                                lineWidth: focused.wrappedValue ? 2 : 1)
+                )
+                .shadow(color: OB.ink.opacity(0.04), radius: 6, y: 3)
+                .padding(.top, 28)
+                .padding(.horizontal, 32)
+                .frame(maxWidth: isIPad ? 460 : .infinity)
+                .animation(.easeInOut(duration: 0.2), value: focused.wrappedValue)
+
+            Text("Optional — stored only on your phone.")
+                .font(.system(size: 12, weight: .regular, design: .rounded))
+                .foregroundColor(OB.inkMute)
+                .padding(.top, 12)
+
+            Spacer()
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Message step (icon + title + body)
+
+private struct MessageStep: View {
+    let symbol: String
+    let tint: Color
+    let title: String
+    let message: String
+    let isIPad: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            IconBadge(symbol: symbol, tint: tint)
             VStack(spacing: 14) {
-                Text(page.title)
-                    .font(.system(size: isIPad ? 38 : 30, weight: .bold, design: .rounded))
-                    .tracking(-0.6)
-                    .foregroundColor(.white)
+                Text(title)
+                    .font(.system(size: isIPad ? 36 : 30, weight: .bold, design: .rounded))
+                    .tracking(-0.4)
+                    .foregroundColor(OB.ink)
                     .multilineTextAlignment(.center)
-
-                Text(page.subtitle)
-                    .font(.system(size: isIPad ? 17 : 15, weight: .semibold, design: .rounded))
-                    .foregroundColor(page.iconColor.opacity(0.95))
-                    .multilineTextAlignment(.center)
-
-                Text(page.description)
-                    .font(.system(size: isIPad ? 15 : 14, weight: .regular, design: .rounded))
-                    .foregroundColor(.white.opacity(0.58))
+                Text(message)
+                    .font(.system(size: 15, weight: .regular, design: .rounded))
+                    .foregroundColor(OB.inkDim)
                     .multilineTextAlignment(.center)
                     .lineSpacing(5)
                     .padding(.horizontal, 8)
             }
-            .padding(.horizontal, isIPad ? 60 : 28)
+            .padding(.top, 28)
+            .padding(.horizontal, isIPad ? 60 : 30)
             .frame(maxWidth: isIPad ? 600 : .infinity)
-            .opacity(textOpacity)
-            .offset(y: textOpacity > 0 ? 0 : 20)
+            Spacer()
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Ready to record (personalised)
+
+private struct ReadyStep: View {
+    let name: String
+    let isIPad: Bool
+    @State private var pop = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            ZStack {
+                Circle().fill(OB.sage.opacity(0.12)).frame(width: 128, height: 128)
+                Circle().fill(OB.sage).frame(width: 76, height: 76)
+                    .shadow(color: OB.sage.opacity(0.4), radius: 16)
+                Image(systemName: "checkmark")
+                    .font(.system(size: 34, weight: .bold))
+                    .foregroundColor(.white)
+            }
+            .scaleEffect(pop ? 1.0 : 0.6)
+            .opacity(pop ? 1 : 0)
+
+            VStack(spacing: 14) {
+                Text(name.isEmpty ? "Ready to be heard" : "Ready when you are,\n\(name).")
+                    .font(.system(size: isIPad ? 36 : 30, weight: .bold, design: .rounded))
+                    .foregroundColor(OB.ink)
+                    .multilineTextAlignment(.center)
+                Text("Your inner sky is ready. Speak your first star — 42 seconds is all it takes.")
+                    .font(.system(size: 15, weight: .regular, design: .rounded))
+                    .foregroundColor(OB.inkDim)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(5)
+                    .padding(.horizontal, 12)
+            }
+            .padding(.top, 28)
+            .padding(.horizontal, isIPad ? 60 : 30)
 
             Spacer()
             Spacer()
         }
         .onAppear {
-            withAnimation(.easeOut(duration: 0.8)) {
-                animate1 = true
-            }
-            withAnimation(.easeOut(duration: 1.2).delay(0.2)) {
-                animate2 = true
-            }
-            withAnimation(.easeOut(duration: 1.0).delay(0.4)) {
-                animate3 = true
-            }
-            withAnimation(.easeOut(duration: 0.8).delay(0.3)) {
-                textOpacity = 1
-            }
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.6).delay(0.1)) { pop = true }
         }
-        .onDisappear {
-            animate1 = false
-            animate2 = false
-            animate3 = false
-            textOpacity = 0
-        }
-    }
-
-    // MARK: - Page 1: Digital Twin = Your Personal Star System
-    // Central sun with 4 orbiting planets (Mind, Heart, Voice, Graph)
-
-    private var twinPlanetSystem: some View {
-        ZStack {
-            // Outer orbit path
-            Circle()
-                .stroke(ivory.opacity(0.08), lineWidth: 1)
-                .frame(width: isIPad ? 240 : 190, height: isIPad ? 240 : 190)
-
-            // Middle orbit path
-            Circle()
-                .stroke(ivory.opacity(0.12), lineWidth: 1)
-                .frame(width: isIPad ? 170 : 130, height: isIPad ? 170 : 130)
-
-            // Inner orbit path
-            Circle()
-                .stroke(ivory.opacity(0.06), lineWidth: 0.5)
-                .frame(width: isIPad ? 260 : 210, height: isIPad ? 260 : 210)
-
-            // Planet: Mind (outer orbit, top)
-            planetDot(color: page.iconColor, size: 10, label: "Mind")
-                .offset(x: 0, y: isIPad ? -120 : -95)
-                .rotationEffect(.degrees(animate2 ? 360 : 0))
-                .animation(.linear(duration: 40).repeatForever(autoreverses: false), value: animate2)
-
-            // Planet: Heart (middle orbit, right)
-            planetDot(color: softCoral, size: 8, label: "Heart")
-                .offset(x: isIPad ? 85 : 65, y: 0)
-                .rotationEffect(.degrees(animate2 ? -360 : 0))
-                .animation(.linear(duration: 28).repeatForever(autoreverses: false), value: animate2)
-
-            // Planet: Voice (middle orbit, left)
-            planetDot(color: forestGreen, size: 9, label: "Voice")
-                .offset(x: isIPad ? -85 : -65, y: isIPad ? 30 : 20)
-                .rotationEffect(.degrees(animate2 ? 360 : 0))
-                .animation(.linear(duration: 34).repeatForever(autoreverses: false), value: animate2)
-
-            // Planet: Graph (outer orbit, bottom-right)
-            planetDot(color: warmGold, size: 7, label: "Graph")
-                .offset(x: isIPad ? 70 : 55, y: isIPad ? 90 : 70)
-                .rotationEffect(.degrees(animate2 ? -360 : 0))
-                .animation(.linear(duration: 50).repeatForever(autoreverses: false), value: animate2)
-
-            // Central sun (your Twin)
-            ZStack {
-                Circle()
-                    .fill(page.iconColor.opacity(animate1 ? 0.15 : 0))
-                    .frame(width: isIPad ? 100 : 80, height: isIPad ? 100 : 80)
-
-                Circle()
-                    .fill(page.iconColor.opacity(animate1 ? 0.3 : 0))
-                    .frame(width: isIPad ? 60 : 48, height: isIPad ? 60 : 48)
-                    .shadow(color: page.iconColor.opacity(0.5), radius: 16)
-
-                Circle()
-                    .fill(page.iconColor.opacity(0.7))
-                    .frame(width: isIPad ? 32 : 24, height: isIPad ? 32 : 24)
-
-                Circle()
-                    .fill(ivory.opacity(0.8))
-                    .frame(width: isIPad ? 14 : 10, height: isIPad ? 14 : 10)
-            }
-            .scaleEffect(animate1 ? 1.0 : 0.5)
-        }
-    }
-
-    // MARK: - Page 2: Insights = Aurora / Nebula Waves
-
-    private var auroraColors: [Color] {
-        [warmGold, page.iconColor, sageGreen, softCoral, forestGreen]
-    }
-
-    private var auroraOffsets: [CGFloat] { [-15, 10, -8, 12, -5] }
-
-    private var auroraInsights: some View {
-        ZStack {
-            // Aurora bands
-            ForEach(0..<5, id: \.self) { i in
-                let bandColor = auroraColors[i]
-                let bandWidth: CGFloat = isIPad ? CGFloat(220 - i * 25) : CGFloat(180 - i * 20)
-                let bandHeight: CGFloat = isIPad ? 6 : 4
-                let xOffset: CGFloat = animate2 ? auroraOffsets[i] : 0
-                let yOffset: CGFloat = CGFloat(i * (isIPad ? 28 : 22) - 50)
-                Capsule()
-                    .fill(
-                        LinearGradient(
-                            colors: [bandColor.opacity(0.3), bandColor.opacity(0.05)],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .frame(width: bandWidth, height: bandHeight)
-                    .offset(x: xOffset, y: yOffset)
-                    .scaleEffect(x: animate1 ? 1.0 : 0.3, anchor: .center)
-                    .opacity(animate1 ? 1 : 0)
-                    .animation(
-                        .easeInOut(duration: 3.0 + Double(i) * 0.5)
-                        .repeatForever(autoreverses: true),
-                        value: animate2
-                    )
-            }
-
-            // Data point stars emerging from aurora
-            auroraDataPoints
-
-            // Central insight orb
-            auroraOrb
-        }
-    }
-
-    private var auroraDataPoints: some View {
-        ForEach(0..<8, id: \.self) { i in
-            let angle = Double(i) * (.pi * 2 / 8) + 0.3
-            let radius: CGFloat = isIPad ? 80 : 65
-            let dotSize: CGFloat = CGFloat(2 + i % 3)
-            Circle()
-                .fill(ivory.opacity(animate3 ? 0.6 : 0))
-                .frame(width: dotSize, height: dotSize)
-                .offset(
-                    x: cos(angle) * radius,
-                    y: sin(angle) * radius * 0.5
-                )
-                .animation(.easeOut(duration: 0.8).delay(Double(i) * 0.1), value: animate3)
-        }
-    }
-
-    private var auroraOrb: some View {
-        ZStack {
-            Circle()
-                .fill(page.iconColor.opacity(animate1 ? 0.12 : 0))
-                .frame(width: isIPad ? 80 : 64, height: isIPad ? 80 : 64)
-
-            Circle()
-                .fill(page.iconColor.opacity(0.4))
-                .frame(width: isIPad ? 36 : 28, height: isIPad ? 36 : 28)
-                .shadow(color: page.iconColor.opacity(0.6), radius: 12)
-
-            Image(systemName: "sparkle")
-                .font(.system(size: isIPad ? 18 : 14, weight: .semibold))
-                .foregroundColor(ivory)
-        }
-        .scaleEffect(animate1 ? 1.0 : 0.6)
-    }
-
-    // MARK: - Page 3: Privacy = Protective Star Shield
-
-    private var shieldConstellation: some View {
-        ZStack {
-            // Outer protective ring of stars
-            shieldStarRing
-
-            // Connection lines forming the shield
-            shieldConnectionLines
-
-            // Pulsing protection rings
-            shieldPulsingRings
-
-            // Central shield
-            shieldCenter
-        }
-    }
-
-    private var shieldStarRing: some View {
-        ForEach(0..<12, id: \.self) { i in
-            let angle = Double(i) * (.pi * 2 / 12)
-            let radius: CGFloat = isIPad ? 100 : 80
-            Circle()
-                .fill(forestGreen.opacity(animate1 ? 0.7 : 0))
-                .frame(width: 4, height: 4)
-                .offset(
-                    x: cos(angle) * radius,
-                    y: sin(angle) * radius
-                )
-                .shadow(color: forestGreen.opacity(0.4), radius: 4)
-                .animation(.easeOut(duration: 0.5).delay(Double(i) * 0.05), value: animate1)
-        }
-    }
-
-    private var shieldConnectionLines: some View {
-        let r: CGFloat = isIPad ? 100 : 80
-        let frameSize: CGFloat = (r + 10) * 2
-        return ForEach(0..<12, id: \.self) { i in
-            let angle1 = Double(i) * (.pi * 2 / 12)
-            let angle2 = Double((i + 1) % 12) * (.pi * 2 / 12)
-            let startX = cos(angle1) * r + r + 10
-            let startY = sin(angle1) * r + r + 10
-            let endX = cos(angle2) * r + r + 10
-            let endY = sin(angle2) * r + r + 10
-            Path { path in
-                path.move(to: CGPoint(x: startX, y: startY))
-                path.addLine(to: CGPoint(x: endX, y: endY))
-            }
-            .stroke(forestGreen.opacity(animate2 ? 0.2 : 0), lineWidth: 0.8)
-            .frame(width: frameSize, height: frameSize)
-            .offset(x: -(r + 10), y: -(r + 10))
-            .animation(.easeOut(duration: 0.8).delay(0.6 + Double(i) * 0.04), value: animate2)
-        }
-    }
-
-    private var shieldPulsingRings: some View {
-        ForEach(0..<3, id: \.self) { i in
-            let ringSize: CGFloat = isIPad ? CGFloat(110 + i * 30) : CGFloat(90 + i * 24)
-            Circle()
-                .stroke(forestGreen.opacity(animate3 ? 0 : 0.2), lineWidth: 1)
-                .frame(width: ringSize, height: ringSize)
-                .scaleEffect(animate3 ? 1.4 : 1.0)
-                .animation(
-                    .easeOut(duration: 2.5)
-                    .repeatForever(autoreverses: false)
-                    .delay(Double(i) * 0.8),
-                    value: animate3
-                )
-        }
-    }
-
-    private var shieldCenter: some View {
-        ZStack {
-            Circle()
-                .fill(forestGreen.opacity(animate1 ? 0.15 : 0))
-                .frame(width: isIPad ? 70 : 56, height: isIPad ? 70 : 56)
-
-            Circle()
-                .fill(forestGreen.opacity(0.35))
-                .frame(width: isIPad ? 44 : 34, height: isIPad ? 44 : 34)
-                .shadow(color: forestGreen.opacity(0.5), radius: 12)
-
-            Image(systemName: "lock.fill")
-                .font(.system(size: isIPad ? 20 : 16, weight: .semibold))
-                .foregroundColor(ivory)
-        }
-        .scaleEffect(animate1 ? 1.0 : 0.5)
-    }
-
-    // MARK: - Planet Dot Helper
-
-    private func planetDot(color: Color, size: CGFloat, label: String) -> some View {
-        VStack(spacing: 3) {
-            ZStack {
-                Circle()
-                    .fill(color.opacity(0.3))
-                    .frame(width: size + 8, height: size + 8)
-                Circle()
-                    .fill(color)
-                    .frame(width: size, height: size)
-                    .shadow(color: color.opacity(0.6), radius: 4)
-            }
-            Text(label.uppercased())
-                .font(.system(size: 7, weight: .bold, design: .rounded))
-                .tracking(1.5)
-                .foregroundColor(ivory.opacity(0.4))
-        }
-        .opacity(animate1 ? 1 : 0)
     }
 }
 
-// MARK: - Intention Check-In Page
+// MARK: - Shared icon badge
+
+private struct IconBadge: View {
+    let symbol: String
+    let tint: Color
+    @State private var appear = false
+
+    var body: some View {
+        ZStack {
+            Circle().fill(tint.opacity(0.12)).frame(width: 104, height: 104)
+            Circle().fill(tint.opacity(0.20)).frame(width: 74, height: 74)
+            Image(systemName: symbol)
+                .font(.system(size: 30, weight: .semibold))
+                .foregroundColor(tint)
+        }
+        .scaleEffect(appear ? 1.0 : 0.6)
+        .opacity(appear ? 1 : 0)
+        .onAppear { withAnimation(.spring(response: 0.5, dampingFraction: 0.65)) { appear = true } }
+    }
+}
+
+// MARK: - Intention Check-In ("Name your planets")
 
 struct IntentionCheckInView: View {
     @Binding var selectedIntentions: Set<String>
@@ -663,22 +418,21 @@ struct IntentionCheckInView: View {
     ]
 
     var body: some View {
-        VStack(spacing: isIPad ? 32 : 24) {
+        VStack(spacing: isIPad ? 28 : 22) {
             Spacer()
 
-            VStack(spacing: 12) {
+            VStack(spacing: 10) {
                 Text("Name your planets")
-                    .font(.system(size: isIPad ? 40 : 32, weight: .bold, design: .rounded))
-                    .foregroundColor(.white)
+                    .font(.system(size: isIPad ? 38 : 30, weight: .bold, design: .rounded))
+                    .foregroundColor(OB.ink)
                     .multilineTextAlignment(.center)
-
-                Text("Each intention becomes a planet in your constellation. Pick the ones that matter.")
-                    .font(isIPad ? .title3 : .body)
-                    .foregroundColor(.white.opacity(0.7))
+                Text("Each intention becomes a planet in your sky. Pick the ones that matter.")
+                    .font(.system(size: 15, weight: .regular, design: .rounded))
+                    .foregroundColor(OB.inkDim)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 20)
             }
-            .padding(.horizontal, isIPad ? 80 : 30)
+            .padding(.horizontal, isIPad ? 80 : 28)
 
             VStack(spacing: 12) {
                 ForEach(intentions, id: \.title) { intention in
@@ -697,7 +451,7 @@ struct IntentionCheckInView: View {
                     }
                 }
             }
-            .padding(.horizontal, isIPad ? 80 : 30)
+            .padding(.horizontal, isIPad ? 80 : 28)
             .frame(maxWidth: isIPad ? 600 : .infinity)
 
             Spacer()
@@ -718,44 +472,66 @@ struct IntentionCard: View {
         Button(action: onTap) {
             HStack(spacing: 14) {
                 Image(systemName: icon)
-                    .font(.system(size: isIPad ? 24 : 20))
-                    .foregroundColor(isSelected ? .white : .white.opacity(0.7))
-                    .frame(width: 32)
+                    .font(.system(size: isIPad ? 22 : 19))
+                    .foregroundColor(isSelected ? OB.sage : OB.inkMute)
+                    .frame(width: 30)
 
                 Text(title)
-                    .font(isIPad ? .title3.weight(.medium) : .body.weight(.medium))
-                    .foregroundColor(isSelected ? .white : .white.opacity(0.8))
+                    .font(.system(size: isIPad ? 18 : 16, weight: .medium, design: .rounded))
+                    .foregroundColor(isSelected ? OB.ink : OB.inkDim)
 
                 Spacer()
 
-                Text(planet)
+                Text(planet.uppercased())
                     .font(.system(size: 9, weight: .bold, design: .rounded))
                     .tracking(1.5)
-                    .foregroundColor(isSelected ? Color(red: 0.831, green: 0.647, blue: 0.278) : .white.opacity(0.25))
+                    .foregroundColor(isSelected ? OB.gold : OB.inkMute.opacity(0.6))
 
                 if isSelected {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 20))
-                        .foregroundColor(Color(red: 0.420, green: 0.620, blue: 0.482))
+                        .foregroundColor(OB.forest)
                 }
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 16)
+            .padding(.horizontal, 18)
+            .padding(.vertical, 15)
             .background(
-                RoundedRectangle(cornerRadius: 14)
-                    .fill(isSelected ? Color.white.opacity(0.15) : Color.white.opacity(0.06))
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(isSelected ? OB.sage.opacity(0.10) : OB.card)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 14)
-                    .stroke(isSelected ? Color(red: 0.357, green: 0.486, blue: 0.420).opacity(0.7) : Color.white.opacity(0.1), lineWidth: 1.5)
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(isSelected ? OB.sage.opacity(0.7) : OB.rule, lineWidth: isSelected ? 1.5 : 1)
             )
+            .shadow(color: OB.ink.opacity(isSelected ? 0 : 0.03), radius: 5, y: 2)
         }
         .buttonStyle(.plain)
         .animation(.easeInOut(duration: 0.2), value: isSelected)
     }
 }
 
-// MARK: - Privacy Badge Component
+// MARK: - Ivory constellation field (soft sage/gold dots on light)
+
+private struct IvorySky: View {
+    var body: some View {
+        Canvas { context, size in
+            for i in 0..<44 {
+                let seed = UInt64(i) &* 6364136223846793005 &+ 1442695040888963407
+                let x = Double((seed >> 16) % 10000) / 10000.0 * size.width
+                let y = Double((seed >> 32) % 10000) / 10000.0 * size.height
+                let r = Double((seed >> 48) % 100) / 100.0 * 1.6 + 0.4
+                let useGold = (seed >> 4) % 5 == 0
+                let opacity = Double((seed >> 8) % 100) / 100.0 * 0.14 + 0.05
+                let dot = Path(ellipseIn: CGRect(x: x - r, y: y - r, width: r * 2, height: r * 2))
+                context.fill(dot, with: .color((useGold ? OB.gold : OB.sage).opacity(opacity)))
+            }
+        }
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Shared components used elsewhere in the app (unchanged)
 
 struct PrivacyBadge: View {
     var compact: Bool = false
@@ -779,8 +555,6 @@ struct PrivacyBadge: View {
     }
 }
 
-// MARK: - Offline Indicator
-
 struct OfflineIndicator: View {
     var body: some View {
         HStack(spacing: 4) {
@@ -798,8 +572,7 @@ struct OfflineIndicator: View {
     }
 }
 
-// MARK: - Star Field Background
-
+/// Ambient star field used by empty states / recording screens (white on dark).
 struct StarFieldView: View {
     let count: Int
 

--- a/solyn/solyn/OnboardingView.swift
+++ b/solyn/solyn/OnboardingView.swift
@@ -9,6 +9,18 @@
 //
 
 import SwiftUI
+import CoreData
+import WidgetKit
+import DailyVoxTwinEngine
+import AVFoundation
+import Speech
+
+/// What the "speak your first star" moment produces, handed to the container to persist.
+struct OnboardingFirstEntry {
+    var audioFileName: String?   // nil in demo / no-audio paths
+    var duration: Double
+    var transcript: String
+}
 
 // MARK: - Palette
 
@@ -29,10 +41,12 @@ private enum OB {
 
 struct OnboardingView: View {
     @Binding var hasCompletedOnboarding: Bool
+    @Environment(\.managedObjectContext) private var viewContext
 
     @State private var screen = 0          // 0 invite, 1 speak, 2 claim
     @State private var starBorn = false
     @State private var transcript = ""
+    @State private var firstEntry: OnboardingFirstEntry?
 
     private var demo: Bool { ProcessInfo.processInfo.arguments.contains("-OnboardingDemo") }
 
@@ -47,8 +61,9 @@ struct OnboardingView: View {
                 case 0:
                     InviteScreen(demo: demo) { advance() }
                 case 1:
-                    SpeakScreen(demo: demo) { text in
-                        transcript = text
+                    SpeakScreen(demo: demo) { entry in
+                        firstEntry = entry
+                        transcript = entry.transcript
                         withAnimation(.easeInOut(duration: 0.8)) { starBorn = true }
                         advance()
                     }
@@ -63,8 +78,39 @@ struct OnboardingView: View {
     private func advance() { withAnimation(.easeInOut(duration: 0.6)) { screen += 1 } }
 
     private func complete() {
+        persistFirstStar()
         UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
         withAnimation(.easeInOut(duration: 0.4)) { hasCompletedOnboarding = true }
+    }
+
+    /// Save the onboarding recording as the user's real first DiaryEntry, so "that
+    /// star is yours" is true — they enter the app to a sky that already holds their
+    /// star, not an empty one, and TodayView won't re-fire a duplicate first-star moment.
+    private func persistFirstStar() {
+        guard let entry = firstEntry else { return }
+        let text = entry.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard entry.audioFileName != nil || !text.isEmpty else { return }
+        let now = Date()
+        let e = DiaryEntry(context: viewContext)
+        e.id = UUID()
+        e.date = now
+        e.createdAt = now
+        e.updatedAt = now
+        e.text = text
+        e.isStarred = false
+        if let fileName = entry.audioFileName {
+            e.setValue(AudioFileList.encode([fileName]), forKey: "audioFileNames")
+            e.setValue(fileName, forKey: "audioFileName")
+            e.setValue(entry.duration, forKey: "duration")
+        }
+        do {
+            try viewContext.save()
+            UserDefaults.standard.set(true, forKey: "hasCompletedFirstEntry")
+            DigitalTwinEngine.shared.processEntry(text: text, mood: nil, date: now, duration: entry.duration)
+            WidgetCenter.shared.reloadAllTimelines()
+        } catch {
+            // Non-fatal: onboarding still completes; worst case the star isn't pre-seeded.
+        }
     }
 }
 
@@ -108,7 +154,19 @@ private struct InviteScreen: View {
             Spacer()
             Spacer()
 
-            PrimaryButton(title: "I'm ready", filled: true, action: onBegin)
+            PrimaryButton(title: "I'm ready", filled: true) {
+                // Pre-frame the mic + speech prompts here, on the calm invite screen,
+                // so they don't interrupt the recording moment itself.
+                #if os(iOS)
+                AVAudioApplication.requestRecordPermission { _ in
+                    SFSpeechRecognizer.requestAuthorization { _ in
+                        DispatchQueue.main.async { onBegin() }
+                    }
+                }
+                #else
+                onBegin()
+                #endif
+            }
                 .padding(.horizontal, 28)
                 .padding(.bottom, 44)
         }
@@ -128,7 +186,7 @@ private struct InviteScreen: View {
 
 private struct SpeakScreen: View {
     let demo: Bool
-    let onBorn: (String) -> Void
+    let onBorn: (OnboardingFirstEntry) -> Void
 
     @StateObject private var recorder = AudioRecorder()
     @State private var phase: Phase = .idle
@@ -136,9 +194,12 @@ private struct SpeakScreen: View {
     @State private var elapsed: Double = 0
     @State private var transcript = ""
     @State private var flare: CGFloat = 0
+    @State private var capturedFile: String?
+    @State private var capturedDuration: Double = 0
+    @State private var typing = false
+    @State private var typedText = ""
 
     enum Phase { case idle, recording, processing, born }
-    private let softTarget: Double = 42
 
     var body: some View {
         VStack(spacing: 0) {
@@ -180,10 +241,13 @@ private struct SpeakScreen: View {
             withAnimation(.easeOut(duration: 0.08)) { level = CGFloat(l) }
         }
         .onReceive(recorder.$currentTime) { t in
+            // 42s is a soft target, not a cut-off — let people finish their sentence.
             elapsed = t
-            if t >= softTarget { finish() }
         }
         .onAppear(perform: autoDemo)
+        .sheet(isPresented: $typing) {
+            TypeFirstEntryView(text: $typedText, onSave: finishTyped, onCancel: { typing = false })
+        }
     }
 
     private var headline: String {
@@ -218,6 +282,10 @@ private struct SpeakScreen: View {
                 }
                 Text("Tap to speak").font(.system(size: 13, weight: .medium, design: .rounded))
                     .foregroundColor(OB.inkMute)
+                Button("I can't talk right now") { typing = true }
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundColor(OB.sage)
+                    .padding(.top, 2)
             }
         case .recording:
             Button(action: finish) {
@@ -256,7 +324,9 @@ private struct SpeakScreen: View {
             born(); return
         }
         withAnimation(.easeInOut(duration: 0.3)) { phase = .processing }
-        guard let res = recorder.stopRecording() else { transcript = ""; born(); return }
+        guard let res = recorder.stopRecording() else { born(); return }
+        capturedFile = res.url.lastPathComponent
+        capturedDuration = res.duration
         SpeechTranscriber.shared.transcribe(from: res.url) { result in
             DispatchQueue.main.async {
                 if case .success(let t) = result { transcript = t }
@@ -269,7 +339,21 @@ private struct SpeakScreen: View {
         withAnimation(.easeInOut(duration: 0.25)) { phase = .born }
         // Springy overshoot = the waveform collapses and the star pops into being.
         withAnimation(.spring(response: 0.7, dampingFraction: 0.52).delay(0.05)) { flare = 1 }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.1) { onBorn(transcript) }
+        let payload = OnboardingFirstEntry(audioFileName: capturedFile,
+                                           duration: capturedDuration,
+                                           transcript: transcript)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.1) { onBorn(payload) }
+    }
+
+    private func finishTyped() {
+        let t = typedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !t.isEmpty else { return }
+        transcript = t
+        capturedFile = nil
+        capturedDuration = 0
+        typing = false
+        // Let the sheet dismiss, then ignite the star from the typed words.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { born() }
     }
 
     private func autoDemo() {
@@ -287,6 +371,59 @@ private struct SpeakScreen: View {
             }
             finish()
         }
+    }
+}
+
+// MARK: - Type instead (escape hatch for "I can't talk right now")
+
+private struct TypeFirstEntryView: View {
+    @Binding var text: String
+    var onSave: () -> Void
+    var onCancel: () -> Void
+    @FocusState private var focused: Bool
+
+    private var isEmpty: Bool { text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Button("Cancel", action: onCancel).foregroundColor(OB.inkMute)
+                Spacer()
+                Text("Your first star")
+                    .font(.system(size: 15, weight: .semibold, design: .rounded)).foregroundColor(OB.ink)
+                Spacer()
+                Button("Save", action: onSave)
+                    .fontWeight(.semibold)
+                    .foregroundColor(isEmpty ? OB.inkMute : OB.sage)
+                    .disabled(isEmpty)
+            }
+            .font(.system(size: 15, design: .rounded))
+            .padding()
+
+            Text("How was your day, really?")
+                .font(.system(size: 22, weight: .bold, design: .rounded))
+                .foregroundColor(OB.ink)
+                .padding(.top, 4)
+
+            TextEditor(text: $text)
+                .font(.system(size: 17, design: .rounded))
+                .foregroundColor(OB.ink)
+                .scrollContentBackground(.hidden)
+                .padding(12)
+                .background(OB.card)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).stroke(OB.rule, lineWidth: 1))
+                .frame(height: 200)
+                .padding()
+                .focused($focused)
+
+            Text("Stored only on your phone.")
+                .font(.system(size: 12, design: .rounded)).foregroundColor(OB.inkMute)
+
+            Spacer()
+        }
+        .background(OB.paper.ignoresSafeArea())
+        .onAppear { focused = true }
     }
 }
 


### PR DESCRIPTION
Replaces the generic slide/quiz onboarding with the app's un-copyable moment: **you speak, and your voice collapses into a private star carrying your own words.** Ivory-light, constellation language, live `AudioRecorder` waveform + on-device `SpeechTranscriber`.

### Flow
Invite ("Your sky starts with your voice") → **Speak** (live waveform orb → collapses & ignites into a star) → **Claim** ("That star is yours. It lives on your phone.")

### Review fixes folded in
1. **Persist the first star** — the recording is saved as a real `DiaryEntry` (audio + transcript), fed to the Twin, with `hasCompletedFirstEntry` set so TodayView won't fire a duplicate celebration. Users enter the app to a sky that **already holds their star**. *(Was: the recording was thrown away → empty sky → the promise broke 30s after we made it.)*
2. **"I can't talk right now" escape hatch** → type the first entry. Voice-only was an activation dead-end for anyone not in a private room.
3. **Permission pre-framing** — mic + speech prompts fire on the calm "I'm ready" tap, not stacked inside the recording moment.
4. **Soft 42s** — no more hard cut-off mid-sentence (matches v1.3.5 behavior).

### Notes
- Real mic + transcription (device only; sim has no mic). `-OnboardingDemo` drives a synthetic autoplay for recording.
- Verified `xcodebuild BUILD SUCCEEDED` (iOS 26). **Device pass still needed** for the mic → star → words moment and the permission/typed paths.
- Supersedes the informational ivory onboarding (PR #16, closed). Demo video + stills in `~/Downloads/dailyvox_voice_onboarding_v2.*`.

### Still open (not blocking)
- Reduce-Motion / VoiceOver pass; optional final flourish (star flies up into the sky).