### PR TITLE
Rating prompt: first ask at entry 3 + positive-moment trigger

### DIFF
--- a/solyn/solyn/DigitalTwinView.swift
+++ b/solyn/solyn/DigitalTwinView.swift
@@ -531,7 +531,7 @@ struct DigitalTwinView: View {
                 shareYourTwinButton
             }
         }
-        .sheet(isPresented: $showTwinShareSheet) {
+        .sheet(isPresented: $showTwinShareSheet, onDismiss: { ReviewManager.shared.recordPositiveMoment() }) {
             if let image = twinShareImage {
                 ShareSheet(activityItems: [
                     image,

--- a/solyn/solyn/ReviewManager.swift
+++ b/solyn/solyn/ReviewManager.swift
@@ -22,10 +22,27 @@ final class ReviewManager {
         checkAndRequestReview(entryCount: count)
     }
 
+    /// Call after a genuinely positive moment (e.g. sharing a personality card),
+    /// once the user has a little history. Requests a review within Apple's caps.
+    func recordPositiveMoment() {
+        guard !UserDefaults.standard.bool(forKey: hasReviewedKey) else { return }
+        // Needs some history so it never fires on a brand-new install.
+        guard UserDefaults.standard.integer(forKey: entryCountKey) >= 2 else { return }
+        if let lastRequest = UserDefaults.standard.object(forKey: lastReviewRequestKey) as? Date {
+            let daysSince = Calendar.current.dateComponents([.day], from: lastRequest, to: Date()).day ?? 0
+            guard daysSince >= 90 else { return }
+        }
+        Task {
+            try? await Task.sleep(for: .seconds(1))
+            await requestReview()
+        }
+    }
+
     private func checkAndRequestReview(entryCount: Int) {
         guard !UserDefaults.standard.bool(forKey: hasReviewedKey) else { return }
 
-        let milestones = [5, 15, 40]
+        // First ask at 3 (most users never reached the old floor of 5).
+        let milestones = [3, 12, 40]
         guard milestones.contains(entryCount) else { return }
 
         if let lastRequest = UserDefaults.standard.object(forKey: lastReviewRequestKey) as? Date {

--- a/solyn/solyn/ShareableInsightCardView.swift
+++ b/solyn/solyn/ShareableInsightCardView.swift
@@ -253,7 +253,7 @@ struct WeeklyInsightsSection: View {
             .frame(height: 280)
         }
         .padding(.vertical, 8)
-        .sheet(isPresented: $showShareSheet) {
+        .sheet(isPresented: $showShareSheet, onDismiss: { ReviewManager.shared.recordPositiveMoment() }) {
             if let image = shareImage {
                 ShareSheet(activityItems: [image])
             }

--- a/solyn/solyn/TwinProfileCard.swift
+++ b/solyn/solyn/TwinProfileCard.swift
@@ -203,7 +203,7 @@ struct TwinProfileCardSection: View {
 
                     TwinProfileCardContent(profile: profile)
                 }
-                .sheet(isPresented: $showShareSheet) {
+                .sheet(isPresented: $showShareSheet, onDismiss: { ReviewManager.shared.recordPositiveMoment() }) {
                     if let image = shareImage {
                         ShareSheet(activityItems: [
                             image,


### PR DESCRIPTION
The last code piece for v1.4.1.

**Why:** 0 ratings at ~500 installs. `ReviewManager` only prompted at entries **5/15/40** — most users never reach 5, so the prompt almost never fires.

**Fix:**
- Lower milestones to **[3, 12, 40]** (first ask at entry 3).
- Add `recordPositiveMoment()`, fired when a **card-share sheet dismisses** (personality card / insight card) — a real positive moment — guarded by the same `hasReviewed` + 90-day + ≥2-entries caps so it stays within Apple's limits and never fires on a fresh install.

Verified `BUILD SUCCEEDED` (iOS 26). Ships with v1.4.1.