### PR TITLE
Twin Resolution: self-prediction fidelity, made felt

### DIFF
--- a/solyn/solyn/DigitalTwinView.swift
+++ b/solyn/solyn/DigitalTwinView.swift
@@ -50,6 +50,9 @@ struct DigitalTwinView: View {
                     // Maturity indicator
                     maturityBadge
 
+                    // How well the Twin actually knows you (self-prediction fidelity)
+                    TwinResolutionCard()
+
                     // Section Picker
                     sectionPicker
 

--- a/solyn/solyn/TwinResolution.swift
+++ b/solyn/solyn/TwinResolution.swift
@@ -1,0 +1,151 @@
+//
+//  TwinResolution.swift
+//  solyn
+//
+//  "Twin Resolution" — a felt measure of how well your Digital Twin actually
+//  knows you. We ask a few self-report questions that map to traits the Twin
+//  already computes from your entries, then compare the Twin's estimate to your
+//  own answer. The closer they match, the higher the resolution.
+//
+//  This is the self-prediction fidelity harness (Park et al. style) made
+//  user-facing: no engine changes, no new permissions — it reads the Twin's
+//  existing trait scores and scores agreement on-device.
+//
+
+import SwiftUI
+import DailyVoxTwinEngine
+
+// MARK: - Question
+
+/// A self-report question whose answer is compared against the Twin's own
+/// computed value for the same trait. `twinValue` returns the Twin's current
+/// 0...1 estimate; the user answers on the same 0...1 scale.
+struct SelfPredictionQuestion: Identifiable {
+    let id: String
+    let prompt: String
+    let lowLabel: String        // anchors the 0 end
+    let highLabel: String       // anchors the 1 end
+    let twinValue: () -> Double  // the Twin's current estimate for this trait
+}
+
+// MARK: - Manager
+
+@MainActor
+final class TwinResolutionManager: ObservableObject {
+    static let shared = TwinResolutionManager()
+
+    private let answersKey = "twinResolution_answers"
+    private let historyKey = "twinResolution_history"   // [ISO-date: resolution] snapshots over time
+
+    /// questionId -> the user's self-report on a 0...1 scale.
+    @Published private(set) var answers: [String: Double]
+
+    private init() {
+        answers = (UserDefaults.standard.dictionary(forKey: answersKey) as? [String: Double]) ?? [:]
+    }
+
+    /// The fixed question bank, each mapped to a trait the Twin exposes.
+    /// (Same accessors TwinProfileGenerator already reads, so these are known-good.)
+    var questions: [SelfPredictionQuestion] {
+        let t = DigitalTwinEngine.shared
+        return [
+            SelfPredictionQuestion(
+                id: "expressiveness",
+                prompt: "How do you tend to express yourself?",
+                lowLabel: "Reserved", highLabel: "Expressive",
+                twinValue: { t.communicationStyle.expressiveness }),
+            SelfPredictionQuestion(
+                id: "directness",
+                prompt: "When you say what you mean, you're usually…",
+                lowLabel: "Nuanced", highLabel: "Direct",
+                twinValue: { t.communicationStyle.directness }),
+            SelfPredictionQuestion(
+                id: "analytical",
+                prompt: "You make sense of things more through…",
+                lowLabel: "Intuition", highLabel: "Analysis",
+                twinValue: { t.thoughtPatterns.analyticalScore }),
+            SelfPredictionQuestion(
+                id: "abstract",
+                prompt: "Your thinking leans…",
+                lowLabel: "Concrete", highLabel: "Abstract",
+                twinValue: { t.thoughtPatterns.abstractScore }),
+            SelfPredictionQuestion(
+                id: "future",
+                prompt: "Your mind spends more time on…",
+                lowLabel: "The past", highLabel: "The future",
+                twinValue: { t.thoughtPatterns.futureOriented }),
+            SelfPredictionQuestion(
+                id: "growth",
+                prompt: "When something goes wrong, you tend to feel you can…",
+                lowLabel: "Accept it", highLabel: "Grow from it",
+                twinValue: { t.thoughtPatterns.growthMindsetScore }),
+            SelfPredictionQuestion(
+                id: "emotionalRange",
+                prompt: "Across a week, your emotions are…",
+                lowLabel: "Steady", highLabel: "Wide-ranging",
+                twinValue: { t.emotionalSignature.emotionalRange }),
+        ]
+    }
+
+    var answeredQuestions: [SelfPredictionQuestion] { questions.filter { answers[$0.id] != nil } }
+    var unansweredQuestions: [SelfPredictionQuestion] { questions.filter { answers[$0.id] == nil } }
+    var answeredCount: Int { answeredQuestions.count }
+    var totalCount: Int { questions.count }
+    var hasAnswered: Bool { !answers.isEmpty }
+
+    /// 0...1 — how closely the Twin's estimates match your self-report.
+    /// `nil` until you've answered at least one question.
+    var resolution: Double? {
+        let answered = answeredQuestions
+        guard !answered.isEmpty else { return nil }
+        let totalError = answered.reduce(0.0) { acc, q in
+            acc + abs(q.twinValue() - (answers[q.id] ?? 0.5))
+        }
+        return max(0, 1 - totalError / Double(answered.count))
+    }
+
+    /// Per-question agreement, for showing where the Twin nails you vs. misses.
+    func agreement(for q: SelfPredictionQuestion) -> Double? {
+        guard let a = answers[q.id] else { return nil }
+        return max(0, 1 - abs(q.twinValue() - a))
+    }
+
+    // MARK: Recording
+
+    func record(_ questionId: String, value: Double) {
+        answers[questionId] = min(1, max(0, value))
+        UserDefaults.standard.set(answers, forKey: answersKey)
+        snapshotResolution()
+    }
+
+    func reset() {
+        answers = [:]
+        UserDefaults.standard.removeObject(forKey: answersKey)
+    }
+
+    /// Record a dated snapshot of the current resolution, so we can show it
+    /// climbing as the Twin learns (the test-retest curve the dossier describes).
+    private func snapshotResolution() {
+        guard let r = resolution else { return }
+        var history = (UserDefaults.standard.dictionary(forKey: historyKey) as? [String: Double]) ?? [:]
+        let day = ISO8601DateFormatter.dayFormatter.string(from: Date())
+        history[day] = r
+        UserDefaults.standard.set(history, forKey: historyKey)
+    }
+
+    var history: [(date: Date, resolution: Double)] {
+        let dict = (UserDefaults.standard.dictionary(forKey: historyKey) as? [String: Double]) ?? [:]
+        return dict.compactMap { key, value in
+            ISO8601DateFormatter.dayFormatter.date(from: key).map { ($0, value) }
+        }.sorted { $0.date < $1.date }
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+}

--- a/solyn/solyn/TwinResolutionView.swift
+++ b/solyn/solyn/TwinResolutionView.swift
@@ -1,0 +1,235 @@
+//
+//  TwinResolutionView.swift
+//  solyn
+//
+//  UI for Twin Resolution: a card in the Digital Twin tab that shows how well
+//  your Twin knows you, and a questionnaire that reveals — question by question —
+//  what the Twin guessed about you and whether it was right.
+//
+
+import SwiftUI
+
+private enum TR {
+    static let gold = Color(red: 0.831, green: 0.647, blue: 0.278)
+    static let sage = Color(red: 0.357, green: 0.486, blue: 0.420)
+    static let forest = Color(red: 0.420, green: 0.620, blue: 0.482)
+    static let coral = Color(red: 0.769, green: 0.451, blue: 0.420)
+}
+
+// MARK: - Card (embedded in the Twin tab)
+
+struct TwinResolutionCard: View {
+    @ObservedObject private var manager = TwinResolutionManager.shared
+    @State private var showSheet = false
+
+    var body: some View {
+        Button { showSheet = true } label: {
+            HStack(spacing: 16) {
+                meter
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Twin Resolution")
+                        .font(.system(size: 16, weight: .bold, design: .rounded))
+                        .foregroundColor(.primary)
+                    Text(subtitle)
+                        .font(.system(size: 13, weight: .regular, design: .rounded))
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.secondary.opacity(0.5))
+            }
+            .padding(16)
+            .background(RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color(.secondarySystemBackground)))
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showSheet) { TwinResolutionSheet() }
+    }
+
+    private var subtitle: String {
+        if let r = manager.resolution {
+            return "Your Twin matches your self-report \(pct(r)). Tap to refine."
+        }
+        return "How well does your Twin know you? Answer \(manager.totalCount) quick questions to find out."
+    }
+
+    private var meter: some View {
+        ZStack {
+            Circle().stroke(TR.sage.opacity(0.15), lineWidth: 6).frame(width: 58, height: 58)
+            if let r = manager.resolution {
+                Circle().trim(from: 0, to: CGFloat(r))
+                    .stroke(LinearGradient(colors: [TR.sage, TR.gold], startPoint: .top, endPoint: .bottom),
+                            style: StrokeStyle(lineWidth: 6, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .frame(width: 58, height: 58)
+                Text("\(Int((r * 100).rounded()))%")
+                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                    .foregroundColor(.primary)
+            } else {
+                Image(systemName: "questionmark")
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundColor(TR.sage)
+            }
+        }
+    }
+}
+
+// MARK: - Sheet (questionnaire + reveal)
+
+struct TwinResolutionSheet: View {
+    @ObservedObject private var manager = TwinResolutionManager.shared
+    @Environment(\.dismiss) private var dismiss
+    @State private var draft: [String: Double] = [:]
+    @State private var revealed = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                if revealed {
+                    resultsView
+                } else {
+                    questionsView
+                }
+            }
+            .background(Color(.systemGroupedBackground).ignoresSafeArea())
+            .navigationTitle(revealed ? "How your Twin did" : "Twin Resolution")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .onAppear {
+            for q in manager.questions where draft[q.id] == nil {
+                draft[q.id] = manager.answers[q.id] ?? 0.5
+            }
+        }
+    }
+
+    // MARK: Questions
+
+    private var questionsView: some View {
+        VStack(spacing: 18) {
+            Text("Answer honestly about yourself. Then see what your Twin — built only from your entries — guessed about you.")
+                .font(.system(size: 14, design: .rounded))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20).padding(.top, 8)
+
+            ForEach(manager.questions) { q in
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(q.prompt)
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                        .foregroundColor(.primary)
+                    Slider(value: Binding(
+                        get: { draft[q.id] ?? 0.5 },
+                        set: { draft[q.id] = $0 }
+                    ), in: 0...1)
+                    .tint(TR.sage)
+                    HStack {
+                        Text(q.lowLabel); Spacer(); Text(q.highLabel)
+                    }
+                    .font(.system(size: 12, design: .rounded))
+                    .foregroundColor(.secondary)
+                }
+                .padding(16)
+                .background(RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color(.secondarySystemGroupedBackground)))
+                .padding(.horizontal, 16)
+            }
+
+            Button {
+                for q in manager.questions { manager.record(q.id, value: draft[q.id] ?? 0.5) }
+                withAnimation(.spring(response: 0.5)) { revealed = true }
+            } label: {
+                Text("Reveal how well your Twin knows you")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(LinearGradient(colors: [TR.sage, TR.sage.opacity(0.85)],
+                                               startPoint: .leading, endPoint: .trailing))
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            }
+            .padding(.horizontal, 16).padding(.vertical, 8)
+        }
+        .padding(.bottom, 24)
+    }
+
+    // MARK: Results
+
+    private var resultsView: some View {
+        VStack(spacing: 20) {
+            if let r = manager.resolution {
+                ZStack {
+                    Circle().stroke(TR.sage.opacity(0.15), lineWidth: 12).frame(width: 150, height: 150)
+                    Circle().trim(from: 0, to: CGFloat(r))
+                        .stroke(LinearGradient(colors: [TR.sage, TR.gold], startPoint: .top, endPoint: .bottom),
+                                style: StrokeStyle(lineWidth: 12, lineCap: .round))
+                        .rotationEffect(.degrees(-90)).frame(width: 150, height: 150)
+                    VStack(spacing: 2) {
+                        Text("\(Int((r * 100).rounded()))%")
+                            .font(.system(size: 40, weight: .bold, design: .rounded))
+                        Text("match").font(.system(size: 13, design: .rounded)).foregroundColor(.secondary)
+                    }
+                }
+                .padding(.top, 12)
+                Text(verdict(r))
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
+
+            VStack(spacing: 10) {
+                ForEach(manager.answeredQuestions) { q in resultRow(q) }
+            }
+            .padding(.horizontal, 16)
+
+            Text("Your Twin sharpens with every entry. Come back after journaling to watch this climb.")
+                .font(.system(size: 13, design: .rounded))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24).padding(.top, 4)
+        }
+        .padding(.bottom, 28)
+    }
+
+    private func resultRow(_ q: SelfPredictionQuestion) -> some View {
+        let userVal = manager.answers[q.id] ?? 0.5
+        let twinVal = q.twinValue()
+        let agree = manager.agreement(for: q) ?? 0
+        let twinGuess = twinVal >= 0.5 ? q.highLabel : q.lowLabel
+        return HStack(spacing: 12) {
+            Image(systemName: agree >= 0.75 ? "checkmark.circle.fill" : agree >= 0.5 ? "circle.lefthalf.filled" : "xmark.circle")
+                .font(.system(size: 20))
+                .foregroundColor(agree >= 0.75 ? TR.forest : agree >= 0.5 ? TR.gold : TR.coral)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(q.prompt).font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundColor(.primary).lineLimit(1)
+                Text("Twin guessed: \(twinGuess.lowercased())")
+                    .font(.system(size: 12, design: .rounded)).foregroundColor(.secondary)
+            }
+            Spacer()
+            Text("\(Int((agree * 100).rounded()))%")
+                .font(.system(size: 14, weight: .bold, design: .rounded))
+                .foregroundColor(agree >= 0.75 ? TR.forest : .secondary)
+        }
+        .padding(14)
+        .background(RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private func verdict(_ r: Double) -> String {
+        switch r {
+        case 0.85...: return "Your Twin already reads you like a book."
+        case 0.7..<0.85: return "Your Twin knows you well — and it's still early."
+        case 0.5..<0.7: return "Your Twin is getting to know you. Keep journaling."
+        default: return "Early days. The more you speak, the sharper your Twin gets."
+        }
+    }
+}
+
+private func pct(_ v: Double) -> String { "\(Int((v * 100).rounded()))%" }


### PR DESCRIPTION
First feature of the Digital-Twin focus push, and the research dossier's #1 ("build the eval harness first").

**What it does:** the Twin already computes personality traits from your entries but never measured whether it's *right*. Twin Resolution asks a few self-report questions that map to those traits, compares the Twin's estimate to your answer, and shows **"your Twin knows you N%"** — a score that climbs as the Twin learns.

- `TwinResolution.swift` — question bank (7 traits) + on-device agreement scoring + dated history. No engine changes, no new permissions.
- `TwinResolutionView.swift` — a meter card in the Twin tab + a questionnaire that reveals, per question, what the Twin guessed and whether it matched (the "it knows me" moment).
- Wired into `DigitalTwinView`.

**Why first:** you can't make the Twin *more* accurate without a number that says whether it's improving — and it makes the Twin's intelligence *felt*, which is the retention hook. Verified `BUILD SUCCEEDED`; **visual/device pass still pending** (the Twin tab is one of the slow-render screens flagged separately).