### PR TITLE
ASO: refresh all copy for v1.4.1 (promo, description, What's New, screenshots)

### DIFF
--- a/solyn/AppStore/AppStoreMetadata.md
+++ b/solyn/AppStore/AppStoreMetadata.md
@@ -10,78 +10,29 @@ Private On-Device Audio Diary
 offline,encrypted,mood,tracker,gratitude,transcribe,speech,memo,notes,therapy,ai,twin,digital
 
 ## Promotional Text (170 characters max)
-Private voice journal & audio diary, 100% on your iPhone. Speak ~42 seconds a day and your Digital Twin learns your moods and patterns. No account. No cloud. Free.
+Speak your first star. Your voice becomes a private journal and a Digital Twin that learns your moods — 100% on your iPhone. No account, no cloud. Free.
 
 ## Description (4000 characters max)
 
-DailyVox is a private voice journal that turns your spoken thoughts into a searchable diary with AI mood tracking — all 100% on-device. Speak your thoughts, and DailyVox transforms them into a living journal while building a digital twin that reflects your inner world.
+DailyVox is a voice journal that never leaves your phone.
 
-YOUR VOICE, YOUR DIARY
-Record your thoughts naturally with voice. DailyVox transcribes everything on-device using Apple's speech recognition - no servers, no uploads, no compromises. Your voice literally never leaves your phone.
+Speak for about 42 seconds a day. DailyVox transcribes it on your device and builds a private model of your moods, your patterns, and the people in your life. It calls this your Digital Twin. No typing, no blank page.
 
-YOUR DIGITAL TWIN
-This is what makes DailyVox different. As you journal, DailyVox tracks and visualizes patterns in your life:
+Your very first moment sets the tone: speak one true thing, and watch your voice become the first star in a private sky only you can see.
 
-- Personal World Map: People, places, and topics you mention — and how they connect
-- Mood Trends: See how your mood shifts across mornings, evenings, weekdays, and weekends
-- Writing Patterns: When you journal, how much you write, your streaks and consistency
-- Top Themes: The subjects that come up most in your entries, ranked by importance
+Everything happens on your iPhone. No account. No server. During a recording, the app makes zero network calls — you can verify it with a network proxy. That is why DailyVox carries Apple's strictest privacy label: Data Not Collected.
 
-Your twin grows with every entry, giving you a clearer picture of your journaling journey over time.
-
-SMART INSIGHTS
-DailyVox uses Apple's on-device NLP to surface patterns you might not notice:
-
-- Sentiment analysis that tracks your emotional trends over weeks and months
-- Named entity recognition to build your personal knowledge graph
-- Smart search suggestions powered by the people and topics in your entries
-- All processing happens on your device — nothing is sent to any server
-
-BEAUTIFUL INSIGHTS
-Track your emotional journey with:
-- Writing streaks and consistency scores
-- Mood trends with interactive charts
-- Weekly activity patterns
-- AI-generated insights about your patterns
-- Weekly summaries of your emotional arc
-
-RICH JOURNALING
-- Voice recording with real-time audio visualization
-- Enhanced audio playback with progress bar, scrubbing, and speed control (0.5x-2x)
-- Photo attachments (up to 5 per entry, stored on-device only)
-- Search and filter your entire history
-- Smart search with knowledge graph-powered suggestions
-- Star your favorite entries
-- Mood tagging for every entry
-- Journaling goals with weekly targets and milestone celebrations
+WHAT YOU GET
+- Talk instead of type — 42 seconds beats a blank page
+- On-device transcription, mood detection, and insights
+- A Digital Twin that learns who you are over time
+- Your inner sky: every entry becomes a star, coloured by mood
+- Weekly insights, streaks, and patterns you'd never spot yourself
+- Face ID lock, encrypted backups (AES-256-GCM), optional iCloud sync
 - Export to PDF, JSON, Markdown, CSV, or plain text
+- No account, no sign-up, no subscription. Works offline. Free.
 
-LOCK SCREEN & WIDGETS
-Quick-access widgets for your Home Screen and Lock Screen:
-- Today's entry preview
-- Streak counter
-- Mood tracker
-- One-tap recording shortcut
-
-SECURITY & PRIVACY
-- Face ID / Touch ID app lock
-- Password-protected encrypted backups (AES-256-GCM)
-- 100% on-device AI processing
-- Optional iCloud sync (encrypted with your Apple ID)
-- No accounts required
-- No tracking, no analytics, no ads
-- No third-party servers - ever
-
-8 BEAUTIFUL THEMES
-System, Light, Sage, Lavender, Rose, Ocean, Warm, and Dark themes to match your style.
-
-BUILT FOR CONSISTENCY
-DailyVox helps you build a journaling habit. Daily reminder notifications, writing prompts to get you started, and journaling goals with weekly targets and milestone celebrations.
-
-Your thoughts deserve a home. DailyVox is that home.
-
-## Keywords (100 characters max, comma-separated)
-diary,journal,voice,mood tracker,digital twin,private,speech to text,mindfulness,encrypted,anxiety
+The most honest thing you write should stay yours. With DailyVox, it does.
 
 ## Category
 Primary: Health & Fitness
@@ -98,6 +49,27 @@ https://getdailyvox.com/support
 
 ## Privacy Policy URL
 https://getdailyvox.com/privacy
+
+## What's New (Version 1.4.1)
+Start with your voice.
+
+- Voice-first onboarding: speak one true thing and watch it become the first star in your private sky
+- Your very first recording is saved as your real first journal entry — no empty start
+- Can't talk right now? Type your first entry instead
+- Fixed Home & Lock Screen widget counters and the recording timer
+- Rating moments that respect your time
+
+Still free. Still 100% on-device. Your words never leave your phone.
+
+## What's New (Version 1.4.0)
+A warm new look.
+
+- Calm sage-and-gold palette across every screen; your Digital Twin at the center
+- Refined recording screen and onboarding; compact audio player on entries
+- Replay the welcome anytime from Settings
+- Polish and fixes throughout
+
+Still free. Still 100% on-device.
 
 ## What's New (Version 1.3.5)
 New in v1.3.5:

--- a/solyn/AppStore/metadata.json
+++ b/solyn/AppStore/metadata.json
@@ -16,8 +16,8 @@
       "name": "DailyVox: Voice Journal Diary",
       "subtitle": "Private On-Device Audio Diary",
       "keywords": "offline,encrypted,mood,tracker,gratitude,transcribe,speech,memo,notes,therapy,ai,twin,digital",
-      "promotional_text": "Private voice journal & audio diary, 100% on your iPhone. Speak ~42 seconds a day and your Digital Twin learns your moods and patterns. No account. No cloud. Free.",
-      "whats_new": "A warm new look.\n\nDailyVox now wears a calm sage-and-gold palette across every screen, and your Digital Twin takes center stage.\n\n- Redesigned, warmer interface throughout\n- Digital Twin promoted to the center of the app\n- Refined recording screen and onboarding\n- Compact audio player on entries\n- Replay the welcome anytime from Settings\n- Polish and fixes across the app\n\nStill free. Still 100% on-device. Your words never leave your phone."
+      "promotional_text": "Speak your first star. Your voice becomes a private journal and a Digital Twin that learns your moods — 100% on your iPhone. No account, no cloud. Free.",
+      "whats_new": "Start with your voice.\n\n- Voice-first onboarding: speak one true thing and watch it become the first star in your private sky\n- Your very first recording is saved as your real first journal entry — no empty start\n- Can't talk right now? Type your first entry instead\n- Fixed Home & Lock Screen widget counters and the recording timer\n- Rating moments that respect your time\n\nStill free. Still 100% on-device. Your words never leave your phone."
     }
   },
   "app_privacy": {
@@ -36,31 +36,46 @@
     "notes_for_reviewer": "DailyVox is a privacy-first voice diary app. All AI processing happens on-device using Apple's NaturalLanguage framework. The app requires microphone access for voice recording, Speech Recognition for transcription, and optionally Photo Library access for attaching photos to entries. Encrypted backups use CryptoKit (AES-256-GCM). No data is sent to external servers. The app does not require an account or internet connection to function."
   },
   "screenshots": {
-    "iphone_67": {
-      "resolution": "1284x2778",
-      "count": 7,
-      "files": [
-        "01_hero.png",
-        "02_digital_twin.png",
-        "03_constellation.png",
-        "04_privacy.png",
-        "05_voice.png",
-        "06_free.png",
-        "07_dynamic_island.png"
-      ],
-      "captions": [
-        "Your inner sky is waiting",
-        "Your Digital Twin learns your patterns",
-        "Every entry becomes a star in your constellation",
-        "100% on-device. Your diary never leaves your phone.",
-        "Voice journaling — just speak, we transcribe",
-        "Open source. No accounts. No tracking.",
-        "Always visible. Never in the way. (NEW in v1.3.5)"
-      ]
-    },
-    "iphone_65": {
-      "resolution": "1242x2688",
+    "_note": "Captioned marketing set generated via screenshot-src/gen_appstore.py. Both sizes are the same 7 frames.",
+    "iphone_6.9": {
+      "resolution": "1320x2868",
+      "dir": "screenshots/iPhone_6.9_1320x2868",
       "count": 7
-    }
+    },
+    "iphone_6.5": {
+      "resolution": "1284x2778",
+      "dir": "screenshots/iPhone_6.5_1284x2778",
+      "count": 7
+    },
+    "recommended_upload_order": [
+      {
+        "file": "07_first_star.png",
+        "headline": "your voice becomes a star"
+      },
+      {
+        "file": "01_predicts_you.png",
+        "headline": "it knows you better than you do"
+      },
+      {
+        "file": "02_just_speak.png",
+        "headline": "speak 42 sec — that's the whole app"
+      },
+      {
+        "file": "03_remembers.png",
+        "headline": "it remembers everything"
+      },
+      {
+        "file": "04_patterns.png",
+        "headline": "it clocks your patterns before you do"
+      },
+      {
+        "file": "05_reads_between_lines.png",
+        "headline": "it reads between the lines"
+      },
+      {
+        "file": "06_private.png",
+        "headline": "it never leaves your phone. period."
+      }
+    ]
   }
 }


### PR DESCRIPTION
Brings every ASO artifact current + consistent for the v1.4.1 paste-into-App-Store-Connect.

- **What's New** → v1.4.1 (voice-first onboarding + fixes); added the v1.4.0 note too.
- **Promo text** → the voice-first signature: *'Speak your first star. Your voice becomes a private journal and a Digital Twin that learns your moods…'* (152/170).
- **Description** → synced to the clean live copy + a voice-star hook line; retired the old verbose version.
- Removed a **stale duplicate Keywords section** (the anchored hidden field is the single source).
- **metadata.json screenshots block** → the captioned 6.9"+6.5" set + recommended upload order (07_first_star first).

Unchanged (already anchored, live): name `DailyVox: Voice Journal Diary`, subtitle `Private On-Device Audio Diary`, keyword field. Docs/metadata only.