### PR TITLE
Fix: gate ConstellationView 30Hz timer so the Twin tab can idle

### DIFF
--- a/solyn/solyn/ConstellationView.swift
+++ b/solyn/solyn/ConstellationView.swift
@@ -8,6 +8,7 @@
 //
 
 import SwiftUI
+import Combine
 
 // MARK: - Star Data Model
 
@@ -38,7 +39,22 @@ struct ConstellationView: View {
 
     @State private var animationTime: Double = Date().timeIntervalSinceReferenceDate
     @State private var appeared = false
-    private let timer = Timer.publish(every: 1.0 / 30.0, on: .main, in: .common).autoconnect()
+    @State private var stars: [ConstellationStar] = []
+    @State private var starConnections: [ConstellationConnection] = []
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// UI-test / screenshot runs need the main run loop to go idle — a live
+    /// 30 Hz timer keeps XCUITest's quiescence wait spinning (~16 min per event).
+    /// Matches the launch arguments ScreenshotTests passes.
+    private static let animationsDisabledForTesting =
+        ProcessInfo.processInfo.arguments.contains("-UITesting") ||
+        ProcessInfo.processInfo.arguments.contains("-ScreenshotMode")
+
+    /// 30 Hz animation clock. Under UI testing the timer is never scheduled at
+    /// all (Empty publisher), so no per-tick commits happen and the app idles.
+    private let timer: AnyPublisher<Date, Never> = ConstellationView.animationsDisabledForTesting
+        ? Empty().eraseToAnyPublisher()
+        : Timer.publish(every: 1.0 / 30.0, on: .main, in: .common).autoconnect().eraseToAnyPublisher()
 
     // Palette
     private let warmGold   = Color(red: 0.831, green: 0.647, blue: 0.278)  // #D4A547
@@ -54,8 +70,6 @@ struct ConstellationView: View {
     var body: some View {
         GeometryReader { geo in
             let size = geo.size
-            let stars = generateStars(in: size)
-            let conns = buildConnections(stars: stars)
 
             Canvas { context, canvasSize in
                 let t = animationTime
@@ -67,7 +81,7 @@ struct ConstellationView: View {
                 drawNebulae(context: context, size: canvasSize, stars: stars, time: t)
 
                 // Layer 3: Connection lines
-                drawConnections(context: context, size: canvasSize, stars: stars, connections: conns, time: t)
+                drawConnections(context: context, size: canvasSize, stars: stars, connections: starConnections, time: t)
 
                 // Layer 4: Stars
                 drawStars(context: context, size: canvasSize, stars: stars, time: t)
@@ -77,7 +91,7 @@ struct ConstellationView: View {
                     drawCoreStar(context: context, size: canvasSize, time: t)
                 }
             }
-            .onReceive(timer) { _ in
+            .onReceive(reduceMotion ? Empty().eraseToAnyPublisher() : timer) { _ in
                 animationTime = Date().timeIntervalSinceReferenceDate
             }
             .overlay {
@@ -92,15 +106,29 @@ struct ConstellationView: View {
         }
         .aspectRatio(1.0, contentMode: .fit)
         .onAppear {
+            rebuildConstellation()
             withAnimation(.easeOut(duration: 2.0)) {
                 appeared = true
             }
         }
+        .onChange(of: starCount) { _, _ in rebuildConstellation() }
+        .onChange(of: starMoods) { _, _ in rebuildConstellation() }
+        .onChange(of: connections.count) { _, _ in rebuildConstellation() }
     }
 
     // MARK: - Star Generation (deterministic from count)
 
-    private func generateStars(in size: CGSize) -> [ConstellationStar] {
+    /// Stars and connections are deterministic functions of (starCount,
+    /// starMoods, connections) — positions are normalized 0-1, so canvas size
+    /// is not an input. Rebuild only when those inputs change instead of on
+    /// every body evaluation (which happens 30×/sec while animating).
+    private func rebuildConstellation() {
+        let newStars = generateStars()
+        stars = newStars
+        starConnections = buildConnections(stars: newStars)
+    }
+
+    private func generateStars() -> [ConstellationStar] {
         guard starCount > 0 else { return [] }
 
         var stars: [ConstellationStar] = []

--- a/solyn/solyn/DigitalTwinView.swift
+++ b/solyn/solyn/DigitalTwinView.swift
@@ -14,6 +14,13 @@ struct DigitalTwinView: View {
     @ObservedObject private var themeManager = ThemeManager.shared
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Matches the launch arguments ScreenshotTests passes. Repeat-forever
+    /// animations keep the run loop busy, so XCUITest never sees the app idle.
+    private static let animationsDisabledForTesting =
+        ProcessInfo.processInfo.arguments.contains("-UITesting") ||
+        ProcessInfo.processInfo.arguments.contains("-ScreenshotMode")
     @State private var selectedSection: TwinSection = .overview
     @State private var showingDetail = false
     @State private var animateOrb = false
@@ -80,11 +87,6 @@ struct DigitalTwinView: View {
         }
         .navigationTitle("Your Digital Twin")
         .background { WarmBackground() }
-        .onAppear {
-            withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
-                animateOrb = true
-            }
-        }
     }
 
     // MARK: - First-Time Twin Introduction
@@ -218,6 +220,15 @@ struct DigitalTwinView: View {
                     .foregroundColor(themeManager.secondaryTextColor.opacity(0.7))
             }
             .padding(.bottom, 20)
+        }
+        .onAppear {
+            // The pulsing core star is decorative. A repeat-forever animation
+            // never lets the run loop idle, so skip it under UI testing and
+            // respect Reduce Motion; the star simply stays at its dim state.
+            guard !Self.animationsDisabledForTesting && !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
+                animateOrb = true
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

The Digital Twin tab was pathologically slow under UI testing: `ScreenshotTests` test04 took **~17 min**, test05 ~15 min, test06 ~33 min, while every other test finished in 12s–1m. A forensic pass over the xcresult activity log showed the time was spent inside **"Wait for com.dailyvox.app to idle"** (~900–1050s per synthesized event), not rendering — the Twin tab never posted the event-loop-idle notification, so XCUITest's quiescence wait ran to its give-up timeout on every tap.

## Mechanism

1. **`ConstellationView`** ran a 30 Hz `Timer.publish` on the main run loop with an `onReceive` mutating `@State animationTime` every 33 ms — one SwiftUI commit per tick means the app is never quiescent.
2. `generateStars` + `buildConnections` ran inside the `GeometryReader` closure on **every body evaluation** (30×/sec), regenerating all stars/connections to feed a 5-layer Canvas with ~200 path fills per frame.
3. **`DigitalTwinView`** started a `repeatForever` orb animation in `onAppear` whose target (`animateOrb`) is only read by the empty-state view — it ran forever even when entries exist.

## Fix (production visuals unchanged)

- The timer publisher is `Empty` (never scheduled at all) when launched with `-UITesting` or `-ScreenshotMode` — exactly the arguments `ScreenshotTests` passes — and the subscription is dropped under Reduce Motion, so the constellation freezes gracefully with **zero per-tick commits**. Everything the timer drives (star pulse, dust twinkle, nebula breathing, connection dash phase, core-star breathe) freezes with it; no second run-loop-waking mechanism remains.
- Stars/connections are cached in `@State` and rebuilt only when their inputs change (`starCount`, `starMoods`, `connections.count`) — positions are normalized 0–1, so canvas size was never actually an input.
- The `repeatForever` orb animation moved into `firstTimeTwinView` (its only consumer) and is gated the same way.

## Measured

| | Before | After |
|---|---|---|
| `test04_DigitalTwin` test case | ~17 min (one ~960s idle-wait give-up) | **19.2–24.2 s** |
| Total `xcodebuild test` wall time (warm build) | — | **145 s** |

Verified: `xcodebuild build` succeeds; test04 passes twice (cold + warm); normal launches still animate (timer path untouched without the flags); Reduce Motion freezes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)