### PR TITLE
v1.5 Body Twin: the Twin gains a body (iPhone layer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to DailyVox are documented here.
 
+## [1.5.0] — 2026-07-04
+
+### Added
+- **Body Twin — the Twin gains a body.** With your permission, DailyVox reads five signals on this iPhone (sleep, morning HRV, resting heart rate, steps, mindful minutes) and freezes a small snapshot alongside each entry, tagged with your activity context (at rest / in motion) so a walk is never mistaken for a feeling
+- **Review before your Twin learns**: every captured signal waits in a review queue — *Keep* folds it into your Twin, *Let go* deletes it. Nothing reaches the Twin without your eyes on it. This gate is the foundation every future passive signal will flow through
+- **Body card** on the Twin tab: maturity (warming up → learning → ready), moments kept, and signals waiting
+- **Body whisper** on the Today screen: one calm line of context before you speak ("Slept 5h 20m. Take a breath.")
+- **Body & Mood insights**: honest correlations (sleep vs mood, steps vs mood) that appear only when there's enough data — patterns, never prescriptions
+- **Settings → Health**: master toggle, per-signal toggles, and "Wipe all health snapshots"
+- **Twin Resolution**: answer a few quick questions and see how well your Twin already knows you — "your Twin knows you N%," measured, not claimed
+- **Native Liquid Glass tab bar** on iOS 26 (warm classic bar preserved on earlier iOS)
+
+### Privacy
+- Health signals stay on this iPhone: never uploaded, never in iCloud/CloudKit, excluded from device backups. They leave the device only inside your encrypted export, locked with your key
+- Per-signal opt-outs filter *before* the HealthKit read — disabled signals are never queried
+- The widget extension has zero health access
+
+### Fixed
+- The Twin tab can rest: the constellation now animates without keeping the run loop busy, honors Reduce Motion, and pauses cleanly during UI tests (screenshot runs dropped from ~17 minutes to seconds)
+- Dark-theme legibility on the new Today cards
+
+### Build
+- `MARKETING_VERSION` 1.4.1 → 1.5.0
+- `CURRENT_PROJECT_VERSION` 18 → 19
+- HealthKit entitlement + Health/Motion usage descriptions added to the app target only
+
 ## [1.4.1] — 2026-07-04
 
 ### Added

--- a/solyn/solyn.xcodeproj/project.pbxproj
+++ b/solyn/solyn.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = SolynWidget/SolynWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = SolynWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "DailyVox Widgets";
@@ -430,7 +430,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dailyvox.app.DailyVoxWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -450,7 +450,7 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = SolynWidget/SolynWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = SolynWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "DailyVox Widgets";
@@ -461,7 +461,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dailyvox.app.DailyVoxWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -606,7 +606,7 @@
 				CODE_SIGN_ENTITLEMENTS = solyn/solyn.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_ASSET_PATHS = "\"solyn/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -629,7 +629,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dailyvox.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -650,7 +650,7 @@
 				CODE_SIGN_ENTITLEMENTS = solyn/solyn.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_ASSET_PATHS = "\"solyn/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -673,7 +673,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dailyvox.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -691,10 +691,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dailyvox.appTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -711,10 +711,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dailyvox.appTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -730,10 +730,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dailyvox.appUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -749,10 +749,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dailyvox.appUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/solyn/solyn/BackupExportView.swift
+++ b/solyn/solyn/BackupExportView.swift
@@ -196,19 +196,29 @@ struct BackupExportView: View {
         }
     }
     
+    @MainActor
     private func exportData() {
         isExporting = true
         HapticManager.shared.buttonTap()
-        
+
+        // Gather the Body Twin payload NOW, on the main actor, so the export
+        // carries one consistent snapshot of the three health stores (a Keep
+        // racing the background queue's file reads could otherwise tear it).
+        let bodyTwinPayload = selectedFormat == .encryptedBackup
+            ? ExportableBodyTwin.currentInMemory()
+            : nil
+
         DispatchQueue.global(qos: .userInitiated).async {
             do {
                 let url: URL
-                
+
                 switch selectedFormat {
                 case .json:
                     url = try BackupService.shared.exportToJSON(entries: entries)
                 case .encryptedBackup:
-                    url = try BackupService.shared.exportEncrypted(entries: entries, password: encryptionPassword)
+                    url = try BackupService.shared.exportEncrypted(entries: entries,
+                                                                   password: encryptionPassword,
+                                                                   bodyTwin: bodyTwinPayload)
                 case .text, .markdown, .csv, .pdf:
                     var filteredEntries = entries
 

--- a/solyn/solyn/BackupService.swift
+++ b/solyn/solyn/BackupService.swift
@@ -10,6 +10,7 @@
 import Foundation
 import CoreData
 import UniformTypeIdentifiers
+import DailyVoxTwinEngine
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -43,6 +44,18 @@ struct ExportableEntry: Codable, Identifiable {
     }
 }
 
+/// Body Twin data carried ONLY by the encrypted .dvx backup (format 1.1).
+/// Health signals never ride the plain JSON export — the password-protected
+/// file is the single way they leave this iPhone, user-initiated and
+/// user-held key. See BodyTwinStores.swift for the gathering side.
+struct ExportableBodyTwin: Codable {
+    let state: BodyTwin?
+    let keptSnapshots: [KeptSnapshot]
+    let pendingSnapshots: [PendingSnapshot]
+
+    var isEmpty: Bool { state == nil && keptSnapshots.isEmpty && pendingSnapshots.isEmpty }
+}
+
 /// Container for full backup data
 struct BackupData: Codable {
     let version: String
@@ -50,9 +63,11 @@ struct BackupData: Codable {
     let deviceName: String
     let entryCount: Int
     let entries: [ExportableEntry]
-    
-    init(entries: [ExportableEntry]) {
-        self.version = "1.0"
+    /// Optional so 1.0 backups decode unchanged and older app builds ignore it.
+    let bodyTwin: ExportableBodyTwin?
+
+    init(entries: [ExportableEntry], bodyTwin: ExportableBodyTwin? = nil) {
+        self.version = bodyTwin == nil ? "1.0" : "1.1"
         self.exportDate = Date()
         #if canImport(UIKit)
         self.deviceName = UIDevice.current.name
@@ -61,6 +76,7 @@ struct BackupData: Codable {
         #endif
         self.entryCount = entries.count
         self.entries = entries
+        self.bodyTwin = bodyTwin
     }
 }
 
@@ -434,7 +450,8 @@ final class BackupService {
     /// Export all entries as an encrypted .dvx file
     func exportEncrypted(entries: [DiaryEntry], password: String) throws -> URL {
         let exportableEntries = entries.map { ExportableEntry(from: $0) }
-        let backupData = BackupData(entries: exportableEntries)
+        let backupData = BackupData(entries: exportableEntries,
+                                    bodyTwin: ExportableBodyTwin.currentOnDisk())
 
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -487,6 +504,15 @@ final class BackupService {
 
         if importedCount > 0 {
             try context.save()
+        }
+
+        // Restore Body Twin data even when every entry already exists — on a
+        // fresh device CloudKit brings the entries back, but health data is
+        // local-only and can ONLY return through this encrypted backup.
+        if let bodyTwin = backupData.bodyTwin {
+            Task { @MainActor in
+                BodyTwinManager.shared.restoreFromBackup(bodyTwin)
+            }
         }
 
         return importedCount

--- a/solyn/solyn/BackupService.swift
+++ b/solyn/solyn/BackupService.swift
@@ -447,11 +447,17 @@ final class BackupService {
 
     // MARK: - Encrypted Export
 
-    /// Export all entries as an encrypted .dvx file
-    func exportEncrypted(entries: [DiaryEntry], password: String) throws -> URL {
+    /// Export all entries as an encrypted .dvx file.
+    ///
+    /// `bodyTwin` must be assembled on the main actor BEFORE hopping to the
+    /// export queue (`ExportableBodyTwin.currentInMemory()`), so the payload
+    /// is one consistent picture of the three Body Twin stores — a Keep
+    /// mid-export can no longer tear it.
+    func exportEncrypted(entries: [DiaryEntry], password: String,
+                         bodyTwin: ExportableBodyTwin?) throws -> URL {
         let exportableEntries = entries.map { ExportableEntry(from: $0) }
         let backupData = BackupData(entries: exportableEntries,
-                                    bodyTwin: ExportableBodyTwin.currentOnDisk())
+                                    bodyTwin: bodyTwin)
 
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601

--- a/solyn/solyn/BackupService.swift
+++ b/solyn/solyn/BackupService.swift
@@ -590,12 +590,12 @@ enum ExportFormat: String, CaseIterable, Identifiable {
 
     var description: String {
         switch self {
-        case .json: return "Full backup with all data. Can be imported back."
+        case .json: return "Full backup of your entries. Can be imported back."
         case .text: return "Simple readable format for archiving."
         case .markdown: return "Formatted text for notes apps."
         case .csv: return "Spreadsheet format for analysis."
         case .pdf: return "Beautiful formatted document."
-        case .encryptedBackup: return "Password-protected backup. Maximum privacy."
+        case .encryptedBackup: return "Password-protected backup, including your Body Twin's health data — the only export that carries it."
         }
     }
 }

--- a/solyn/solyn/BodyTwinCard.swift
+++ b/solyn/solyn/BodyTwinCard.swift
@@ -116,6 +116,9 @@ struct BodyTwinCard: View {
             }
             manager.recordAuthorizationRequested()
             manager.isEnabled = true
+            // Prime the Motion & Fitness prompt inside this connect moment,
+            // not mid entry-save (first CMMotionActivity query triggers it).
+            await ActivityContextDetector.shared.update()
         }
     }
 }

--- a/solyn/solyn/BodyTwinCard.swift
+++ b/solyn/solyn/BodyTwinCard.swift
@@ -67,8 +67,11 @@ struct BodyTwinCard: View {
                     }
                 }
                 .padding(16)
-                .background(RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(Color(.secondarySystemBackground)))
+                // Grouped-secondary matches every neighboring Twin-tab card
+                // (plain-secondary rendered cool gray on the warm ivory canvas
+                // in light, and a darker off-shade in Dark).
+                .background(RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(Color(.secondarySystemGroupedBackground)))
             }
             .buttonStyle(.plain)
             .disabled(isRequestingAccess)

--- a/solyn/solyn/BodyTwinCard.swift
+++ b/solyn/solyn/BodyTwinCard.swift
@@ -19,15 +19,31 @@ struct BodyTwinCard: View {
     @State private var showReview = false
     @State private var isRequestingAccess = false
 
+    /// The review queue stays reachable whenever anything is waiting — even
+    /// with the master toggle off. Keep is still an explicit act and Let go
+    /// must always be available; queued health data with no way to view or
+    /// discard it would break the review-before-learning promise.
+    private var opensReview: Bool {
+        twin.bodyTwin.isActive || queue.count > 0
+    }
+
+    /// Authorized but switched off in Settings, nothing waiting: a quiet
+    /// signpost, not a button. A tap here must NOT silently reverse an
+    /// explicit Settings opt-out — re-enabling lives in Settings → Health.
+    private var isQuietOffState: Bool {
+        !twin.bodyTwin.isActive && twin.bodyTwin.isAuthorized && queue.count == 0
+    }
+
     var body: some View {
         // Absent entirely on devices without HealthKit, matching Settings.
         if healthKit.isAvailable {
             Button {
-                if twin.bodyTwin.isActive {
+                if opensReview {
                     showReview = true
-                } else {
+                } else if !twin.bodyTwin.isAuthorized {
                     enableBodyTwin()
                 }
+                // isQuietOffState: deliberately inert.
             } label: {
                 HStack(spacing: 16) {
                     meter
@@ -41,12 +57,14 @@ struct BodyTwinCard: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
                     Spacer()
-                    if twin.bodyTwin.isActive && queue.count > 0 {
+                    if queue.count > 0 {
                         DSTag(text: "\(queue.count) waiting", tint: DS.Palette.gold)
                     }
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(.secondary.opacity(0.5))
+                    if !isQuietOffState {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(.secondary.opacity(0.5))
+                    }
                 }
                 .padding(16)
                 .background(RoundedRectangle(cornerRadius: 18, style: .continuous)
@@ -63,6 +81,16 @@ struct BodyTwinCard: View {
             return "Asking Health for permission…"
         }
         guard twin.bodyTwin.isActive else {
+            if queue.count > 0 {
+                // Off, but signals still await a decision — the tap opens
+                // the review sheet (Keep stays explicit, Let go always works).
+                return "Body Twin is off — tap to review or let go of what's still waiting."
+            }
+            if twin.bodyTwin.isAuthorized {
+                // Explicitly switched off — respect it. Point to Settings
+                // instead of re-enabling on a stray tap.
+                return "Body Twin is off. You can turn it back on in Settings → Health."
+            }
             return "Your Twin can learn what your body felt. Tap to begin."
         }
         let kept = twin.bodyTwin.entriesWithSnapshot

--- a/solyn/solyn/BodyTwinCard.swift
+++ b/solyn/solyn/BodyTwinCard.swift
@@ -1,0 +1,121 @@
+//
+//  BodyTwinCard.swift
+//  solyn
+//
+//  The Body dimension on the Twin tab: how far your Twin has come in learning
+//  what your body felt, and the doorway to the review queue. Deliberately
+//  static — no timers, no repeat-forever animations — so the Twin tab can go
+//  idle (the ScreenshotTests perf fix depends on it).
+//
+
+import SwiftUI
+import DailyVoxTwinEngine
+
+struct BodyTwinCard: View {
+    @ObservedObject private var twin = DigitalTwinEngine.shared
+    @ObservedObject private var healthKit = HealthKitService.shared
+    @ObservedObject private var queue = PendingSnapshotQueue.shared
+    @ObservedObject private var manager = BodyTwinManager.shared
+    @State private var showReview = false
+    @State private var isRequestingAccess = false
+
+    var body: some View {
+        // Absent entirely on devices without HealthKit, matching Settings.
+        if healthKit.isAvailable {
+            Button {
+                if twin.bodyTwin.isActive {
+                    showReview = true
+                } else {
+                    enableBodyTwin()
+                }
+            } label: {
+                HStack(spacing: 16) {
+                    meter
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Body Twin")
+                            .font(.system(size: 16, weight: .bold, design: .rounded))
+                            .foregroundColor(.primary)
+                        Text(subtitle)
+                            .font(.system(size: 13, weight: .regular, design: .rounded))
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer()
+                    if twin.bodyTwin.isActive && queue.count > 0 {
+                        DSTag(text: "\(queue.count) waiting", tint: DS.Palette.gold)
+                    }
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.secondary.opacity(0.5))
+                }
+                .padding(16)
+                .background(RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(Color(.secondarySystemBackground)))
+            }
+            .buttonStyle(.plain)
+            .disabled(isRequestingAccess)
+            .sheet(isPresented: $showReview) { BodyTwinReviewView() }
+        }
+    }
+
+    private var subtitle: String {
+        if isRequestingAccess {
+            return "Asking Health for permission…"
+        }
+        guard twin.bodyTwin.isActive else {
+            return "Your Twin can learn what your body felt. Tap to begin."
+        }
+        let kept = twin.bodyTwin.entriesWithSnapshot
+        switch twin.bodyTwin.maturity {
+        case .warmingUp:
+            return kept == 0
+                ? "Warming up — it learns only the moments you keep."
+                : "Warming up — \(kept) \(kept == 1 ? "moment" : "moments") kept so far."
+        case .learning:
+            return "Learning your rhythms — \(kept) moments kept."
+        case .ready:
+            return "Ready — it knows your body's rhythms from \(kept) kept moments."
+        }
+    }
+
+    private var meter: some View {
+        ZStack {
+            Circle()
+                .stroke(DS.Palette.terracotta.opacity(0.15), lineWidth: 6)
+                .frame(width: 58, height: 58)
+            if twin.bodyTwin.isActive {
+                // Quiet progress toward a stable baseline (30 kept moments).
+                Circle()
+                    .trim(from: 0, to: min(1, CGFloat(twin.bodyTwin.entriesWithSnapshot) / 30))
+                    .stroke(LinearGradient(colors: [DS.Palette.terracotta, DS.Palette.gold],
+                                           startPoint: .top, endPoint: .bottom),
+                            style: StrokeStyle(lineWidth: 6, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .frame(width: 58, height: 58)
+            }
+            Image(systemName: "figure.mind.and.body")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(twin.bodyTwin.isActive ? DS.Palette.terracotta : DS.Palette.sage)
+        }
+    }
+
+    /// Same enable flow as Settings → Health: the permission sheet completing
+    /// is all read-only HealthKit lets us know, so completion counts as
+    /// "asked" and the Twin turns on.
+    private func enableBodyTwin() {
+        guard !isRequestingAccess else { return }
+        isRequestingAccess = true
+        Task { @MainActor in
+            defer { isRequestingAccess = false }
+            if !healthKit.isAuthorized {
+                do {
+                    try await healthKit.requestAuthorization()
+                } catch {
+                    return
+                }
+            }
+            manager.recordAuthorizationRequested()
+            manager.isEnabled = true
+        }
+    }
+}

--- a/solyn/solyn/BodyTwinManager.swift
+++ b/solyn/solyn/BodyTwinManager.swift
@@ -138,6 +138,29 @@ final class BodyTwinManager: ObservableObject {
         PendingSnapshotQueue.shared.remove(id: id)
     }
 
+    // MARK: - Backup Restore
+
+    /// Restores Body Twin data from an encrypted backup (BackupService).
+    /// Snapshots land verbatim in their stores, deduped by id, and nothing is
+    /// ever re-folded or re-captured — a Keep decided on the old device stays
+    /// decided. The learned state is adopted only when the backup's Twin has
+    /// folded more than this device's, so a stale backup can never erase live
+    /// learning. Consent flags stay local: HealthKit authorization is
+    /// per-device and must be asked here anew.
+    func restoreFromBackup(_ payload: ExportableBodyTwin) {
+        PendingSnapshotQueue.shared.restore(payload.pendingSnapshots)
+        KeptSnapshotStore.shared.restore(payload.keptSnapshots)
+
+        guard var imported = payload.state else { return }
+        let local = DigitalTwinEngine.shared.bodyTwin
+        guard imported.entriesWithSnapshot > local.entriesWithSnapshot else { return }
+        imported.isAuthorized = local.isAuthorized
+        imported.isEnabledByUser = local.isEnabledByUser
+        let store = FileBodyTwinStateStore()
+        store.saveBodyTwin(imported)
+        DigitalTwinEngine.configureBodyTwinStore(store)
+    }
+
     // MARK: - Wipe
 
     /// Settings' "Wipe all health snapshots": clears the review queue, the

--- a/solyn/solyn/BodyTwinManager.swift
+++ b/solyn/solyn/BodyTwinManager.swift
@@ -97,6 +97,13 @@ final class BodyTwinManager: ObservableObject {
 
     // MARK: - Capture
 
+    /// Monotonic counter bumped by `wipeAllHealthData()`. A capture Task
+    /// suspends across several HealthKit round-trips; if the user completes
+    /// the destructive wipe inside that window, the resumed task must not
+    /// enqueue a fresh snapshot into the queue the wipe just promised to
+    /// clear. (The master toggle is covered by re-checking `isActive`.)
+    private var captureGeneration = 0
+
     /// Composes a background-context snapshot and, when it carries anything
     /// useful, adds it to the review queue — your Twin learns nothing until
     /// you tap Keep. Wired into TodayView's save flow after phase-1 save;
@@ -104,6 +111,7 @@ final class BodyTwinManager: ObservableObject {
     func captureSnapshotIfEligible(at moment: Date = Date()) async {
         guard DigitalTwinEngine.shared.bodyTwin.isActive,
               HealthKitService.shared.isAuthorized else { return }
+        let generation = captureGeneration
 
         let detector = ActivityContextDetector.shared
         let context = await detector.update()
@@ -111,9 +119,12 @@ final class BodyTwinManager: ObservableObject {
             at: moment,
             activityContext: context,
             activityConfidence: detector.currentConfidence,
-            minutesSinceLastWorkout: detector.minutesSinceLastWorkout
+            minutesSinceLastWorkout: detector.minutesSinceLastWorkout,
+            includedSignals: enabledSignals   // disabled signals are never queried
         )
 
+        // Belt-and-braces behind the includedSignals mask: nothing a user
+        // switched off may survive into the queue even if a read slips through.
         if !sleepEnabled     { snapshot.sleepHours = nil }
         if !hrvEnabled       { snapshot.morningHRVMs = nil }
         if !restingHREnabled { snapshot.restingHRBpm = nil }
@@ -121,7 +132,23 @@ final class BodyTwinManager: ObservableObject {
         if !mindfulEnabled   { snapshot.mindfulMinutesToday = nil }
 
         guard snapshot.hasUsefulData else { return }
+        // Re-check the gate after the awaits: a wipe or toggle-off completed
+        // mid-capture wins over the in-flight snapshot.
+        guard DigitalTwinEngine.shared.bodyTwin.isActive,
+              generation == captureGeneration else { return }
         PendingSnapshotQueue.shared.enqueue(snapshot)
+    }
+
+    /// The per-signal opt-outs as a `HealthSignalSet`, so composeSnapshot
+    /// only queries HealthKit for what the user left on.
+    var enabledSignals: HealthSignalSet {
+        var signals: HealthSignalSet = []
+        if sleepEnabled     { signals.insert(.sleep) }
+        if hrvEnabled       { signals.insert(.hrv) }
+        if restingHREnabled { signals.insert(.restingHR) }
+        if stepsEnabled     { signals.insert(.steps) }
+        if mindfulEnabled   { signals.insert(.mindful) }
+        return signals
     }
 
     // MARK: - Review Decisions
@@ -129,6 +156,12 @@ final class BodyTwinManager: ObservableObject {
     /// Keep — the only path by which a snapshot ever reaches the Twin.
     func keepSnapshot(id: UUID) {
         guard let snapshot = PendingSnapshotQueue.shared.keep(id: id) else { return }
+        // Fold-once invariant, belt-and-braces: if this id somehow re-entered
+        // the queue after already being kept (a duplicate slipping past the
+        // restore filters), drop it silently rather than double-fold the
+        // baseline. KeptSnapshotStore.append's own dedupe can't help here —
+        // it runs AFTER the fold.
+        guard !KeptSnapshotStore.shared.contains(id: id) else { return }
         DigitalTwinEngine.shared.foldHealthSnapshot(snapshot)
         KeptSnapshotStore.shared.append(id: id, snapshot: snapshot)
     }
@@ -147,9 +180,17 @@ final class BodyTwinManager: ObservableObject {
     /// folded more than this device's, so a stale backup can never erase live
     /// learning. Consent flags stay local: HealthKit authorization is
     /// per-device and must be asked here anew.
+    ///
+    /// Order matters: the kept store is restored FIRST so the pending merge
+    /// can drop anything already reviewed — a snapshot that was pending when
+    /// the backup was made but has been Kept since must not re-enter the
+    /// queue (a second Keep would double-fold it). Let-go decisions are
+    /// covered by the queue's own tombstone filter.
     func restoreFromBackup(_ payload: ExportableBodyTwin) {
-        PendingSnapshotQueue.shared.restore(payload.pendingSnapshots)
         KeptSnapshotStore.shared.restore(payload.keptSnapshots)
+        let keptIds = KeptSnapshotStore.shared.ids
+        PendingSnapshotQueue.shared.restore(
+            payload.pendingSnapshots.filter { !keptIds.contains($0.id) })
 
         guard var imported = payload.state else { return }
         let local = DigitalTwinEngine.shared.bodyTwin
@@ -169,6 +210,9 @@ final class BodyTwinManager: ObservableObject {
     /// only the two consent flags, then re-configures the store — which
     /// reloads the pristine state into the engine's published sub-model.
     func wipeAllHealthData() {
+        // Invalidate any capture Task currently suspended mid-HealthKit-read
+        // so it cannot enqueue into the queue this wipe clears.
+        captureGeneration += 1
         PendingSnapshotQueue.shared.wipe()
         KeptSnapshotStore.shared.wipe()
 

--- a/solyn/solyn/BodyTwinManager.swift
+++ b/solyn/solyn/BodyTwinManager.swift
@@ -40,6 +40,11 @@ final class BodyTwinManager: ObservableObject {
         didSet {
             defaults.set(isEnabled, forKey: Keys.enabled)
             DigitalTwinEngine.shared.setBodyTwinEnabled(isEnabled)
+            if !isEnabled {
+                // The user just said "stop using my body data" — the cached
+                // health line must not flash on the Record tab afterwards.
+                BodyWhisperProvider.shared.invalidate()
+            }
         }
     }
 

--- a/solyn/solyn/BodyTwinManager.swift
+++ b/solyn/solyn/BodyTwinManager.swift
@@ -171,6 +171,29 @@ final class BodyTwinManager: ObservableObject {
         KeptSnapshotStore.shared.append(id: id, snapshot: snapshot)
     }
 
+    /// Keep all — batch path for the review sheet's one-tap approval.
+    /// Looping `keepSnapshot(id:)` cost three synchronous file rewrites per
+    /// snapshot (pending.json, state.json, kept.json) on the main actor —
+    /// O(N²) encoding for one gesture. This drains the queue once, folds
+    /// through the engine's batch API (one publish, one state save), and
+    /// appends to the kept store in a single write: three writes total.
+    func keepAll() {
+        let drained = PendingSnapshotQueue.shared.drainAll()
+        guard !drained.isEmpty else { return }
+
+        // Fold-once invariant, same as keepSnapshot: anything already kept
+        // is dropped without folding.
+        let alreadyKept = KeptSnapshotStore.shared.ids
+        let fresh = drained.filter { !alreadyKept.contains($0.id) }
+        guard !fresh.isEmpty else { return }
+
+        DigitalTwinEngine.shared.foldHealthSnapshots(fresh.map(\.snapshot))
+        let keptAt = Date()
+        KeptSnapshotStore.shared.appendAll(fresh.map {
+            KeptSnapshot(id: $0.id, snapshot: $0.snapshot, keptAt: keptAt)
+        })
+    }
+
     /// Let go — deleted before the Twin ever saw it.
     func discardSnapshot(id: UUID) {
         PendingSnapshotQueue.shared.remove(id: id)

--- a/solyn/solyn/BodyTwinManager.swift
+++ b/solyn/solyn/BodyTwinManager.swift
@@ -1,0 +1,158 @@
+//
+//  BodyTwinManager.swift
+//  solyn
+//
+//  App-side coordinator for the Body Twin (v1.5): user preferences, the
+//  after-three-entries invite gate, snapshot capture into the review queue,
+//  the Keep / Let go decisions, and the wipe-everything escape hatch.
+//  All health data stays on this iPhone — see BodyTwinStores.swift.
+//
+
+import SwiftUI
+import DailyVoxTwinEngine
+
+@MainActor
+final class BodyTwinManager: ObservableObject {
+    static let shared = BodyTwinManager()
+
+    private let defaults = UserDefaults.standard
+
+    private enum Keys {
+        static let enabled          = "bodyTwin_enabled"
+        static let signalSleep      = "bodyTwin_signalSleep"
+        static let signalHRV        = "bodyTwin_signalHRV"
+        static let signalRestingHR  = "bodyTwin_signalRestingHR"
+        static let signalSteps      = "bodyTwin_signalSteps"
+        static let signalMindful    = "bodyTwin_signalMindful"
+        static let hasSeenInvite    = "bodyTwin_hasSeenInvite"
+        /// ReviewManager's saved-entry counter — the app's existing source of
+        /// truth for how many entries this person has made.
+        static let entryCount       = "reviewManager_entryCount"
+    }
+
+    // MARK: - Preferences
+
+    /// Master toggle, mirrored into the engine (`BodyTwin.isEnabledByUser`)
+    /// through the setter so pref and engine state move together. Defaults on
+    /// to match the engine — the real gate is authorization, which only the
+    /// user can grant.
+    @Published var isEnabled: Bool {
+        didSet {
+            defaults.set(isEnabled, forKey: Keys.enabled)
+            DigitalTwinEngine.shared.setBodyTwinEnabled(isEnabled)
+        }
+    }
+
+    /// Per-signal opt-outs. A signal switched off is nil-ed out of every
+    /// snapshot before it even reaches the review queue.
+    @Published var sleepEnabled: Bool     { didSet { defaults.set(sleepEnabled, forKey: Keys.signalSleep) } }
+    @Published var hrvEnabled: Bool       { didSet { defaults.set(hrvEnabled, forKey: Keys.signalHRV) } }
+    @Published var restingHREnabled: Bool { didSet { defaults.set(restingHREnabled, forKey: Keys.signalRestingHR) } }
+    @Published var stepsEnabled: Bool     { didSet { defaults.set(stepsEnabled, forKey: Keys.signalSteps) } }
+    @Published var mindfulEnabled: Bool   { didSet { defaults.set(mindfulEnabled, forKey: Keys.signalMindful) } }
+
+    @Published private(set) var hasSeenInvite: Bool {
+        didSet { defaults.set(hasSeenInvite, forKey: Keys.hasSeenInvite) }
+    }
+
+    private init() {
+        isEnabled        = Self.bool(Keys.enabled, default: true)
+        sleepEnabled     = Self.bool(Keys.signalSleep, default: true)
+        hrvEnabled       = Self.bool(Keys.signalHRV, default: true)
+        restingHREnabled = Self.bool(Keys.signalRestingHR, default: true)
+        stepsEnabled     = Self.bool(Keys.signalSteps, default: true)
+        mindfulEnabled   = Self.bool(Keys.signalMindful, default: true)
+        hasSeenInvite    = UserDefaults.standard.bool(forKey: Keys.hasSeenInvite)
+    }
+
+    private static func bool(_ key: String, default fallback: Bool) -> Bool {
+        UserDefaults.standard.object(forKey: key) == nil
+            ? fallback
+            : UserDefaults.standard.bool(forKey: key)
+    }
+
+    // MARK: - Invite Gate
+
+    var savedEntryCount: Int { defaults.integer(forKey: Keys.entryCount) }
+
+    /// One-time "your Twin can learn what your body felt" invite: shown only
+    /// after three entries of history, and never again once seen or once
+    /// HealthKit has been asked (Settings → Health remains the anytime path).
+    var shouldOfferInvite: Bool {
+        !hasSeenInvite
+            && !DigitalTwinEngine.shared.bodyTwin.isAuthorized
+            && savedEntryCount >= 3
+    }
+
+    func markInviteSeen() {
+        hasSeenInvite = true
+    }
+
+    /// Call after `HealthKitService.requestAuthorization()` completes so the
+    /// engine remembers the user has been asked (read grants are unknowable
+    /// by HealthKit design).
+    func recordAuthorizationRequested() {
+        DigitalTwinEngine.shared.setBodyTwinAuthorized(true)
+    }
+
+    // MARK: - Capture
+
+    /// Composes a background-context snapshot and, when it carries anything
+    /// useful, adds it to the review queue — your Twin learns nothing until
+    /// you tap Keep. Wired into TodayView's save flow after phase-1 save;
+    /// never called for onboarding seeds, Siri intents, imports, or edits.
+    func captureSnapshotIfEligible(at moment: Date = Date()) async {
+        guard DigitalTwinEngine.shared.bodyTwin.isActive,
+              HealthKitService.shared.isAuthorized else { return }
+
+        let detector = ActivityContextDetector.shared
+        let context = await detector.update()
+        var snapshot = await HealthKitService.shared.composeSnapshot(
+            at: moment,
+            activityContext: context,
+            activityConfidence: detector.currentConfidence,
+            minutesSinceLastWorkout: detector.minutesSinceLastWorkout
+        )
+
+        if !sleepEnabled     { snapshot.sleepHours = nil }
+        if !hrvEnabled       { snapshot.morningHRVMs = nil }
+        if !restingHREnabled { snapshot.restingHRBpm = nil }
+        if !stepsEnabled     { snapshot.stepsToday = nil }
+        if !mindfulEnabled   { snapshot.mindfulMinutesToday = nil }
+
+        guard snapshot.hasUsefulData else { return }
+        PendingSnapshotQueue.shared.enqueue(snapshot)
+    }
+
+    // MARK: - Review Decisions
+
+    /// Keep — the only path by which a snapshot ever reaches the Twin.
+    func keepSnapshot(id: UUID) {
+        guard let snapshot = PendingSnapshotQueue.shared.keep(id: id) else { return }
+        DigitalTwinEngine.shared.foldHealthSnapshot(snapshot)
+        KeptSnapshotStore.shared.append(id: id, snapshot: snapshot)
+    }
+
+    /// Let go — deleted before the Twin ever saw it.
+    func discardSnapshot(id: UUID) {
+        PendingSnapshotQueue.shared.remove(id: id)
+    }
+
+    // MARK: - Wipe
+
+    /// Settings' "Wipe all health snapshots": clears the review queue, the
+    /// kept store, and everything the Body Twin has learned. The engine has
+    /// no single reset call, so this persists a pristine `BodyTwin` carrying
+    /// only the two consent flags, then re-configures the store — which
+    /// reloads the pristine state into the engine's published sub-model.
+    func wipeAllHealthData() {
+        PendingSnapshotQueue.shared.wipe()
+        KeptSnapshotStore.shared.wipe()
+
+        let consent = DigitalTwinEngine.shared.bodyTwin
+        let store = FileBodyTwinStateStore()
+        store.saveBodyTwin(BodyTwin(isAuthorized: consent.isAuthorized,
+                                    isEnabledByUser: consent.isEnabledByUser))
+        DigitalTwinEngine.configureBodyTwinStore(store)
+    }
+}

--- a/solyn/solyn/BodyTwinReviewView.swift
+++ b/solyn/solyn/BodyTwinReviewView.swift
@@ -1,0 +1,197 @@
+//
+//  BodyTwinReviewView.swift
+//  solyn
+//
+//  Review before your Twin learns: each pending snapshot is shown exactly as
+//  captured, and nothing reaches the Twin until you tap Keep. Let go deletes
+//  the snapshot unseen.
+//
+
+import SwiftUI
+import DailyVoxTwinEngine
+
+struct BodyTwinReviewView: View {
+    @ObservedObject private var queue = PendingSnapshotQueue.shared
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                if queue.items.isEmpty {
+                    emptyState
+                } else {
+                    reviewList
+                }
+            }
+            .background(Color(.systemGroupedBackground).ignoresSafeArea())
+            .navigationTitle("Your body had a say")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    // MARK: Pending list
+
+    private var reviewList: some View {
+        VStack(spacing: 18) {
+            Text("These signals arrived with your recent entries. Keep what feels true — your Twin learns nothing until you do. Let go, and it's deleted.")
+                .font(.system(size: 14, design: .rounded))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20).padding(.top, 8)
+
+            ForEach(queue.items) { item in
+                snapshotRow(item)
+                    .padding(.horizontal, 16)
+            }
+
+            if queue.count >= 2 {
+                Button {
+                    keepAll()
+                } label: {
+                    Text("Keep all \(queue.count)")
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(LinearGradient(colors: [DS.Palette.sage, DS.Palette.sage.opacity(0.85)],
+                                                   startPoint: .leading, endPoint: .trailing))
+                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                }
+                .padding(.horizontal, 16).padding(.vertical, 8)
+            }
+        }
+        .padding(.bottom, 24)
+    }
+
+    private func snapshotRow(_ item: PendingSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(item.snapshot.capturedAt.formatted(date: .abbreviated, time: .shortened))
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .foregroundColor(.primary)
+                Spacer()
+                contextTag(item.snapshot.activityContext)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(signals(in: item.snapshot), id: \.text) { signal in
+                    HStack(spacing: 8) {
+                        Image(systemName: signal.icon)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(signal.color)
+                            .frame(width: 18)
+                        Text(signal.text)
+                            .font(.system(size: 13, design: .rounded))
+                            .foregroundColor(.primary)
+                    }
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    withAnimation(.spring(response: 0.35)) {
+                        BodyTwinManager.shared.discardSnapshot(id: item.id)
+                    }
+                } label: {
+                    Text("Let go")
+                        .font(.system(size: 14, weight: .semibold, design: .rounded))
+                        .foregroundColor(DS.Palette.coral)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(Capsule().fill(DS.Palette.coral.opacity(0.12)))
+                }
+                Button {
+                    withAnimation(.spring(response: 0.35)) {
+                        BodyTwinManager.shared.keepSnapshot(id: item.id)
+                    }
+                    HapticManager.shared.entrySaved()
+                } label: {
+                    Text("Keep")
+                        .font(.system(size: 14, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(Capsule().fill(DS.Palette.sage))
+                }
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(16)
+        .background(RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    // MARK: Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 34))
+                .foregroundColor(DS.Palette.gold)
+            Text("Nothing waiting")
+                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                .foregroundColor(.primary)
+            Text("When your body has something to add after an entry, it will rest here until you decide.")
+                .font(.system(size: 13, design: .rounded))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+        }
+        .padding(.top, 80)
+    }
+
+    // MARK: Rendering helpers
+
+    /// The activity tag, rendered honestly — it tells you how to read the
+    /// other numbers, never more than that.
+    private func contextTag(_ context: ActivityContext) -> some View {
+        let (label, tint): (String, Color) = {
+            switch context {
+            case .atRest:      return ("At rest", DS.Palette.sage)
+            case .active:      return ("In motion", DS.Palette.terracotta)
+            case .postWorkout: return ("Just after a workout", DS.Palette.gold)
+            case .unknown:     return ("Context unknown", DS.Palette.inkMute)
+            }
+        }()
+        return DSTag(text: label, tint: tint)
+    }
+
+    private func signals(in snapshot: HealthSnapshot) -> [(icon: String, color: Color, text: String)] {
+        var rows: [(icon: String, color: Color, text: String)] = []
+        if let sleep = snapshot.sleepHours {
+            rows.append(("moon.zzz.fill", DS.Palette.sage,
+                         String(format: "%.1f h sleep", sleep)))
+        }
+        if let hrv = snapshot.morningHRVMs {
+            rows.append(("waveform.path.ecg", DS.Palette.terracotta,
+                         "\(Int(hrv.rounded())) ms morning HRV"))
+        }
+        if let restingHR = snapshot.restingHRBpm {
+            rows.append(("heart.fill", DS.Palette.coral,
+                         "\(Int(restingHR.rounded())) bpm resting heart"))
+        }
+        if let steps = snapshot.stepsToday {
+            rows.append(("figure.walk", DS.Palette.gold,
+                         "\(steps.formatted()) steps"))
+        }
+        if let mindful = snapshot.mindfulMinutesToday {
+            rows.append(("leaf.fill", DS.Palette.forest,
+                         "\(mindful) mindful min"))
+        }
+        return rows
+    }
+
+    private func keepAll() {
+        withAnimation(.spring(response: 0.4)) {
+            for item in queue.items {
+                BodyTwinManager.shared.keepSnapshot(id: item.id)
+            }
+        }
+        HapticManager.shared.entrySaved()
+    }
+}

--- a/solyn/solyn/BodyTwinReviewView.swift
+++ b/solyn/solyn/BodyTwinReviewView.swift
@@ -188,9 +188,8 @@ struct BodyTwinReviewView: View {
 
     private func keepAll() {
         withAnimation(.spring(response: 0.4)) {
-            for item in queue.items {
-                BodyTwinManager.shared.keepSnapshot(id: item.id)
-            }
+            // Batch path: three file writes total, not three per snapshot.
+            BodyTwinManager.shared.keepAll()
         }
         HapticManager.shared.entrySaved()
     }

--- a/solyn/solyn/BodyTwinStores.swift
+++ b/solyn/solyn/BodyTwinStores.swift
@@ -1,0 +1,165 @@
+//
+//  BodyTwinStores.swift
+//  solyn
+//
+//  LOCAL-ONLY persistence for the Body Twin (v1.5).
+//
+//  Everything HealthKit-derived lives in Application Support/BodyTwin/ as
+//  plain JSON, excluded from device backup, and never touches Core Data or
+//  the CloudKit-synced AIState store (guideline 2.5.1 — see the engine's
+//  BodyTwinStateStore.swift for the full privacy boundary). Three stores
+//  share the directory:
+//
+//    state.json    — the engine's BodyTwin sub-model (FileBodyTwinStateStore)
+//    pending.json  — snapshots waiting for review before your Twin learns them
+//    kept.json     — snapshots the user chose to keep (for future insights)
+//
+
+import Foundation
+import DailyVoxTwinEngine
+
+// MARK: - Shared Directory
+
+/// Application Support/BodyTwin/, created on demand. The backup-exclusion
+/// flag is (re)applied on every access so health-derived JSON can never ride
+/// a device backup into iCloud, even for users upgrading from older installs.
+private enum BodyTwinFileStorage {
+
+    static var directory: URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        var dir = base.appendingPathComponent("BodyTwin", isDirectory: true)
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try? dir.setResourceValues(values)
+        return dir
+    }
+
+    static func read<T: Decodable>(_ type: T.Type, from fileName: String) -> T? {
+        guard let data = try? Data(contentsOf: directory.appendingPathComponent(fileName)) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+
+    static func write<T: Encodable>(_ value: T, to fileName: String) {
+        guard let data = try? JSONEncoder().encode(value) else { return }
+        try? data.write(to: directory.appendingPathComponent(fileName), options: [.atomic])
+    }
+
+    static func delete(_ fileName: String) {
+        try? FileManager.default.removeItem(at: directory.appendingPathComponent(fileName))
+    }
+}
+
+// MARK: - Body Twin State Store
+
+/// The app's concrete `BodyTwinStateStore`: baseline and counters as a local
+/// JSON file. Injected via `DigitalTwinEngine.configureBodyTwinStore(_:)` at
+/// launch (solynApp), beside the CloudKit-backed store the text Twin uses.
+final class FileBodyTwinStateStore: BodyTwinStateStore {
+
+    private let fileName = "state.json"
+
+    func loadBodyTwin() -> BodyTwin? {
+        BodyTwinFileStorage.read(BodyTwin.self, from: fileName)
+    }
+
+    func saveBodyTwin(_ bodyTwin: BodyTwin) {
+        BodyTwinFileStorage.write(bodyTwin, to: fileName)
+    }
+}
+
+// MARK: - Pending Snapshot Queue
+
+/// One snapshot waiting for review, keyed by its own id — snapshots are
+/// per-recording-session, not per-entry, so several can share a day.
+struct PendingSnapshot: Codable, Equatable, Identifiable {
+    let id: UUID
+    let snapshot: HealthSnapshot
+    let createdAt: Date
+}
+
+/// Snapshots your body offered, held for review before your Twin learns them.
+/// Nothing in this queue has touched the Twin: Keep hands a snapshot to
+/// `foldHealthSnapshot`, Let go deletes it unseen.
+@MainActor
+final class PendingSnapshotQueue: ObservableObject {
+    static let shared = PendingSnapshotQueue()
+
+    private let fileName = "pending.json"
+
+    @Published private(set) var items: [PendingSnapshot]
+
+    var count: Int { items.count }
+
+    private init() {
+        items = BodyTwinFileStorage.read([PendingSnapshot].self, from: fileName) ?? []
+    }
+
+    func enqueue(_ snapshot: HealthSnapshot) {
+        items.append(PendingSnapshot(id: UUID(), snapshot: snapshot, createdAt: Date()))
+        persist()
+    }
+
+    /// Let go — removed before the Twin ever saw it.
+    func remove(id: UUID) {
+        items.removeAll { $0.id == id }
+        persist()
+    }
+
+    /// Keep — dequeues and returns the snapshot so the caller can fold it
+    /// into the Twin and record it in `KeptSnapshotStore`.
+    func keep(id: UUID) -> HealthSnapshot? {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return nil }
+        let item = items.remove(at: index)
+        persist()
+        return item.snapshot
+    }
+
+    func wipe() {
+        items = []
+        persist()
+    }
+
+    private func persist() {
+        BodyTwinFileStorage.write(items, to: fileName)
+    }
+}
+
+// MARK: - Kept Snapshot Store
+
+/// A snapshot the user chose to keep, dated for calendar-day correlation.
+struct KeptSnapshot: Codable, Equatable, Identifiable {
+    let id: UUID
+    let snapshot: HealthSnapshot
+    let keptAt: Date
+}
+
+/// Append-only record of approved snapshots, so future insights can line up
+/// body signals with the day's mood. A day is ~10 small numbers, so all of
+/// them are kept; ids dedupe any repeated Keep.
+@MainActor
+final class KeptSnapshotStore {
+    static let shared = KeptSnapshotStore()
+
+    private let fileName = "kept.json"
+    private var cache: [KeptSnapshot]
+
+    private init() {
+        cache = BodyTwinFileStorage.read([KeptSnapshot].self, from: fileName) ?? []
+    }
+
+    func append(id: UUID, snapshot: HealthSnapshot, keptAt: Date = Date()) {
+        guard !cache.contains(where: { $0.id == id }) else { return }
+        cache.append(KeptSnapshot(id: id, snapshot: snapshot, keptAt: keptAt))
+        BodyTwinFileStorage.write(cache, to: fileName)
+    }
+
+    func loadAll() -> [KeptSnapshot] { cache }
+
+    func wipe() {
+        cache = []
+        BodyTwinFileStorage.delete(fileName)
+    }
+}

--- a/solyn/solyn/BodyTwinStores.swift
+++ b/solyn/solyn/BodyTwinStores.swift
@@ -25,6 +25,10 @@ import DailyVoxTwinEngine
 /// a device backup into iCloud, even for users upgrading from older installs.
 private enum BodyTwinFileStorage {
 
+    static let stateFile   = "state.json"
+    static let pendingFile = "pending.json"
+    static let keptFile    = "kept.json"
+
     static var directory: URL {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         var dir = base.appendingPathComponent("BodyTwin", isDirectory: true)
@@ -59,7 +63,7 @@ private enum BodyTwinFileStorage {
 /// launch (solynApp), beside the CloudKit-backed store the text Twin uses.
 final class FileBodyTwinStateStore: BodyTwinStateStore {
 
-    private let fileName = "state.json"
+    private let fileName = BodyTwinFileStorage.stateFile
 
     func loadBodyTwin() -> BodyTwin? {
         BodyTwinFileStorage.read(BodyTwin.self, from: fileName)
@@ -87,7 +91,7 @@ struct PendingSnapshot: Codable, Equatable, Identifiable {
 final class PendingSnapshotQueue: ObservableObject {
     static let shared = PendingSnapshotQueue()
 
-    private let fileName = "pending.json"
+    private let fileName = BodyTwinFileStorage.pendingFile
 
     @Published private(set) var items: [PendingSnapshot]
 
@@ -117,6 +121,17 @@ final class PendingSnapshotQueue: ObservableObject {
         return item.snapshot
     }
 
+    /// Backup restore: merge imported items in, deduped by id — a snapshot
+    /// already reviewed (or still waiting) on this device is never duplicated.
+    func restore(_ imported: [PendingSnapshot]) {
+        let existing = Set(items.map(\.id))
+        let added = imported.filter { !existing.contains($0.id) }
+        guard !added.isEmpty else { return }
+        items.append(contentsOf: added)
+        items.sort { $0.createdAt < $1.createdAt }
+        persist()
+    }
+
     func wipe() {
         items = []
         persist()
@@ -143,7 +158,7 @@ struct KeptSnapshot: Codable, Equatable, Identifiable {
 final class KeptSnapshotStore {
     static let shared = KeptSnapshotStore()
 
-    private let fileName = "kept.json"
+    private let fileName = BodyTwinFileStorage.keptFile
     private var cache: [KeptSnapshot]
 
     private init() {
@@ -158,8 +173,35 @@ final class KeptSnapshotStore {
 
     func loadAll() -> [KeptSnapshot] { cache }
 
+    /// Backup restore: merge imported snapshots in, deduped by id.
+    func restore(_ imported: [KeptSnapshot]) {
+        let existing = Set(cache.map(\.id))
+        let added = imported.filter { !existing.contains($0.id) }
+        guard !added.isEmpty else { return }
+        cache.append(contentsOf: added)
+        cache.sort { $0.keptAt < $1.keptAt }
+        BodyTwinFileStorage.write(cache, to: fileName)
+    }
+
     func wipe() {
         cache = []
         BodyTwinFileStorage.delete(fileName)
+    }
+}
+
+// MARK: - Backup Bridge
+
+extension ExportableBodyTwin {
+    /// Everything the Body Twin holds on disk, gathered for the encrypted
+    /// export. Safe to call off the main actor (BackupService runs on a
+    /// background queue): every store writes atomically from the main actor,
+    /// so a concurrent read always sees a complete file.
+    static func currentOnDisk() -> ExportableBodyTwin? {
+        let payload = ExportableBodyTwin(
+            state: BodyTwinFileStorage.read(BodyTwin.self, from: BodyTwinFileStorage.stateFile),
+            keptSnapshots: BodyTwinFileStorage.read([KeptSnapshot].self, from: BodyTwinFileStorage.keptFile) ?? [],
+            pendingSnapshots: BodyTwinFileStorage.read([PendingSnapshot].self, from: BodyTwinFileStorage.pendingFile) ?? []
+        )
+        return payload.isEmpty ? nil : payload
     }
 }

--- a/solyn/solyn/BodyTwinStores.swift
+++ b/solyn/solyn/BodyTwinStores.swift
@@ -25,11 +25,19 @@ import DailyVoxTwinEngine
 /// a device backup into iCloud, even for users upgrading from older installs.
 private enum BodyTwinFileStorage {
 
-    static let stateFile   = "state.json"
-    static let pendingFile = "pending.json"
-    static let keptFile    = "kept.json"
+    static let stateFile     = "state.json"
+    static let pendingFile   = "pending.json"
+    static let keptFile      = "kept.json"
+    /// Ids of snapshots the user Let go of (no snapshot data, just UUIDs) —
+    /// see `PendingSnapshotQueue.discardedIds`.
+    static let discardedFile = "discarded.json"
 
-    static var directory: URL {
+    /// Resolved once per launch: the directory is created and the exclusion
+    /// flag applied on first access each run (covering users upgrading from
+    /// older installs), then reused — store reads/writes happen on every
+    /// Keep, so re-running the fileExists/setResourceValues syscalls per
+    /// access was measurable churn for zero extra safety.
+    static let directory: URL = {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         var dir = base.appendingPathComponent("BodyTwin", isDirectory: true)
         if !FileManager.default.fileExists(atPath: dir.path) {
@@ -39,7 +47,7 @@ private enum BodyTwinFileStorage {
         values.isExcludedFromBackup = true
         try? dir.setResourceValues(values)
         return dir
-    }
+    }()
 
     static func read<T: Decodable>(_ type: T.Type, from fileName: String) -> T? {
         guard let data = try? Data(contentsOf: directory.appendingPathComponent(fileName)) else { return nil }
@@ -93,23 +101,42 @@ final class PendingSnapshotQueue: ObservableObject {
 
     private let fileName = BodyTwinFileStorage.pendingFile
 
+    /// Review is a decision, not a chore backlog: the queue holds at most
+    /// this many snapshots, dropping the OLDEST on overflow. Capture fires on
+    /// every entry save, so a daily journaler who ignores the sheet for
+    /// months would otherwise accumulate an unbounded pending.json — paid for
+    /// in first-Twin-tab decode time and a 3N-file-write "Keep all". 30 is
+    /// a month of daily signals; anything older was never going to be
+    /// meaningfully reviewed.
+    private static let maxPending = 30
+
+    /// Ids the user explicitly Let go of, persisted (ids only — the snapshot
+    /// data itself is deleted immediately). A backup exported while one of
+    /// these was still pending would otherwise resurrect it on re-import;
+    /// the tombstone keeps "Let go" deleted. Capped — see `recordTombstones`.
+    private(set) var discardedIds: [UUID]
+
     @Published private(set) var items: [PendingSnapshot]
 
     var count: Int { items.count }
 
     private init() {
         items = BodyTwinFileStorage.read([PendingSnapshot].self, from: fileName) ?? []
+        discardedIds = BodyTwinFileStorage.read([UUID].self, from: BodyTwinFileStorage.discardedFile) ?? []
     }
 
     func enqueue(_ snapshot: HealthSnapshot) {
         items.append(PendingSnapshot(id: UUID(), snapshot: snapshot, createdAt: Date()))
+        capOverflow()
         persist()
     }
 
-    /// Let go — removed before the Twin ever saw it.
+    /// Let go — removed before the Twin ever saw it, and tombstoned so no
+    /// backup re-import can bring it back for review.
     func remove(id: UUID) {
         items.removeAll { $0.id == id }
         persist()
+        recordTombstones([id])
     }
 
     /// Keep — dequeues and returns the snapshot so the caller can fold it
@@ -121,24 +148,63 @@ final class PendingSnapshotQueue: ObservableObject {
         return item.snapshot
     }
 
-    /// Backup restore: merge imported items in, deduped by id — a snapshot
-    /// already reviewed (or still waiting) on this device is never duplicated.
+    /// Keep all — drains the whole queue in one pass with a single
+    /// pending.json write, so the caller can batch-fold and batch-append
+    /// instead of paying three file rewrites per snapshot.
+    func drainAll() -> [PendingSnapshot] {
+        guard !items.isEmpty else { return [] }
+        let drained = items
+        items = []
+        persist()
+        return drained
+    }
+
+    /// Backup restore: merge imported items in, deduped against ids still
+    /// waiting here AND against the Let-go tombstones — a decided Discard
+    /// stays decided. The caller (`BodyTwinManager.restoreFromBackup`)
+    /// additionally filters out ids already in `KeptSnapshotStore`, so a
+    /// decided Keep is never re-queued (and never re-folded).
     func restore(_ imported: [PendingSnapshot]) {
         let existing = Set(items.map(\.id))
-        let added = imported.filter { !existing.contains($0.id) }
+        let discarded = Set(discardedIds)
+        let added = imported.filter { !existing.contains($0.id) && !discarded.contains($0.id) }
         guard !added.isEmpty else { return }
         items.append(contentsOf: added)
         items.sort { $0.createdAt < $1.createdAt }
+        capOverflow()
         persist()
     }
 
     func wipe() {
         items = []
         persist()
+        // A wipe is a full reset — tombstones are bookkeeping for the wiped
+        // queue and go with it.
+        discardedIds = []
+        BodyTwinFileStorage.delete(BodyTwinFileStorage.discardedFile)
     }
 
     private func persist() {
         BodyTwinFileStorage.write(items, to: fileName)
+    }
+
+    /// Enforces `maxPending`, dropping the oldest first (items are kept in
+    /// createdAt order).
+    private func capOverflow() {
+        if items.count > Self.maxPending {
+            items.removeFirst(items.count - Self.maxPending)
+        }
+    }
+
+    private func recordTombstones(_ ids: [UUID]) {
+        discardedIds.append(contentsOf: ids)
+        // Tombstones only need to outlive the backups a user plausibly
+        // re-imports; 200 ids (~3 KB of UUIDs) covers months of decisions
+        // without growing forever.
+        if discardedIds.count > 200 {
+            discardedIds.removeFirst(discardedIds.count - 200)
+        }
+        BodyTwinFileStorage.write(discardedIds, to: BodyTwinFileStorage.discardedFile)
     }
 }
 
@@ -154,6 +220,12 @@ struct KeptSnapshot: Codable, Equatable, Identifiable {
 /// Append-only record of approved snapshots, so future insights can line up
 /// body signals with the day's mood. A day is ~10 small numbers, so all of
 /// them are kept; ids dedupe any repeated Keep.
+///
+/// Accepted trade-off: every append re-encodes and rewrites the full file.
+/// At ~350 bytes/snapshot and 1–2 Keeps a day that is well under 1 MB after
+/// YEARS of daily journaling — sharding or compaction would be complexity
+/// without a felt win. Revisit only if the Watch release multiplies capture
+/// frequency.
 @MainActor
 final class KeptSnapshotStore {
     static let shared = KeptSnapshotStore()
@@ -171,7 +243,22 @@ final class KeptSnapshotStore {
         BodyTwinFileStorage.write(cache, to: fileName)
     }
 
+    /// Batch append for "Keep all": one dedupe pass, one file write.
+    func appendAll(_ newItems: [KeptSnapshot]) {
+        let existing = ids
+        let fresh = newItems.filter { !existing.contains($0.id) }
+        guard !fresh.isEmpty else { return }
+        cache.append(contentsOf: fresh)
+        BodyTwinFileStorage.write(cache, to: fileName)
+    }
+
     func loadAll() -> [KeptSnapshot] { cache }
+
+    /// All kept ids — the fold-once invariant's source of truth: an id in
+    /// here has already been folded into the Twin exactly once.
+    var ids: Set<UUID> { Set(cache.map(\.id)) }
+
+    func contains(id: UUID) -> Bool { cache.contains { $0.id == id } }
 
     /// Backup restore: merge imported snapshots in, deduped by id.
     func restore(_ imported: [KeptSnapshot]) {
@@ -192,15 +279,23 @@ final class KeptSnapshotStore {
 // MARK: - Backup Bridge
 
 extension ExportableBodyTwin {
-    /// Everything the Body Twin holds on disk, gathered for the encrypted
-    /// export. Safe to call off the main actor (BackupService runs on a
-    /// background queue): every store writes atomically from the main actor,
-    /// so a concurrent read always sees a complete file.
-    static func currentOnDisk() -> ExportableBodyTwin? {
+    /// Everything the Body Twin holds, gathered for the encrypted export
+    /// from the authoritative in-memory MainActor state — one consistent
+    /// payload. Re-reading the three files from the export's background
+    /// queue was a torn-read hazard: a Keep mid-export is a three-file
+    /// transaction (pending → state → kept), and interleaved per-file reads
+    /// could produce a backup whose snapshot is in NEITHER list or whose
+    /// counters disagree with kept.json. Gather here on the main actor; only
+    /// encode/encrypt/write happen off it.
+    @MainActor
+    static func currentInMemory() -> ExportableBodyTwin? {
+        let bodyTwin = DigitalTwinEngine.shared.bodyTwin
         let payload = ExportableBodyTwin(
-            state: BodyTwinFileStorage.read(BodyTwin.self, from: BodyTwinFileStorage.stateFile),
-            keptSnapshots: BodyTwinFileStorage.read([KeptSnapshot].self, from: BodyTwinFileStorage.keptFile) ?? [],
-            pendingSnapshots: BodyTwinFileStorage.read([PendingSnapshot].self, from: BodyTwinFileStorage.pendingFile) ?? []
+            // A pristine sub-model means the feature was never used — omit
+            // it so entry-only users keep emitting format-1.0 backups.
+            state: bodyTwin == BodyTwin() ? nil : bodyTwin,
+            keptSnapshots: KeptSnapshotStore.shared.loadAll(),
+            pendingSnapshots: PendingSnapshotQueue.shared.items
         )
         return payload.isEmpty ? nil : payload
     }

--- a/solyn/solyn/BodyTwinTodayCards.swift
+++ b/solyn/solyn/BodyTwinTodayCards.swift
@@ -1,0 +1,398 @@
+//
+//  BodyTwinTodayCards.swift
+//  solyn
+//
+//  TodayView's two idle-state Body Twin cards, mutually exclusive by
+//  construction (the whisper needs Health connected, the invite needs it
+//  not-yet-asked):
+//
+//    • Body whisper — one calm line of body context, cached per calendar day
+//      and recomputed at most every few hours, silent while in motion. It is
+//      context for the mic, never competition.
+//    • Permission invite — the one-time, value-framed doorway to HealthKit
+//      after three entries of trust; declining never nags again
+//      (Settings → Health stays the path back).
+//
+
+import SwiftUI
+import UIKit
+import DailyVoxTwinEngine
+
+// MARK: - Body Whisper
+
+/// One calm line of body context with its icon and tint.
+struct BodyWhisper: Equatable {
+    let icon: String
+    let tint: Color
+    let text: String
+}
+
+/// Computes and caches today's whisper. Static by design — no timers, no
+/// repeat animations — so TodayView's idle state stays idle-able.
+@MainActor
+final class BodyWhisperProvider: ObservableObject {
+    static let shared = BodyWhisperProvider()
+
+    @Published private(set) var whisper: BodyWhisper?
+
+    /// When today's whisper (or deliberate silence) was computed. Valid for
+    /// the calendar day, recomputed after a few hours at most.
+    private var computedAt: Date?
+    private let recomputeAfter: TimeInterval = 3 * 60 * 60
+
+    private init() {}
+
+    func refreshIfNeeded(now: Date = Date()) async {
+        guard DigitalTwinEngine.shared.bodyTwin.isActive,
+              HealthKitService.shared.isAuthorized else {
+            // Deliberately uncached: the moment Health is connected, the
+            // next refresh may speak.
+            computedAt = nil
+            setWhisper(nil)
+            return
+        }
+        if let computedAt,
+           Calendar.current.isDate(computedAt, inSameDayAs: now),
+           now.timeIntervalSince(computedAt) < recomputeAfter {
+            return
+        }
+        computedAt = now
+
+        let detector = ActivityContextDetector.shared
+        let context = await detector.update()
+        // Mid-motion is no moment for quiet context.
+        guard context != .active else {
+            setWhisper(nil)
+            return
+        }
+
+        var snapshot = await HealthKitService.shared.composeSnapshot(
+            at: now,
+            activityContext: context,
+            activityConfidence: detector.currentConfidence,
+            minutesSinceLastWorkout: detector.minutesSinceLastWorkout
+        )
+        // Honor the same per-signal opt-outs the review queue honors.
+        let manager = BodyTwinManager.shared
+        if !manager.sleepEnabled     { snapshot.sleepHours = nil }
+        if !manager.hrvEnabled       { snapshot.morningHRVMs = nil }
+        if !manager.restingHREnabled { snapshot.restingHRBpm = nil }
+        if !manager.stepsEnabled     { snapshot.stepsToday = nil }
+        if !manager.mindfulEnabled   { snapshot.mindfulMinutesToday = nil }
+
+        guard snapshot.hasUsefulData else {
+            setWhisper(nil)
+            return
+        }
+        setWhisper(Self.compose(from: snapshot))
+    }
+
+    private func setWhisper(_ newWhisper: BodyWhisper?) {
+        guard newWhisper != whisper else { return }
+        if UIAccessibility.isReduceMotionEnabled {
+            whisper = newWhisper
+        } else {
+            withAnimation(.spring(response: 0.4)) { whisper = newWhisper }
+        }
+    }
+
+    /// Sleep first (most felt), then movement, then stillness. Heart numbers
+    /// stay out of the whisper — a bare HRV reading reads clinical, and the
+    /// whisper promises calm, not diagnosis.
+    private static func compose(from snapshot: HealthSnapshot) -> BodyWhisper? {
+        if let sleep = snapshot.sleepHours {
+            let slept = formatHours(sleep)
+            if sleep < 6 {
+                return BodyWhisper(icon: "moon.zzz.fill", tint: DS.Palette.gold,
+                                   text: "You slept \(slept). Take a breath before you speak.")
+            }
+            if sleep < 7 {
+                return BodyWhisper(icon: "moon.zzz.fill", tint: DS.Palette.sage,
+                                   text: "Slept \(slept) — ease into today gently.")
+            }
+            return BodyWhisper(icon: "moon.zzz.fill", tint: DS.Palette.sage,
+                               text: "Slept \(slept) — your sky is clear.")
+        }
+        if let steps = snapshot.stepsToday, steps >= 6000 {
+            return BodyWhisper(icon: "figure.walk", tint: DS.Palette.gold,
+                               text: "\(steps.formatted()) steps already — your day is in motion.")
+        }
+        if let mindful = snapshot.mindfulMinutesToday, mindful > 0 {
+            return BodyWhisper(icon: "leaf.fill", tint: DS.Palette.forest,
+                               text: mindful == 1
+                                   ? "1 quiet minute today — carry that calm in."
+                                   : "\(mindful) quiet minutes today — carry that calm in.")
+        }
+        return nil
+    }
+
+    private static func formatHours(_ hours: Double) -> String {
+        let totalMinutes = Int((hours * 60).rounded())
+        let h = totalMinutes / 60
+        let m = totalMinutes % 60
+        return m == 0 ? "\(h)h" : "\(h)h \(m)m"
+    }
+}
+
+// MARK: - Idle Cards (TodayView slot)
+
+/// The single Body Twin slot between TodayView's header and entry card.
+/// Renders the one-time invite, or today's whisper, or nothing.
+struct BodyTwinIdleCards: View {
+    @ObservedObject private var healthKit = HealthKitService.shared
+    @ObservedObject private var manager = BodyTwinManager.shared
+    @ObservedObject private var whisperProvider = BodyWhisperProvider.shared
+    @State private var showInviteSheet = false
+
+    var body: some View {
+        // Absent entirely on devices without HealthKit, matching Settings.
+        if healthKit.isAvailable {
+            if manager.shouldOfferInvite {
+                inviteCard
+            } else if let whisper = whisperProvider.whisper {
+                whisperCard(whisper)
+            }
+        }
+    }
+
+    // MARK: Whisper card
+
+    private func whisperCard(_ whisper: BodyWhisper) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: whisper.icon)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(whisper.tint)
+            Text(whisper.text)
+                .font(.dsCallout)
+                .foregroundColor(DS.Palette.inkSoft)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, DS.Space.md)
+        .padding(.vertical, DS.Space.sm)
+        .background(
+            RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
+                .fill(whisper.tint.opacity(0.10))
+        )
+        .transition(.opacity)
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: Invite card
+
+    private var inviteCard: some View {
+        Button {
+            HapticManager.shared.buttonTap()
+            showInviteSheet = true
+        } label: {
+            HStack(spacing: DS.Space.sm) {
+                ZStack {
+                    Circle()
+                        .fill(DS.Palette.tintTerra)
+                        .frame(width: 40, height: 40)
+                    Image(systemName: "figure.mind.and.body")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundColor(DS.Palette.terracotta)
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Your Twin can learn what your body felt")
+                        .font(.dsCallout)
+                        .foregroundColor(DS.Palette.ink)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("Sleep, steps, quiet minutes — you approve every signal first.")
+                        .font(.dsCaption)
+                        .foregroundColor(DS.Palette.inkMute)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(DS.Palette.inkMute.opacity(0.6))
+            }
+            .padding(DS.Space.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
+                    .fill(ThemeManager.shared.warmCardBackground)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
+                    .stroke(DS.Palette.gold.opacity(0.25), lineWidth: 1)
+            )
+            .dsShadowSoft()
+        }
+        .buttonStyle(SpringPressStyle(scale: 0.97))
+        .transition(.opacity)
+        .sheet(isPresented: $showInviteSheet, onDismiss: {
+            // Any way the sheet closes counts as seen — one gentle ask, ever.
+            withAnimation(.spring(response: 0.4)) {
+                manager.markInviteSeen()
+            }
+        }) {
+            BodyTwinInviteSheet()
+        }
+    }
+}
+
+// MARK: - Invite Explainer Sheet
+
+/// The five signals, the review-before-learning promise, and the
+/// private-by-design line — then one soft yes and one soft no.
+struct BodyTwinInviteSheet: View {
+    @ObservedObject private var healthKit = HealthKitService.shared
+    @ObservedObject private var manager = BodyTwinManager.shared
+    @Environment(\.dismiss) private var dismiss
+    @State private var isRequestingAccess = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    header
+                    signalsList
+                    promises
+                    actions
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 16)
+                .padding(.bottom, 32)
+            }
+            .background(Color(.systemGroupedBackground).ignoresSafeArea())
+            .navigationTitle("Your body's side of the story")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(DS.Palette.terracotta.opacity(0.15))
+                    .frame(width: 64, height: 64)
+                Image(systemName: "figure.mind.and.body")
+                    .font(.system(size: 28, weight: .semibold))
+                    .foregroundColor(DS.Palette.terracotta)
+            }
+            Text("Your Twin can learn what your body felt")
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .foregroundColor(.primary)
+                .multilineTextAlignment(.center)
+            Text("Some days the body speaks first — short sleep, a long walk, a quiet morning. Connect Health and your Twin can hear that side of you too.")
+                .font(.system(size: 14, design: .rounded))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private var signalsList: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            signalRow(icon: "moon.zzz.fill", color: DS.Palette.sage,
+                      name: "Sleep", detail: "Hours of rest the night before")
+            signalRow(icon: "waveform.path.ecg", color: DS.Palette.terracotta,
+                      name: "Morning HRV", detail: "How your heart greeted the day")
+            signalRow(icon: "heart.fill", color: DS.Palette.coral,
+                      name: "Resting heart", detail: "Your calm baseline, not your peaks")
+            signalRow(icon: "figure.walk", color: DS.Palette.gold,
+                      name: "Steps", detail: "How far the day carried you")
+            signalRow(icon: "leaf.fill", color: DS.Palette.forest,
+                      name: "Mindful minutes", detail: "Quiet minutes you set aside")
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private func signalRow(icon: String, color: Color, name: String, detail: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(color)
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(name)
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .foregroundColor(.primary)
+                Text(detail)
+                    .font(.system(size: 12, design: .rounded))
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private var promises: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            promiseRow(icon: "sparkles", color: DS.Palette.gold,
+                       text: "Review before your Twin learns. Every signal waits for you — Keep what feels true, let go of the rest.")
+            promiseRow(icon: "lock.shield.fill", color: DS.Palette.sage,
+                       text: "Private by design. Health signals stay on this iPhone — never uploaded, never synced.")
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private func promiseRow(icon: String, color: Color, text: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(color)
+                .frame(width: 22)
+            Text(text)
+                .font(.system(size: 13, design: .rounded))
+                .foregroundColor(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var actions: some View {
+        VStack(spacing: 12) {
+            Button {
+                connectHealth()
+            } label: {
+                Text(isRequestingAccess ? "Asking Health…" : "Connect Health")
+            }
+            .buttonStyle(.dsPrimary)
+            .disabled(isRequestingAccess)
+
+            // The sheet's onDismiss marks the invite seen — asked once, ever.
+            // Settings → Health stays the anytime path back.
+            Button("Maybe later") {
+                dismiss()
+            }
+            .font(.dsCallout)
+            .foregroundColor(.secondary)
+            .disabled(isRequestingAccess)
+        }
+    }
+
+    /// Same enable flow as Settings → Health and the Twin-tab card: the
+    /// permission sheet completing is all read-only HealthKit lets us know,
+    /// so completion counts as "asked" and the Twin turns on.
+    private func connectHealth() {
+        guard !isRequestingAccess else { return }
+        isRequestingAccess = true
+        Task { @MainActor in
+            defer { isRequestingAccess = false }
+            if !healthKit.isAuthorized {
+                do {
+                    try await healthKit.requestAuthorization()
+                } catch {
+                    return // sheet failed to appear — stay, so they can retry
+                }
+            }
+            manager.recordAuthorizationRequested()
+            manager.isEnabled = true
+            HapticManager.shared.entrySaved()
+            dismiss()
+            // The whisper may now have something to say for today.
+            await BodyWhisperProvider.shared.refreshIfNeeded()
+        }
+    }
+}

--- a/solyn/solyn/BodyTwinTodayCards.swift
+++ b/solyn/solyn/BodyTwinTodayCards.swift
@@ -259,12 +259,14 @@ struct BodyTwinIdleCards: View {
             }
             .padding(DS.Space.md)
             .frame(maxWidth: .infinity, alignment: .leading)
+            // 20pt like the entry card stacked directly beneath it — the two
+            // full-width Today cards should share one corner radius.
             .background(
-                RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
                     .fill(theme.warmCardBackground)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
                     .stroke(DS.Palette.gold.opacity(0.25), lineWidth: 1)
             )
             .dsShadowSoft()

--- a/solyn/solyn/BodyTwinTodayCards.swift
+++ b/solyn/solyn/BodyTwinTodayCards.swift
@@ -157,7 +157,15 @@ struct BodyTwinIdleCards: View {
     @ObservedObject private var healthKit = HealthKitService.shared
     @ObservedObject private var manager = BodyTwinManager.shared
     @ObservedObject private var whisperProvider = BodyWhisperProvider.shared
+    @ObservedObject private var theme = ThemeManager.shared
     @State private var showInviteSheet = false
+
+    // Fixed warm inks belong to the ivory theme only; every other theme sits
+    // on system backgrounds, so text must use system adaptive colors or it
+    // vanishes in Dark (ThemeManager's own `ivory ? warm : system` pattern).
+    private var inkPrimary: Color   { theme.selectedTheme == .ivory ? DS.Palette.ink : .primary }
+    private var inkSecondary: Color { theme.selectedTheme == .ivory ? DS.Palette.inkSoft : .primary }
+    private var inkMuted: Color     { theme.selectedTheme == .ivory ? DS.Palette.inkMute : .secondary }
 
     var body: some View {
         // Absent entirely on devices without HealthKit, matching Settings.
@@ -179,7 +187,7 @@ struct BodyTwinIdleCards: View {
                 .foregroundColor(whisper.tint)
             Text(whisper.text)
                 .font(.dsCallout)
-                .foregroundColor(DS.Palette.inkSoft)
+                .foregroundColor(inkSecondary)
                 .fixedSize(horizontal: false, vertical: true)
             Spacer(minLength: 0)
         }
@@ -212,23 +220,23 @@ struct BodyTwinIdleCards: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Your Twin can learn what your body felt")
                         .font(.dsCallout)
-                        .foregroundColor(DS.Palette.ink)
+                        .foregroundColor(inkPrimary)
                         .fixedSize(horizontal: false, vertical: true)
                     Text("Sleep, steps, quiet minutes — you approve every signal first.")
                         .font(.dsCaption)
-                        .foregroundColor(DS.Palette.inkMute)
+                        .foregroundColor(inkMuted)
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 0)
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(DS.Palette.inkMute.opacity(0.6))
+                    .foregroundColor(inkMuted.opacity(0.6))
             }
             .padding(DS.Space.md)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)
-                    .fill(ThemeManager.shared.warmCardBackground)
+                    .fill(theme.warmCardBackground)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: DS.Radius.md, style: .continuous)

--- a/solyn/solyn/BodyTwinTodayCards.swift
+++ b/solyn/solyn/BodyTwinTodayCards.swift
@@ -43,6 +43,21 @@ final class BodyWhisperProvider: ObservableObject {
     private init() {}
 
     func refreshIfNeeded(now: Date = Date()) async {
+        // SCREENSHOT-ONLY: the simulator's Health store is always empty, so
+        // composeSnapshot would yield permanent silence. Under -ScreenshotMode
+        // (set exclusively by the UI-test harness) we pin the snapshot a real
+        // 6h 54m night would produce and let the normal composer phrase it.
+        let arguments = ProcessInfo.processInfo.arguments
+        if arguments.contains("-ScreenshotMode") && !arguments.contains("-BodyTwinInviteDemo") {
+            setWhisper(Self.compose(from: HealthSnapshot(
+                capturedAt: now,
+                activityContext: .atRest,
+                sleepHours: 6.9,
+                activityConfidence: 0.95
+            )))
+            return
+        }
+
         guard DigitalTwinEngine.shared.bodyTwin.isActive,
               HealthKitService.shared.isAuthorized else {
             // Deliberately uncached: the moment Health is connected, the

--- a/solyn/solyn/BodyTwinTodayCards.swift
+++ b/solyn/solyn/BodyTwinTodayCards.swift
@@ -81,14 +81,15 @@ final class BodyWhisperProvider: ObservableObject {
             return
         }
 
+        let manager = BodyTwinManager.shared
         var snapshot = await HealthKitService.shared.composeSnapshot(
             at: now,
             activityContext: context,
             activityConfidence: detector.currentConfidence,
-            minutesSinceLastWorkout: detector.minutesSinceLastWorkout
+            minutesSinceLastWorkout: detector.minutesSinceLastWorkout,
+            includedSignals: manager.enabledSignals   // opt-outs filter the reads themselves
         )
-        // Honor the same per-signal opt-outs the review queue honors.
-        let manager = BodyTwinManager.shared
+        // Belt-and-braces behind the includedSignals mask, mirroring capture.
         if !manager.sleepEnabled     { snapshot.sleepHours = nil }
         if !manager.hrvEnabled       { snapshot.morningHRVMs = nil }
         if !manager.restingHREnabled { snapshot.restingHRBpm = nil }
@@ -353,7 +354,7 @@ struct BodyTwinInviteSheet: View {
             promiseRow(icon: "sparkles", color: DS.Palette.gold,
                        text: "Review before your Twin learns. Every signal waits for you — Keep what feels true, let go of the rest.")
             promiseRow(icon: "lock.shield.fill", color: DS.Palette.sage,
-                       text: "Private by design. Health signals stay on this iPhone — never uploaded, never synced.")
+                       text: "Private by design. Health and motion signals stay on this iPhone — never uploaded, never synced. iOS will also ask about motion, so moving days are read in context.")
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/solyn/solyn/BodyTwinTodayCards.swift
+++ b/solyn/solyn/BodyTwinTodayCards.swift
@@ -58,6 +58,17 @@ final class BodyWhisperProvider: ObservableObject {
             return
         }
 
+        // Cold-launch re-sync: the engine's persisted isActive loads
+        // synchronously at launch, but HealthKitService.isAuthorized starts
+        // false until its async getRequestStatusForAuthorization round-trip
+        // lands — and TodayView's .task reliably wins that race. Without
+        // this, an authorized user's whisper is absent on every cold launch
+        // until the app is backgrounded and foregrounded once.
+        if DigitalTwinEngine.shared.bodyTwin.isActive,
+           !HealthKitService.shared.isAuthorized {
+            await HealthKitService.shared.refreshAuthorizationState()
+        }
+
         guard DigitalTwinEngine.shared.bodyTwin.isActive,
               HealthKitService.shared.isAuthorized else {
             // Deliberately uncached: the moment Health is connected, the
@@ -101,6 +112,15 @@ final class BodyWhisperProvider: ObservableObject {
             return
         }
         setWhisper(Self.compose(from: snapshot))
+    }
+
+    /// Synchronously drops the cached whisper. Called when the user turns
+    /// Body Twin off, so the health-derived line can never flash back on the
+    /// Record tab after they said "stop" (the async refresh would only clear
+    /// it a frame or two later).
+    func invalidate() {
+        computedAt = nil
+        setWhisper(nil)
     }
 
     private func setWhisper(_ newWhisper: BodyWhisper?) {
@@ -158,6 +178,7 @@ struct BodyTwinIdleCards: View {
     @ObservedObject private var healthKit = HealthKitService.shared
     @ObservedObject private var manager = BodyTwinManager.shared
     @ObservedObject private var whisperProvider = BodyWhisperProvider.shared
+    @ObservedObject private var twin = DigitalTwinEngine.shared
     @ObservedObject private var theme = ThemeManager.shared
     @State private var showInviteSheet = false
 
@@ -173,7 +194,10 @@ struct BodyTwinIdleCards: View {
         if healthKit.isAvailable {
             if manager.shouldOfferInvite {
                 inviteCard
-            } else if let whisper = whisperProvider.whisper {
+            } else if twin.bodyTwin.isActive, let whisper = whisperProvider.whisper {
+                // Render-time gate on the engine flag: a cached whisper must
+                // never appear after the user disabled Body Twin (the
+                // provider is also invalidated on disable — belt and braces).
                 whisperCard(whisper)
             }
         }

--- a/solyn/solyn/DigitalTwinView.swift
+++ b/solyn/solyn/DigitalTwinView.swift
@@ -53,6 +53,9 @@ struct DigitalTwinView: View {
                     // How well the Twin actually knows you (self-prediction fidelity)
                     TwinResolutionCard()
 
+                    // The Body dimension + review-before-learning queue
+                    BodyTwinCard()
+
                     // Section Picker
                     sectionPicker
 

--- a/solyn/solyn/DigitalTwinView.swift
+++ b/solyn/solyn/DigitalTwinView.swift
@@ -130,10 +130,10 @@ struct DigitalTwinView: View {
                 VStack(spacing: 8) {
                     ZStack {
                         Circle()
-                            .fill(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(animateOrb ? 0.12 : 0.06))
+                            .fill(DS.Palette.gold.opacity(animateOrb ? 0.12 : 0.06))
                             .frame(width: 60, height: 60)
                         Circle()
-                            .fill(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.3))
+                            .fill(DS.Palette.gold.opacity(0.3))
                             .frame(width: 24, height: 24)
                         Circle()
                             .fill(Color(red: 0.957, green: 0.933, blue: 0.878).opacity(0.7))
@@ -168,7 +168,7 @@ struct DigitalTwinView: View {
                     icon: "mic.circle.fill",
                     title: "You speak",
                     description: "Record a voice entry on the Record tab. 42 seconds is the sweet spot — take as long as you need.",
-                    color: Color(red: 0.357, green: 0.486, blue: 0.420),
+                    color: DS.Palette.sage,
                     isLast: false
                 )
                 twinIntroStep(
@@ -176,7 +176,7 @@ struct DigitalTwinView: View {
                     icon: "sparkle",
                     title: "Stars appear",
                     description: "Each entry becomes a star in your constellation, colored by mood.",
-                    color: Color(red: 0.831, green: 0.647, blue: 0.278),
+                    color: DS.Palette.gold,
                     isLast: false
                 )
                 twinIntroStep(
@@ -192,7 +192,7 @@ struct DigitalTwinView: View {
                     icon: "lock.shield.fill",
                     title: "Always private",
                     description: "Everything stays on your device. No servers. No cloud AI. No accounts.",
-                    color: Color(red: 0.420, green: 0.620, blue: 0.482),
+                    color: DS.Palette.forest,
                     isLast: true
                 )
             }
@@ -202,14 +202,14 @@ struct DigitalTwinView: View {
             HStack(spacing: 10) {
                 Image(systemName: "hand.point.left.fill")
                     .font(.system(size: 16))
-                    .foregroundColor(Color(red: 0.831, green: 0.647, blue: 0.278))
+                    .foregroundColor(DS.Palette.gold)
                 Text("Switch to the Record tab to begin")
                     .font(.system(size: 15, weight: .medium, design: .rounded))
                     .foregroundColor(themeManager.textColor)
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 16)
-            .background(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.08))
+            .background(DS.Palette.gold.opacity(0.08))
             .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
             .padding(.horizontal, 20)
 
@@ -217,7 +217,7 @@ struct DigitalTwinView: View {
             HStack(spacing: 6) {
                 Image(systemName: "lock.shield.fill")
                     .font(.caption2)
-                    .foregroundColor(Color(red: 0.420, green: 0.620, blue: 0.482))
+                    .foregroundColor(DS.Palette.forest)
                 Text("Your Twin never leaves your device")
                     .font(.system(size: 11, weight: .medium, design: .rounded))
                     .foregroundColor(themeManager.secondaryTextColor.opacity(0.7))
@@ -394,7 +394,7 @@ struct DigitalTwinView: View {
                     RoundedRectangle(cornerRadius: 4)
                         .fill(
                             LinearGradient(
-                                colors: [themeManager.accentColor, Color(red: 0.831, green: 0.647, blue: 0.278), themeManager.accentColor.opacity(0.6)],
+                                colors: [themeManager.accentColor, DS.Palette.gold, themeManager.accentColor.opacity(0.6)],
                                 startPoint: .leading,
                                 endPoint: .trailing
                             )
@@ -414,7 +414,8 @@ struct DigitalTwinView: View {
                     .foregroundColor(themeManager.accentColor)
             }
         }
-        .padding(.horizontal)
+        // No extra horizontal padding: the parent VStack already carries the
+        // 16pt grid inset, so the bar aligns flush with the cards around it.
     }
 
     // MARK: - Section Picker
@@ -903,12 +904,12 @@ struct DigitalTwinView: View {
             GeometryReader { geo in
                 ZStack(alignment: .leading) {
                     RoundedRectangle(cornerRadius: 4)
-                        .fill(Color.gray.opacity(0.2))
+                        .fill(DS.Palette.inkMute.opacity(0.2))
 
                     RoundedRectangle(cornerRadius: 4)
                         .fill(
                             LinearGradient(
-                                colors: [themeManager.accentColor, Color(red: 0.831, green: 0.647, blue: 0.278)],
+                                colors: [themeManager.accentColor, DS.Palette.gold],
                                 startPoint: .leading,
                                 endPoint: .trailing
                             )
@@ -935,7 +936,7 @@ struct DigitalTwinView: View {
         return VStack(spacing: 6) {
             ZStack {
                 Circle()
-                    .stroke(Color.gray.opacity(0.2), lineWidth: lineWidth)
+                    .stroke(DS.Palette.inkMute.opacity(0.2), lineWidth: lineWidth)
                 Circle()
                     .trim(from: 0, to: max(0.05, value))
                     .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
@@ -997,7 +998,7 @@ struct DigitalTwinView: View {
                             HStack(spacing: 1) {
                                 ForEach(0..<5, id: \.self) { i in
                                     Circle()
-                                        .fill(Double(i) / 5.0 < node.importance ? themeManager.accentColor : Color.gray.opacity(0.2))
+                                        .fill(Double(i) / 5.0 < node.importance ? themeManager.accentColor : DS.Palette.inkMute.opacity(0.2))
                                         .frame(width: 4, height: 4)
                                 }
                             }
@@ -1027,7 +1028,7 @@ struct DigitalTwinView: View {
         VStack(spacing: 16) {
             Image(systemName: "sparkles")
                 .font(.system(size: 40))
-                .foregroundColor(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.6))
+                .foregroundColor(DS.Palette.gold.opacity(0.6))
 
             Text("Your constellation awaits")
                 .font(.system(size: 18, weight: .semibold, design: .rounded))
@@ -1054,14 +1055,14 @@ struct DigitalTwinView: View {
     private var privacyBadge: some View {
         HStack(spacing: 8) {
             Image(systemName: "lock.shield.fill")
-                .foregroundColor(Color(red: 0.420, green: 0.620, blue: 0.482))
+                .foregroundColor(DS.Palette.forest)
             Text("100% on-device. Your twin never leaves your device.")
                 .font(.caption)
                 .foregroundColor(themeManager.secondaryTextColor)
         }
         .padding()
         .frame(maxWidth: .infinity)
-        .background(Color(red: 0.420, green: 0.620, blue: 0.482).opacity(0.1))
+        .background(DS.Palette.forest.opacity(0.1))
         .cornerRadius(12)
     }
 
@@ -1070,9 +1071,9 @@ struct DigitalTwinView: View {
     private func sentimentColor(_ sentiment: Double) -> Color {
         if sentiment > 0.3 { return DS.Palette.forest }
         if sentiment > 0.1 { return DS.Palette.sage }
-        if sentiment > -0.1 { return .gray }
+        if sentiment > -0.1 { return DS.Palette.inkMute }
         if sentiment > -0.3 { return DS.Palette.gold }
-        return .red
+        return DS.Palette.coral
     }
 
     private func sentimentLabel(_ sentiment: Double) -> String {

--- a/solyn/solyn/EmptyStateView.swift
+++ b/solyn/solyn/EmptyStateView.swift
@@ -132,8 +132,8 @@ struct WelcomeCard: View {
         }
         .padding(24)
         .background(Color(.secondarySystemGroupedBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 20))
-        .shadow(color: Color.black.opacity(0.04), radius: 12, y: 4)
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .dsShadowSoft()
     }
 }
 

--- a/solyn/solyn/Info.plist
+++ b/solyn/solyn/Info.plist
@@ -13,7 +13,7 @@
 	<key>NSMicrophoneUsageDescription</key>
 	<string>DailyVox needs microphone access to record your voice diary entries.</string>
 	<key>NSMotionUsageDescription</key>
-	<string>DailyVox uses motion activity to tell when you were walking or working out, so a racing heart from exercise is never mistaken for emotion. Activity context stays on this iPhone.</string>
+	<string>DailyVox uses motion activity to tell whether you were moving when a journal entry was made, so body signals are read in the right context. Activity context stays on this iPhone.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>DailyVox lets you attach photos to your diary entries. Photos are stored on your device only.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/solyn/solyn/Info.plist
+++ b/solyn/solyn/Info.plist
@@ -8,8 +8,12 @@
 	<false/>
 	<key>NSFaceIDUsageDescription</key>
 	<string>DailyVox uses Face ID to lock and unlock access to your private diary entries.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>DailyVox reads sleep, heart, steps and mindfulness data on this iPhone so your Twin can understand what your body felt around each entry. You review every signal before your Twin learns it; nothing is uploaded or synced.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>DailyVox needs microphone access to record your voice diary entries.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>DailyVox uses motion activity to tell when you were walking or working out, so a racing heart from exercise is never mistaken for emotion. Activity context stays on this iPhone.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>DailyVox lets you attach photos to your diary entries. Photos are stored on your device only.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/solyn/solyn/ScreenshotDataSeeder.swift
+++ b/solyn/solyn/ScreenshotDataSeeder.swift
@@ -12,6 +12,7 @@ import CoreData
 
 struct ScreenshotDataSeeder {
 
+    @MainActor
     static func seedIfNeeded(context: NSManagedObjectContext) {
         guard ProcessInfo.processInfo.arguments.contains("-ScreenshotMode") else { return }
 
@@ -216,5 +217,131 @@ struct ScreenshotDataSeeder {
                 duration: entry.duration
             )
         }
+
+        seedBodyTwinFixtures(entries: entries, calendar: calendar, now: now)
+    }
+
+    // MARK: - Body Twin Fixtures (v1.5)
+
+    /// Seeds Body Twin state through the same local stores the app uses at
+    /// runtime, so every new surface (Twin-tab card, review sheet, Settings
+    /// Health section, Insights Body & Mood card) has honest data to show.
+    /// Screenshot-only: reachable exclusively behind the -ScreenshotMode gate.
+    ///
+    /// Pass -BodyTwinInviteDemo as well to force the not-yet-authorized state
+    /// instead, so TodayView's one-time Health invite card is capturable.
+    @MainActor
+    private static func seedBodyTwinFixtures(
+        entries: [(text: String, mood: String, daysAgo: Int, starred: Bool, duration: Double)],
+        calendar: Calendar,
+        now: Date
+    ) {
+        let defaults = UserDefaults.standard
+
+        // The invite gate reads ReviewManager's saved-entry counter; 35 seeded
+        // entries = 35 saved. Mark as already-reviewed so the StoreKit rating
+        // prompt can never wander into a screenshot.
+        defaults.set(entries.count, forKey: "reviewManager_entryCount")
+        defaults.set(true, forKey: "reviewManager_hasReviewed")
+
+        if ProcessInfo.processInfo.arguments.contains("-BodyTwinInviteDemo") {
+            // Not-yet-authorized: the one-time "your Twin can learn what your
+            // body felt" invite renders on TodayView's idle state.
+            defaults.set(false, forKey: "bodyTwin_hasSeenInvite")
+            defaults.removeObject(forKey: "com.dailyvox.bodytwin.hkRequested")
+            PendingSnapshotQueue.shared.wipe()
+            KeptSnapshotStore.shared.wipe()
+            let store = FileBodyTwinStateStore()
+            store.saveBodyTwin(BodyTwin(isAuthorized: false, isEnabledByUser: true))
+            DigitalTwinEngine.configureBodyTwinStore(store)
+            return
+        }
+
+        // Health connected, Body Twin mid-journey (.learning maturity).
+        defaults.set(true, forKey: "bodyTwin_hasSeenInvite")
+        defaults.set(true, forKey: "bodyTwin_enabled")
+        // HealthKitService's persisted "the user has been asked" flag (the only
+        // authorization signal read-only HealthKit exposes).
+        defaults.set(true, forKey: "com.dailyvox.bodytwin.hkRequested")
+
+        // Kept snapshots: one per day across the last three weeks, whose sleep
+        // and steps honestly track the seeded entries' moods — brighter days
+        // slept longer and moved more — so the Body & Mood insights card shows
+        // patterns the data actually contains. Morning HRV appears on only
+        // some days (like real life), staying below the 14-day insight bar.
+        var kept: [KeptSnapshot] = []
+        for entry in entries where (1...21).contains(entry.daysAgo) && entry.daysAgo != 13 {
+            let day = calendar.date(byAdding: .day, value: -entry.daysAgo, to: now)!
+            let capturedAt = calendar.date(bySettingHour: 9, minute: (entry.daysAgo * 13) % 60, second: 0, of: day)!
+            let jitter = Double((entry.daysAgo * 7) % 5)   // deterministic, small
+            let (sleep, steps): (Double, Int) = {
+                switch entry.mood {
+                case "happy", "excited", "grateful": return (7.4 + jitter * 0.08, 9200 + entry.daysAgo * 90)
+                case "calm":                         return (7.0 + jitter * 0.06, 7600 + entry.daysAgo * 70)
+                case "tired":                        return (6.3, 5200)
+                case "anxious":                      return (5.7 + jitter * 0.10, 3900 + entry.daysAgo * 60)
+                default:                             return (5.9, 3800)   // sad
+                }
+            }()
+            var snapshot = HealthSnapshot(
+                capturedAt: capturedAt,
+                activityContext: .atRest,
+                sleepHours: sleep,
+                stepsToday: steps,
+                activityConfidence: 0.9
+            )
+            if entry.daysAgo % 2 == 0 {   // HRV on ~10 of 20 days
+                snapshot.morningHRVMs = 34 + Double((entry.daysAgo * 11) % 18)
+            }
+            kept.append(KeptSnapshot(id: UUID(), snapshot: snapshot, keptAt: capturedAt))
+        }
+        KeptSnapshotStore.shared.wipe()
+        KeptSnapshotStore.shared.restore(kept)
+
+        // Review queue: two snapshots waiting, exactly as capture would leave
+        // them — a short-sleep evening at rest, and a post-workout morning
+        // where HR fields are honestly absent.
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: now)!
+        let eveningAt = calendar.date(bySettingHour: 21, minute: 37, second: 0, of: yesterday)!
+        let evening = HealthSnapshot(
+            capturedAt: eveningAt,
+            activityContext: .atRest,
+            sleepHours: 5.0 + 50.0 / 60.0,   // 5h 50m
+            morningHRVMs: 38,
+            restingHRBpm: 64,
+            stepsToday: 4100,
+            activityConfidence: 0.92
+        )
+        let morningAt = calendar.date(bySettingHour: 8, minute: 12, second: 0, of: now)!
+        let morning = HealthSnapshot(
+            capturedAt: morningAt,
+            activityContext: .postWorkout,
+            stepsToday: 9800,
+            minutesSinceLastWorkout: 6,
+            activityConfidence: 0.85
+        )
+        PendingSnapshotQueue.shared.wipe()
+        PendingSnapshotQueue.shared.restore([
+            PendingSnapshot(id: UUID(), snapshot: evening, createdAt: eveningAt),
+            PendingSnapshot(id: UUID(), snapshot: morning, createdAt: morningAt)
+        ])
+
+        // Engine state: authorized + enabled, 22 kept moments (.learning),
+        // baseline consistent with the kept snapshots above.
+        let newestKeptAt = kept.map(\.keptAt).max() ?? now
+        var baseline = PersonalBaseline()
+        baseline.averageSleepHours = 6.9
+        baseline.samplesFolded = 22
+        baseline.sleepSamplesFolded = 20
+        baseline.lastRefreshed = newestKeptAt
+        let store = FileBodyTwinStateStore()
+        store.saveBodyTwin(BodyTwin(
+            isAuthorized: true,
+            isEnabledByUser: true,
+            baseline: baseline,
+            entriesWithSnapshot: 22,
+            lastSnapshotAt: newestKeptAt
+        ))
+        DigitalTwinEngine.configureBodyTwinStore(store)
     }
 }

--- a/solyn/solyn/ScreenshotDataSeeder.swift
+++ b/solyn/solyn/ScreenshotDataSeeder.swift
@@ -299,8 +299,10 @@ struct ScreenshotDataSeeder {
         KeptSnapshotStore.shared.restore(kept)
 
         // Review queue: two snapshots waiting, exactly as capture would leave
-        // them — a short-sleep evening at rest, and a post-workout morning
-        // where HR fields are honestly absent.
+        // them — a short-sleep evening at rest, and a mid-walk morning where
+        // the rest-dependent fields are honestly absent. (No .postWorkout
+        // here: v1.5 requests no Workouts read access, so screenshots must
+        // not depict a state the shipping detector cannot produce.)
         let yesterday = calendar.date(byAdding: .day, value: -1, to: now)!
         let eveningAt = calendar.date(bySettingHour: 21, minute: 37, second: 0, of: yesterday)!
         let evening = HealthSnapshot(
@@ -315,9 +317,8 @@ struct ScreenshotDataSeeder {
         let morningAt = calendar.date(bySettingHour: 8, minute: 12, second: 0, of: now)!
         let morning = HealthSnapshot(
             capturedAt: morningAt,
-            activityContext: .postWorkout,
-            stepsToday: 9800,
-            minutesSinceLastWorkout: 6,
+            activityContext: .active,
+            stepsToday: 6800,
             activityConfidence: 0.85
         )
         PendingSnapshotQueue.shared.wipe()

--- a/solyn/solyn/SettingsView.swift
+++ b/solyn/solyn/SettingsView.swift
@@ -539,7 +539,10 @@ struct SettingsView: View {
             } header: {
                 Text("Health")
             } footer: {
-                Text("Health signals stay on this iPhone. They are never uploaded, never synced, and your Twin only learns the ones you approve.")
+                // Honest promise: DECISIONS #1's single sanctioned exit path
+                // (user-initiated encrypted export, user-held key) is named,
+                // so "stays on this iPhone" never over-claims.
+                Text("Health signals stay on this iPhone — never synced, and your Twin only learns the ones you approve. The one way they ever leave is inside an encrypted backup you export yourself, locked with your password.")
             }
             .confirmationDialog("Wipe all health snapshots and everything your Twin learned from them? This cannot be undone.",
                                 isPresented: $showWipeHealthConfirm, titleVisibility: .visible) {
@@ -587,6 +590,11 @@ struct SettingsView: View {
             }
             bodyTwinManager.recordAuthorizationRequested()
             bodyTwinManager.isEnabled = true
+            // Prime the Motion & Fitness prompt HERE, inside the moment the
+            // user chose to connect — the first CMMotionActivity query is
+            // what triggers it, and without this pass it would otherwise pop
+            // un-contextualized in the middle of their next entry save.
+            await ActivityContextDetector.shared.update()
         }
     }
 

--- a/solyn/solyn/SettingsView.swift
+++ b/solyn/solyn/SettingsView.swift
@@ -448,7 +448,13 @@ struct SettingsView: View {
         if healthKit.isAvailable {
             Section {
                 Toggle(isOn: Binding(
-                    get: { twin.bodyTwin.isActive },
+                    // Optimistic while the async enable flow runs: isActive
+                    // only flips after the Health sheet completes, so without
+                    // this the knob the user just flipped ON snaps back to
+                    // OFF for the whole permission ask. It reverts naturally
+                    // if requestAuthorization throws (flag resets, get falls
+                    // back to isActive == false).
+                    get: { isRequestingHealthAccess || twin.bodyTwin.isActive },
                     set: { newValue in
                         if newValue {
                             enableBodyTwin()
@@ -523,7 +529,12 @@ struct SettingsView: View {
                                  ? "1 signal waiting for review"
                                  : "\(pendingSnapshots.count) signals waiting for review")
                                 .font(.subheadline.weight(.semibold))
-                            Text("Your Twin tab holds them — nothing is learned until you tap Keep.")
+                            // The Twin tab opens the queue even while Body
+                            // Twin is off (BodyTwinCard) — the caption tracks
+                            // that so it never points at a door that won't open.
+                            Text(twin.bodyTwin.isActive
+                                 ? "Your Twin tab holds them — nothing is learned until you tap Keep."
+                                 : "Body Twin is off, but the Twin tab still holds them — Keep or Let go anytime.")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }

--- a/solyn/solyn/SettingsView.swift
+++ b/solyn/solyn/SettingsView.swift
@@ -678,7 +678,7 @@ struct SettingsView: View {
                     }
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Export Data")
-                            .font(.subheadline)
+                            .font(.subheadline.weight(.semibold))
                         Text("JSON, Text, Markdown, CSV")
                             .font(.caption)
                             .foregroundColor(.secondary)
@@ -700,7 +700,7 @@ struct SettingsView: View {
                     }
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Import Backup")
-                            .font(.subheadline)
+                            .font(.subheadline.weight(.semibold))
                         Text("Restore from JSON backup")
                             .font(.caption)
                             .foregroundColor(.secondary)

--- a/solyn/solyn/SettingsView.swift
+++ b/solyn/solyn/SettingsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import CoreData
 import WidgetKit
+import DailyVoxTwinEngine
 #if os(iOS)
 import UIKit
 #endif
@@ -12,6 +13,10 @@ struct SettingsView: View {
     @ObservedObject private var lockManager = AppLockManager.shared
     @ObservedObject private var themeManager = ThemeManager.shared
     @ObservedObject private var goalManager = GoalManager.shared
+    @ObservedObject private var bodyTwinManager = BodyTwinManager.shared
+    @ObservedObject private var twin = DigitalTwinEngine.shared
+    @ObservedObject private var healthKit = HealthKitService.shared
+    @ObservedObject private var pendingSnapshots = PendingSnapshotQueue.shared
 
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \DiaryEntry.date, ascending: true)],
@@ -54,6 +59,10 @@ struct SettingsView: View {
     @State private var showDeletePhotosConfirm = false
     @State private var showDeleteAllConfirm = false
 
+    // Health states
+    @State private var showWipeHealthConfirm = false
+    @State private var isRequestingHealthAccess = false
+
     var body: some View {
         Form {
             exportSection
@@ -64,6 +73,7 @@ struct SettingsView: View {
             dailyReminderSection
             storageSection
             iCloudSection
+            healthSection
             privacySection
             backupSection
             aboutSection
@@ -430,6 +440,159 @@ struct SettingsView: View {
             return "Syncing across your devices"
         }
         return "iCloud not available — sign in to enable"
+    }
+
+    @ViewBuilder
+    private var healthSection: some View {
+        // Absent entirely on devices without HealthKit — no dead toggle to explain.
+        if healthKit.isAvailable {
+            Section {
+                Toggle(isOn: Binding(
+                    get: { twin.bodyTwin.isActive },
+                    set: { newValue in
+                        if newValue {
+                            enableBodyTwin()
+                        } else {
+                            bodyTwinManager.isEnabled = false
+                        }
+                    }
+                )) {
+                    HStack(spacing: 12) {
+                        ZStack {
+                            Circle()
+                                .fill(twin.bodyTwin.isActive ? DS.Palette.terracotta.opacity(0.15) : DS.Palette.inkMute.opacity(0.15))
+                                .frame(width: 36, height: 36)
+                            Image(systemName: "figure.mind.and.body")
+                                .font(.body)
+                                .foregroundColor(twin.bodyTwin.isActive ? DS.Palette.terracotta : DS.Palette.inkMute)
+                        }
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Body Twin")
+                                .font(.subheadline.weight(.semibold))
+                            Text(bodyTwinStatusText)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .disabled(isRequestingHealthAccess)
+
+                if twin.bodyTwin.isActive {
+                    HealthSignalToggle(
+                        label: "Sleep",
+                        detail: "Hours of rest the night before",
+                        icon: "moon.zzz.fill",
+                        color: DS.Palette.sage,
+                        isOn: $bodyTwinManager.sleepEnabled
+                    )
+                    HealthSignalToggle(
+                        label: "Heart",
+                        detail: "Morning HRV and resting heart rate",
+                        icon: "heart.fill",
+                        color: DS.Palette.terracotta,
+                        isOn: heartSignalBinding
+                    )
+                    HealthSignalToggle(
+                        label: "Steps",
+                        detail: "Steps taken through the day",
+                        icon: "figure.walk",
+                        color: DS.Palette.gold,
+                        isOn: $bodyTwinManager.stepsEnabled
+                    )
+                    HealthSignalToggle(
+                        label: "Mindful Minutes",
+                        detail: "Quiet minutes you set aside",
+                        icon: "leaf.fill",
+                        color: DS.Palette.forest,
+                        isOn: $bodyTwinManager.mindfulEnabled
+                    )
+                }
+
+                if pendingSnapshots.count > 0 {
+                    HStack(spacing: 12) {
+                        ZStack {
+                            Circle()
+                                .fill(DS.Palette.gold.opacity(0.15))
+                                .frame(width: 36, height: 36)
+                            Image(systemName: "sparkles")
+                                .font(.body)
+                                .foregroundColor(DS.Palette.gold)
+                        }
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(pendingSnapshots.count == 1
+                                 ? "1 signal waiting for review"
+                                 : "\(pendingSnapshots.count) signals waiting for review")
+                                .font(.subheadline.weight(.semibold))
+                            Text("Your Twin tab holds them — nothing is learned until you tap Keep.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                Button(role: .destructive) {
+                    showWipeHealthConfirm = true
+                } label: {
+                    Label("Wipe All Health Snapshots", systemImage: "trash")
+                }
+            } header: {
+                Text("Health")
+            } footer: {
+                Text("Health signals stay on this iPhone. They are never uploaded, never synced, and your Twin only learns the ones you approve.")
+            }
+            .confirmationDialog("Wipe all health snapshots and everything your Twin learned from them? This cannot be undone.",
+                                isPresented: $showWipeHealthConfirm, titleVisibility: .visible) {
+                Button("Wipe Health Snapshots", role: .destructive) { wipeAllHealthSnapshots() }
+                Button("Cancel", role: .cancel) {}
+            }
+        }
+    }
+
+    private var bodyTwinStatusText: String {
+        if isRequestingHealthAccess {
+            return "Asking Health for permission…"
+        }
+        return twin.bodyTwin.isActive
+            ? "Learning what your body felt"
+            : "Off — your Twin learns from your words alone"
+    }
+
+    /// One switch for both heart signals — HRV and resting rate travel together.
+    private var heartSignalBinding: Binding<Bool> {
+        Binding(
+            get: { bodyTwinManager.hrvEnabled && bodyTwinManager.restingHREnabled },
+            set: { newValue in
+                bodyTwinManager.hrvEnabled = newValue
+                bodyTwinManager.restingHREnabled = newValue
+            }
+        )
+    }
+
+    /// Master-toggle ON path. First time through, this shows Apple's Health
+    /// permission sheet; the sheet completing is all read-only HealthKit lets
+    /// us know (per-signal grants are invisible by design), so completion
+    /// counts as "asked" and the Twin turns on.
+    private func enableBodyTwin() {
+        guard !isRequestingHealthAccess else { return }
+        isRequestingHealthAccess = true
+        Task { @MainActor in
+            defer { isRequestingHealthAccess = false }
+            if !healthKit.isAuthorized {
+                do {
+                    try await healthKit.requestAuthorization()
+                } catch {
+                    return // sheet failed to appear — leave the toggle off
+                }
+            }
+            bodyTwinManager.recordAuthorizationRequested()
+            bodyTwinManager.isEnabled = true
+        }
+    }
+
+    private func wipeAllHealthSnapshots() {
+        bodyTwinManager.wipeAllHealthData()
+        HapticManager.shared.entryDeleted()
     }
 
     @ViewBuilder
@@ -956,6 +1119,37 @@ struct ReminderPresetRow: View {
         }
         .buttonStyle(.plain)
         .listRowBackground(isSelected ? DS.Palette.sage.opacity(0.08) : Color.clear)
+    }
+}
+
+// MARK: - Health Signal Toggle
+
+struct HealthSignalToggle: View {
+    let label: String
+    let detail: String
+    let icon: String
+    let color: Color
+    @Binding var isOn: Bool
+
+    var body: some View {
+        Toggle(isOn: $isOn) {
+            HStack(spacing: 12) {
+                ZStack {
+                    Circle()
+                        .fill(color.opacity(0.15))
+                        .frame(width: 32, height: 32)
+                    Image(systemName: icon)
+                        .font(.caption)
+                        .foregroundColor(color)
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label)
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
     }
 }
 

--- a/solyn/solyn/StatsView.swift
+++ b/solyn/solyn/StatsView.swift
@@ -25,6 +25,16 @@ struct StatsView: View {
     /// correlation math must never run inside body (Twin-perf lesson).
     @State private var bodyInsights: [BodyInsight] = []
 
+    /// Cache key for `bodyInsights`: recompute only when the calendar day or
+    /// the kept-snapshot count changes, so tab-switching to Insights never
+    /// re-walks a multi-year history for the same answer.
+    @State private var bodyInsightsKey: BodyInsightsCacheKey?
+
+    private struct BodyInsightsCacheKey: Equatable {
+        let day: Date
+        let keptCount: Int
+    }
+
     private var isIPad: Bool { horizontalSizeClass == .regular }
 
     var body: some View {
@@ -335,29 +345,48 @@ struct StatsView: View {
     }
 
     /// Feeds kept snapshots + the per-day mood series into the engine.
+    ///
+    /// Cached and computed off-main: for a Body Twin user with years of
+    /// history this walks every entry (Calendar.startOfDay dominates) plus
+    /// every kept snapshot — tens of ms that must not ride the tab-switch
+    /// frame on every Insights visit. Only the raw (date, mood) pairs are
+    /// gathered on the main actor (managed objects are not thread-safe);
+    /// the day-bucketing and Pearson math run at utility QoS.
     private func refreshBodyInsights() {
-        let snapshots = KeptSnapshotStore.shared.loadAll().map(\.snapshot)
-        guard !snapshots.isEmpty else {
+        let kept = KeptSnapshotStore.shared.loadAll()
+        guard !kept.isEmpty else {
             bodyInsights = []
+            bodyInsightsKey = nil
             return
         }
-        bodyInsights = BodyCorrelations.compute(snapshots: snapshots, moodByDay: moodValueByDay)
-    }
 
-    /// Mood valence (1–5) per calendar day, real moods only — `.none` is a
-    /// placeholder, not a reading, and would flatten every correlation.
-    private var moodValueByDay: [Date: Double] {
-        let calendar = Calendar.current
-        var byDay: [Date: Double] = [:]
-        for entry in entries {
+        let key = BodyInsightsCacheKey(day: Calendar.current.startOfDay(for: Date()),
+                                       keptCount: kept.count)
+        guard key != bodyInsightsKey else { return }
+        bodyInsightsKey = key
+
+        // Main-thread extraction only — no Core Data access off-main.
+        let moodPairs: [(date: Date, mood: String)] = entries.compactMap { entry in
             guard let date = entry.date,
-                  let moodString = entry.value(forKey: "mood") as? String,
-                  let mood = Mood(rawValue: moodString),
-                  mood != .none else { continue }
-            let day = calendar.startOfDay(for: date)
-            if byDay[day] == nil { byDay[day] = Double(mood.moodValue) }
+                  let moodString = entry.value(forKey: "mood") as? String else { return nil }
+            return (date, moodString)
         }
-        return byDay
+        let snapshots = kept.map(\.snapshot)
+
+        Task.detached(priority: .utility) {
+            // Mood valence (1–5) per calendar day, real moods only — `.none`
+            // is a placeholder, not a reading, and would flatten every
+            // correlation. First entry in fetch order (newest) wins a day.
+            let calendar = Calendar.current
+            var moodByDay: [Date: Double] = [:]
+            for pair in moodPairs {
+                guard let mood = Mood(rawValue: pair.mood), mood != .none else { continue }
+                let day = calendar.startOfDay(for: pair.date)
+                if moodByDay[day] == nil { moodByDay[day] = Double(mood.moodValue) }
+            }
+            let result = BodyCorrelations.compute(snapshots: snapshots, moodByDay: moodByDay)
+            await MainActor.run { bodyInsights = result }
+        }
     }
 
     private func bodyInsightIcon(_ kind: BodyInsight.Kind) -> String {

--- a/solyn/solyn/StatsView.swift
+++ b/solyn/solyn/StatsView.swift
@@ -132,7 +132,7 @@ struct StatsView: View {
             HStack {
                 Image(systemName: "flame.fill")
                     .font(.title2)
-                    .foregroundColor(Color(red: 0.769, green: 0.584, blue: 0.416))
+                    .foregroundColor(DS.Palette.terracotta)
                 Text("Writing Streak")
                     .font(.system(.headline, design: .rounded))
                 Spacer()
@@ -141,7 +141,7 @@ struct StatsView: View {
             HStack(alignment: .bottom, spacing: 4) {
                 Text("\(currentStreak)")
                     .font(.system(size: 48, weight: .bold, design: .rounded))
-                    .foregroundColor(Color(red: 0.769, green: 0.584, blue: 0.416))
+                    .foregroundColor(DS.Palette.terracotta)
                 Text(currentStreak == 1 ? "day" : "days")
                     .font(.title3)
                     .foregroundColor(.secondary)
@@ -308,7 +308,7 @@ struct StatsView: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Image(systemName: "figure.mind.and.body")
-                    .foregroundColor(Color(red: 0.769, green: 0.584, blue: 0.416))
+                    .foregroundColor(DS.Palette.terracotta)
                 Text("Body & Mood")
                     .font(.system(.headline, design: .rounded))
             }
@@ -391,17 +391,19 @@ struct StatsView: View {
 
     private func bodyInsightIcon(_ kind: BodyInsight.Kind) -> String {
         switch kind {
-        case .sleepAndMood: return "bed.double.fill"
+        case .sleepAndMood: return "moon.zzz.fill"
         case .stepsAndMood: return "figure.walk"
         case .hrvAndMood: return "waveform.path.ecg"
         }
     }
 
+    /// Same signal→color mapping as the review sheet, invite sheet, and
+    /// Settings → Health: sleep is sage, steps gold, HRV terracotta.
     private func bodyInsightColor(_ kind: BodyInsight.Kind) -> Color {
         switch kind {
-        case .sleepAndMood: return colorFromName("indigo")
-        case .stepsAndMood: return colorFromName("green")
-        case .hrvAndMood: return colorFromName("pink")
+        case .sleepAndMood: return DS.Palette.sage
+        case .stepsAndMood: return DS.Palette.gold
+        case .hrvAndMood: return DS.Palette.terracotta
         }
     }
 
@@ -449,10 +451,10 @@ struct StatsView: View {
                 .font(.system(.headline, design: .rounded))
 
             LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: isIPad ? 4 : 2), spacing: 16) {
-                StatItem(title: "Total Words", value: "\(totalWords)", icon: "text.word.spacing", color: Color(red: 0.357, green: 0.486, blue: 0.420))
-                StatItem(title: "Avg Words/Entry", value: "\(avgWordsPerEntry)", icon: "chart.bar.fill", color: Color(red: 0.420, green: 0.620, blue: 0.482))
-                StatItem(title: "Starred", value: "\(starredCount)", icon: "star.fill", color: Color(red: 0.831, green: 0.647, blue: 0.278))
-                StatItem(title: "With Audio", value: "\(audioCount)", icon: "waveform", color: Color(red: 0.769, green: 0.584, blue: 0.416))
+                StatItem(title: "Total Words", value: "\(totalWords)", icon: "text.word.spacing", color: DS.Palette.sage)
+                StatItem(title: "Avg Words/Entry", value: "\(avgWordsPerEntry)", icon: "chart.bar.fill", color: DS.Palette.forest)
+                StatItem(title: "Starred", value: "\(starredCount)", icon: "star.fill", color: DS.Palette.gold)
+                StatItem(title: "With Audio", value: "\(audioCount)", icon: "waveform", color: DS.Palette.terracotta)
             }
         }
         .dsCard()
@@ -468,7 +470,7 @@ struct StatsView: View {
                 VStack(alignment: .leading, spacing: 12) {
                     HStack {
                         Image(systemName: "sparkles")
-                            .foregroundColor(Color(red: 0.831, green: 0.647, blue: 0.278))
+                            .foregroundColor(DS.Palette.gold)
                         Text("AI Insights")
                             .font(.system(.headline, design: .rounded))
                     }
@@ -510,7 +512,7 @@ struct StatsView: View {
         return VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Image(systemName: "calendar")
-                    .foregroundColor(Color(red: 0.357, green: 0.486, blue: 0.420))
+                    .foregroundColor(DS.Palette.sage)
                 Text("Weekly reflection")
                     .font(.system(.headline, design: .rounded))
             }
@@ -544,7 +546,7 @@ struct StatsView: View {
 
             ZStack {
                 Circle()
-                    .stroke(Color.gray.opacity(0.2), lineWidth: 8)
+                    .stroke(DS.Palette.inkMute.opacity(0.2), lineWidth: 8)
                 Circle()
                     .trim(from: 0, to: progress)
                     .stroke(DS.Palette.sage, style: StrokeStyle(lineWidth: 8, lineCap: .round))
@@ -615,7 +617,7 @@ struct StatsView: View {
             }
             .padding(32)
             .background(Color(.systemBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 24))
+            .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
             .shadow(radius: 20)
             .padding(40)
             .transition(.scale.combined(with: .opacity))
@@ -624,7 +626,7 @@ struct StatsView: View {
 
     private func colorFromName(_ name: String) -> Color {
         switch name {
-        case "orange": return Color(red: 0.769, green: 0.584, blue: 0.416)  // terracotta
+        case "orange": return DS.Palette.terracotta  // terracotta
         case "green": return Color(red: 0.420, green: 0.620, blue: 0.482)   // forest green
         case "blue": return Color(red: 0.357, green: 0.486, blue: 0.420)    // sage green
         case "yellow": return Color(red: 0.831, green: 0.647, blue: 0.278)  // warm gold

--- a/solyn/solyn/StatsView.swift
+++ b/solyn/solyn/StatsView.swift
@@ -21,6 +21,10 @@ struct StatsView: View {
 
     @State private var showMilestone: Int? = nil
 
+    /// Embodied insights, computed off the render path in onAppear — the
+    /// correlation math must never run inside body (Twin-perf lesson).
+    @State private var bodyInsights: [BodyInsight] = []
+
     private var isIPad: Bool { horizontalSizeClass == .regular }
 
     var body: some View {
@@ -49,6 +53,11 @@ struct StatsView: View {
                     // Mood Trends
                     moodTrendsCard
 
+                    // Body & Mood — absent entirely until honest patterns exist
+                    if !bodyInsights.isEmpty {
+                        bodyCorrelationsCard
+                    }
+
                     // Stats Summary
                     statsSummaryCard
 
@@ -68,6 +77,7 @@ struct StatsView: View {
             }
         }
         .onAppear {
+            refreshBodyInsights()
             if let milestone = goalManager.checkMilestone(currentStreak: currentStreak) {
                 HapticManager.shared.streakMilestone()
                 withAnimation(.spring(response: 0.5)) {
@@ -275,6 +285,130 @@ struct StatsView: View {
                 Spacer()
                 Text("Today").font(.dsCaption2).foregroundColor(DS.Palette.inkMute)
             }
+        }
+    }
+
+    // MARK: - Body & Mood Card
+
+    /// Patterns between the body signals the user chose to keep and how the
+    /// same days felt. The engine (BodyCorrelations) stays silent below 14
+    /// paired days or |r| < 0.35, so this card only ever shows real patterns —
+    /// and the card itself disappears when there are none.
+    private var bodyCorrelationsCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "figure.mind.and.body")
+                    .foregroundColor(Color(red: 0.769, green: 0.584, blue: 0.416))
+                Text("Body & Mood")
+                    .font(.system(.headline, design: .rounded))
+            }
+
+            ForEach(bodyInsights) { insight in
+                HStack(alignment: .top, spacing: DS.Space.md) {
+                    Image(systemName: bodyInsightIcon(insight.kind))
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(bodyInsightColor(insight.kind))
+                        .frame(width: 38, height: 38)
+                        .background(
+                            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                                .fill(bodyInsightColor(insight.kind).opacity(0.12))
+                        )
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(bodyInsightTitle(insight))
+                            .font(.dsHeadline)
+                        Text(bodyInsightDescription(insight))
+                            .font(.dsCaption)
+                            .foregroundColor(DS.Palette.inkMute)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer(minLength: 0)
+                }
+                .padding(.vertical, 4)
+            }
+
+            Text("Patterns from the body signals you chose to keep — a noticing, not a prescription.")
+                .font(.dsCaption2)
+                .foregroundColor(DS.Palette.inkMute)
+        }
+        .dsCard()
+    }
+
+    /// Feeds kept snapshots + the per-day mood series into the engine.
+    private func refreshBodyInsights() {
+        let snapshots = KeptSnapshotStore.shared.loadAll().map(\.snapshot)
+        guard !snapshots.isEmpty else {
+            bodyInsights = []
+            return
+        }
+        bodyInsights = BodyCorrelations.compute(snapshots: snapshots, moodByDay: moodValueByDay)
+    }
+
+    /// Mood valence (1–5) per calendar day, real moods only — `.none` is a
+    /// placeholder, not a reading, and would flatten every correlation.
+    private var moodValueByDay: [Date: Double] {
+        let calendar = Calendar.current
+        var byDay: [Date: Double] = [:]
+        for entry in entries {
+            guard let date = entry.date,
+                  let moodString = entry.value(forKey: "mood") as? String,
+                  let mood = Mood(rawValue: moodString),
+                  mood != .none else { continue }
+            let day = calendar.startOfDay(for: date)
+            if byDay[day] == nil { byDay[day] = Double(mood.moodValue) }
+        }
+        return byDay
+    }
+
+    private func bodyInsightIcon(_ kind: BodyInsight.Kind) -> String {
+        switch kind {
+        case .sleepAndMood: return "bed.double.fill"
+        case .stepsAndMood: return "figure.walk"
+        case .hrvAndMood: return "waveform.path.ecg"
+        }
+    }
+
+    private func bodyInsightColor(_ kind: BodyInsight.Kind) -> Color {
+        switch kind {
+        case .sleepAndMood: return colorFromName("indigo")
+        case .stepsAndMood: return colorFromName("green")
+        case .hrvAndMood: return colorFromName("pink")
+        }
+    }
+
+    private func bodyInsightTitle(_ insight: BodyInsight) -> String {
+        switch insight.kind {
+        case .sleepAndMood:
+            return insight.movesTogether
+                ? "Rest and brightness rise together"
+                : "Your sleep writes its own pattern"
+        case .stepsAndMood:
+            return insight.movesTogether
+                ? "Moving days glow a little brighter"
+                : "Your stiller days glow brighter"
+        case .hrvAndMood:
+            return insight.movesTogether
+                ? "Your calm shows in your morning rhythm"
+                : "Your morning rhythm runs its own way"
+        }
+    }
+
+    /// The two group means tell the pattern honestly in either direction.
+    private func bodyInsightDescription(_ insight: BodyInsight) -> String {
+        let days = "across \(insight.sampleDays) days"
+        switch insight.kind {
+        case .sleepAndMood:
+            let bright = String(format: "%.1f", insight.signalMeanOnBrighterDays)
+            let dim = String(format: "%.1f", insight.signalMeanOnDimmerDays)
+            return "Your brighter days followed about \(bright)h of sleep; dimmer ones about \(dim)h — \(days)."
+        case .stepsAndMood:
+            let bright = Int(insight.signalMeanOnBrighterDays).formatted()
+            let dim = Int(insight.signalMeanOnDimmerDays).formatted()
+            return "Brighter days carried around \(bright) steps; dimmer ones around \(dim) — \(days)."
+        case .hrvAndMood:
+            let bright = Int(insight.signalMeanOnBrighterDays.rounded())
+            let dim = Int(insight.signalMeanOnDimmerDays.rounded())
+            return "Morning rhythm (HRV) averaged \(bright) ms on brighter days and \(dim) ms on dimmer ones — \(days)."
         }
     }
 

--- a/solyn/solyn/TimelineView.swift
+++ b/solyn/solyn/TimelineView.swift
@@ -24,14 +24,16 @@ enum LifeArea: String, CaseIterable {
     case family = "Family"
     case creativity = "Creativity"
 
+    /// Warm-palette hues (same blue→sage, green→forest, pink→dusty rose,
+    /// purple→plum, orange→terracotta, yellow→gold mapping as Insights).
     var color: Color {
         switch self {
-        case .work: return .blue
-        case .health: return .green
-        case .relationships: return .pink
-        case .growth: return .purple
-        case .family: return .orange
-        case .creativity: return .yellow
+        case .work: return DS.Palette.sage
+        case .health: return DS.Palette.forest
+        case .relationships: return Color(red: 0.741, green: 0.486, blue: 0.498) // dusty rose
+        case .growth: return Color(red: 0.557, green: 0.467, blue: 0.592)        // muted plum
+        case .family: return DS.Palette.terracotta
+        case .creativity: return DS.Palette.gold
         }
     }
 
@@ -82,6 +84,7 @@ func detectLifeAreas(from text: String) -> [LifeArea] {
 struct TimelineView: View {
     @Environment(\.managedObjectContext) private var viewContext
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @ObservedObject private var theme = ThemeManager.shared
 
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \DiaryEntry.date, ascending: false)],
@@ -129,12 +132,12 @@ struct TimelineView: View {
                         Section(header: HStack(alignment: .firstTextBaseline) {
                             Text(sectionTitle(for: key))
                                 .font(.dsTitle2)
-                                .foregroundColor(DS.Palette.ink)
+                                .foregroundColor(theme.selectedTheme == .ivory ? DS.Palette.ink : Color.primary)
                                 .textCase(nil)
                             Spacer()
                             Text(sectionSummary(for: sectionEntries))
                                 .font(.dsCaption)
-                                .foregroundColor(DS.Palette.inkMute)
+                                .foregroundColor(theme.selectedTheme == .ivory ? DS.Palette.inkMute : Color.secondary)
                                 .textCase(nil)
                         }
                         .padding(.top, DS.Space.xs)
@@ -181,7 +184,7 @@ struct TimelineView: View {
                         toggleVoiceSearch()
                     } label: {
                         Image(systemName: isListening ? "mic.fill" : "mic")
-                            .foregroundColor(isListening ? .red : .accentColor)
+                            .foregroundColor(isListening ? theme.recordingColor : .accentColor)
                     }
                     .accessibilityLabel("Voice search")
                     
@@ -571,6 +574,12 @@ struct EntryRowView: View {
     let entry: DiaryEntry
     let searchText: String
     let dateString: String
+    @ObservedObject private var theme = ThemeManager.shared
+
+    // Fixed warm inks belong to the ivory theme only; on system dark cards
+    // they disappear (same `ivory ? warm : system` pattern as BodyTwinIdleCards).
+    private var inkPrimary: Color { theme.selectedTheme == .ivory ? DS.Palette.ink : .primary }
+    private var inkMuted: Color   { theme.selectedTheme == .ivory ? DS.Palette.inkMute : .secondary }
 
     private var wordCount: Int {
         guard let text = entry.text, !text.isEmpty else { return 0 }
@@ -601,7 +610,7 @@ struct EntryRowView: View {
                 HStack(spacing: 6) {
                     Text(dateString)
                         .font(.dsCaption)
-                        .foregroundColor(DS.Palette.inkMute)
+                        .foregroundColor(inkMuted)
 
                     if let moodString = entry.value(forKey: "mood") as? String,
                        let mood = Mood(rawValue: moodString),
@@ -614,13 +623,13 @@ struct EntryRowView: View {
                     if wordCount > 0 {
                         Text("\(wordCount) words")
                             .font(.dsCaption2)
-                            .foregroundColor(DS.Palette.inkMute.opacity(0.8))
+                            .foregroundColor(inkMuted.opacity(0.8))
                     }
 
                     if hasPhotos {
                         Image(systemName: "photo")
                             .font(.system(size: 10))
-                            .foregroundColor(DS.Palette.inkMute.opacity(0.8))
+                            .foregroundColor(inkMuted.opacity(0.8))
                     }
                 }
 
@@ -630,7 +639,7 @@ struct EntryRowView: View {
                 } else {
                     Text("Tap to add text")
                         .font(.dsBody)
-                        .foregroundColor(DS.Palette.inkMute)
+                        .foregroundColor(inkMuted)
                         .italic()
                 }
 
@@ -671,7 +680,7 @@ struct EntryRowView: View {
         if searchText.isEmpty {
             Text(text)
                 .font(.dsBody)
-                .foregroundColor(DS.Palette.ink)
+                .foregroundColor(inkPrimary)
         } else {
             Text(attributedString(for: text))
                 .font(.dsBody)

--- a/solyn/solyn/TodayView.swift
+++ b/solyn/solyn/TodayView.swift
@@ -893,6 +893,11 @@ struct TodayView: View {
             // Clear any selected prompt once an entry has been saved
             selectedPrompt = nil
             WidgetCenter.shared.reloadAllTimelines()
+            // Body Twin: offer this moment's body signals to the review queue.
+            // Fire-and-forget — never delays or fails the save, and this is the
+            // ONLY capture site (onboarding seeds, Siri, imports and edits
+            // deliberately never snapshot).
+            Task { await BodyTwinManager.shared.captureSnapshotIfEligible() }
         } catch {
             logger.error("Failed to save entry: \(error.localizedDescription)")
             recordingState = .idle

--- a/solyn/solyn/TodayView.swift
+++ b/solyn/solyn/TodayView.swift
@@ -103,7 +103,7 @@ struct TodayView: View {
                     VStack(spacing: 16) {
                         Image(systemName: "sparkles")
                             .font(.system(size: 56))
-                            .foregroundColor(Color(red: 0.831, green: 0.647, blue: 0.278))
+                            .foregroundColor(DS.Palette.gold)
 
                         Text("Your first star")
                             .font(.system(size: 22, weight: .bold, design: .rounded))
@@ -124,14 +124,14 @@ struct TodayView: View {
                                 .padding(.vertical, 12)
                                 .background(Color.accentColor)
                                 .foregroundColor(.white)
-                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         }
                         .buttonStyle(.plain)
                     }
                     .padding(24)
                     .frame(maxWidth: 300)
                     .background(Color(.systemBackground))
-                    .clipShape(RoundedRectangle(cornerRadius: 20))
+                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
                     .shadow(color: .black.opacity(0.2), radius: 20, y: 10)
                     .transition(.scale.combined(with: .opacity))
                 }
@@ -166,14 +166,14 @@ struct TodayView: View {
                 // Small star icon
                 ZStack {
                     Circle()
-                        .fill(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.1))
+                        .fill(DS.Palette.gold.opacity(0.1))
                         .frame(width: 64, height: 64)
                     Circle()
-                        .fill(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.2))
+                        .fill(DS.Palette.gold.opacity(0.2))
                         .frame(width: 40, height: 40)
                     Image(systemName: "sparkle")
                         .font(.system(size: 20, weight: .semibold))
-                        .foregroundColor(Color(red: 0.831, green: 0.647, blue: 0.278))
+                        .foregroundColor(DS.Palette.gold)
                 }
 
                 VStack(spacing: 12) {
@@ -200,7 +200,7 @@ struct TodayView: View {
                     ZStack {
                         // Pulsing ring
                         Circle()
-                            .stroke(Color(red: 0.357, green: 0.486, blue: 0.420).opacity(0.2), lineWidth: 2)
+                            .stroke(DS.Palette.sage.opacity(0.2), lineWidth: 2)
                             .frame(width: 108, height: 108)
                             .scaleEffect(firstTimePulse ? 1.3 : 1.0)
                             .opacity(firstTimePulse ? 0 : 0.5)
@@ -208,18 +208,18 @@ struct TodayView: View {
 
                         // Ambient glow
                         Circle()
-                            .fill(Color(red: 0.357, green: 0.486, blue: 0.420).opacity(0.08))
+                            .fill(DS.Palette.sage.opacity(0.08))
                             .frame(width: 120, height: 120)
                             .blur(radius: 15)
 
                         // Outer ring
                         Circle()
-                            .stroke(Color(red: 0.357, green: 0.486, blue: 0.420).opacity(0.3), lineWidth: 4)
+                            .stroke(DS.Palette.sage.opacity(0.3), lineWidth: 4)
                             .frame(width: 96, height: 96)
 
                         // Main circle
                         Circle()
-                            .fill(Color(red: 0.357, green: 0.486, blue: 0.420))
+                            .fill(DS.Palette.sage)
                             .frame(width: 80, height: 80)
 
                         // Mic icon
@@ -239,7 +239,7 @@ struct TodayView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "lock.shield.fill")
                         .font(.caption2)
-                        .foregroundColor(Color(red: 0.420, green: 0.620, blue: 0.482))
+                        .foregroundColor(DS.Palette.forest)
                     Text("No servers. No accounts. 100% private.")
                         .font(.system(size: 11, weight: .medium, design: .rounded))
                         .foregroundColor(.secondary.opacity(0.7))
@@ -305,7 +305,7 @@ struct TodayView: View {
                     StatBadge(
                         icon: "flame.fill",
                         value: "\(streakCount) day streak",
-                        color: Color(red: 0.769, green: 0.584, blue: 0.416)
+                        color: DS.Palette.terracotta
                     )
                 }
 
@@ -313,7 +313,7 @@ struct TodayView: View {
                     StatBadge(
                         icon: "calendar",
                         value: "\(daysRecordedThisYear) this year",
-                        color: Color(red: 0.357, green: 0.486, blue: 0.420)
+                        color: DS.Palette.sage
                     )
                 }
 
@@ -454,7 +454,7 @@ struct TodayView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color(.secondarySystemGroupedBackground))
                     .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-                    .shadow(color: Color.black.opacity(0.04), radius: 12, y: 4)
+                    .dsShadowSoft()
                 }
                 .buttonStyle(.plain)
             } else {
@@ -467,14 +467,14 @@ struct TodayView: View {
                         HStack(spacing: 12) {
                             Image(systemName: "arrow.down")
                                 .font(.system(size: 14, weight: .semibold))
-                                .foregroundColor(Color(red: 0.831, green: 0.647, blue: 0.278))
+                                .foregroundColor(DS.Palette.gold)
                             Text("Tap the mic below to plant your first star")
                                 .font(.system(size: 14, weight: .medium, design: .rounded))
                                 .foregroundColor(.secondary)
                         }
                         .padding(.vertical, 12)
                         .padding(.horizontal, 20)
-                        .background(Color(red: 0.831, green: 0.647, blue: 0.278).opacity(0.08))
+                        .background(DS.Palette.gold.opacity(0.08))
                         .clipShape(Capsule())
                     }
                 } else {
@@ -482,11 +482,11 @@ struct TodayView: View {
                     VStack(spacing: 16) {
                         ZStack {
                             Circle()
-                                .fill(Color(red: 0.357, green: 0.486, blue: 0.420).opacity(0.1))
+                                .fill(DS.Palette.sage.opacity(0.1))
                                 .frame(width: 80, height: 80)
                             Image(systemName: "mic.circle.fill")
                                 .font(.system(size: 36))
-                                .foregroundColor(Color(red: 0.357, green: 0.486, blue: 0.420))
+                                .foregroundColor(DS.Palette.sage)
                         }
 
                         VStack(spacing: 4) {
@@ -763,8 +763,8 @@ struct TodayView: View {
         if normalizedLevel > threshold {
             // Warm gradient from sage to gold — NOT traffic light colors
             let t = CGFloat(index) / barCount
-            let sage = Color(red: 0.357, green: 0.486, blue: 0.420)
-            let gold = Color(red: 0.831, green: 0.647, blue: 0.278)
+            let sage = DS.Palette.sage
+            let gold = DS.Palette.gold
             return t < 0.6 ? sage : gold
         }
         return Color.secondary.opacity(0.12)

--- a/solyn/solyn/TodayView.swift
+++ b/solyn/solyn/TodayView.swift
@@ -258,6 +258,12 @@ struct TodayView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
                     headerSection
+                    // Body Twin idle-state slot: today's one-line body whisper,
+                    // or the one-time Health invite — never both, never while
+                    // recording, never in the first-run zero-state.
+                    if recordingState == .idle {
+                        BodyTwinIdleCards()
+                    }
                     entryCardSection
                     if recordingState == .idle && latestEntry == nil {
                         promptsSection
@@ -269,6 +275,10 @@ struct TodayView: View {
             }
             Spacer(minLength: 0)
             recordingSection
+        }
+        .task { await BodyWhisperProvider.shared.refreshIfNeeded() }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            Task { await BodyWhisperProvider.shared.refreshIfNeeded() }
         }
     }
 

--- a/solyn/solyn/TwinChatView.swift
+++ b/solyn/solyn/TwinChatView.swift
@@ -570,7 +570,7 @@ struct TwinChatView: View {
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)
                     .background(
-                        RoundedRectangle(cornerRadius: 18)
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
                             .fill(message.isUser
                                   ? themeManager.accentColor
                                   : themeManager.cardBackgroundColor)

--- a/solyn/solyn/TwinResolutionView.swift
+++ b/solyn/solyn/TwinResolutionView.swift
@@ -41,8 +41,11 @@ struct TwinResolutionCard: View {
                     .foregroundColor(.secondary.opacity(0.5))
             }
             .padding(16)
-            .background(RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(Color(.secondarySystemBackground)))
+            // Grouped-secondary matches every neighboring Twin-tab card
+            // (plain-secondary rendered cool gray on the warm ivory canvas
+            // in light, and a darker off-shade in Dark).
+            .background(RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color(.secondarySystemGroupedBackground)))
         }
         .buttonStyle(.plain)
         .sheet(isPresented: $showSheet) { TwinResolutionSheet() }

--- a/solyn/solyn/solyn.entitlements
+++ b/solyn/solyn/solyn.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.$(CFBundleIdentifier)</string>

--- a/solyn/solyn/solynApp.swift
+++ b/solyn/solyn/solynApp.swift
@@ -33,6 +33,10 @@ struct DailyVoxApp: App {
         LocalAIEngine.configure(store: twinStore)
         DigitalTwinEngine.configure(store: twinStore)
 
+        // Body Twin state is LOCAL-ONLY (guideline 2.5.1): a backup-excluded
+        // JSON file, never the CloudKit-synced store above.
+        DigitalTwinEngine.configureBodyTwinStore(FileBodyTwinStateStore())
+
         ScreenshotDataSeeder.seedIfNeeded(context: persistenceController.container.viewContext)
     }
 

--- a/solyn/solynTests/solynTests.swift
+++ b/solyn/solynTests/solynTests.swift
@@ -35,7 +35,9 @@ struct MoodTests {
     @Test func moodInitFromRawValue() {
         #expect(Mood(rawValue: "happy") == .happy)
         #expect(Mood(rawValue: "sad") == .sad)
-        #expect(Mood(rawValue: "") == .none)
+        // Explicit `Mood.none`: a bare `.none` against a `Mood?` resolves to
+        // Optional.none and can never match `.some(.none)`.
+        #expect(Mood(rawValue: "") == Mood.none)
         #expect(Mood(rawValue: "invalid") == nil)
     }
 

--- a/solyn/solynTests/solynTests.swift
+++ b/solyn/solynTests/solynTests.swift
@@ -8,6 +8,7 @@
 import Testing
 import Foundation
 import CryptoKit
+import DailyVoxTwinEngine
 @testable import solyn
 
 // MARK: - Mood Tests
@@ -137,5 +138,102 @@ struct EncryptionErrorTests {
             #expect(error.errorDescription != nil)
             #expect(!error.errorDescription!.isEmpty)
         }
+    }
+}
+
+// MARK: - Body Twin Restore-Filtering Tests
+
+/// The fold-once / decided-stays-decided invariants around backup restore:
+/// a snapshot the user already Kept or Let go of must never re-enter the
+/// review queue, no matter how many times a stale .dvx is re-imported.
+@MainActor
+struct BodyTwinRestoreFilteringTests {
+
+    private func pending(_ id: UUID, at date: Date = Date()) -> PendingSnapshot {
+        PendingSnapshot(id: id,
+                        snapshot: HealthSnapshot(capturedAt: date, sleepHours: 7.0),
+                        createdAt: date)
+    }
+
+    private func resetStores() {
+        PendingSnapshotQueue.shared.wipe()
+        KeptSnapshotStore.shared.wipe()
+    }
+
+    @Test func discardedIdNeverReentersTheQueue() {
+        resetStores()
+        defer { resetStores() }
+
+        let tombstoned = UUID()
+        PendingSnapshotQueue.shared.restore([pending(tombstoned)])
+        #expect(PendingSnapshotQueue.shared.count == 1)
+
+        // Let go — deleted, and the id is tombstoned.
+        BodyTwinManager.shared.discardSnapshot(id: tombstoned)
+        #expect(PendingSnapshotQueue.shared.count == 0)
+
+        // Re-importing a backup that still carried it must NOT resurrect it.
+        PendingSnapshotQueue.shared.restore([pending(tombstoned)])
+        #expect(PendingSnapshotQueue.shared.count == 0,
+                "A Let-go snapshot came back through backup restore")
+    }
+
+    @Test func alreadyKeptIdIsFilteredOutOfRestoredPending() {
+        resetStores()
+        defer { resetStores() }
+
+        let keptId = UUID()
+        let freshId = UUID()
+        KeptSnapshotStore.shared.restore([
+            KeptSnapshot(id: keptId,
+                         snapshot: HealthSnapshot(capturedAt: Date(), sleepHours: 6.5),
+                         keptAt: Date())
+        ])
+
+        // A stale backup exported while keptId was still pending.
+        let payload = ExportableBodyTwin(state: nil,
+                                         keptSnapshots: [],
+                                         pendingSnapshots: [pending(keptId), pending(freshId)])
+        BodyTwinManager.shared.restoreFromBackup(payload)
+
+        let queuedIds = PendingSnapshotQueue.shared.items.map(\.id)
+        #expect(!queuedIds.contains(keptId),
+                "An already-Kept snapshot re-entered the review queue")
+        #expect(queuedIds.contains(freshId))
+    }
+
+    @Test func keepSnapshotSkipsFoldWhenIdAlreadyKept() {
+        resetStores()
+        defer { resetStores() }
+
+        let id = UUID()
+        let snapshot = HealthSnapshot(capturedAt: Date(), sleepHours: 8.0)
+        KeptSnapshotStore.shared.restore([KeptSnapshot(id: id, snapshot: snapshot, keptAt: Date())])
+        PendingSnapshotQueue.shared.restore([pending(id)])
+        // (Duplicate deliberately forced past the restore filters.)
+        let foldedBefore = DigitalTwinEngine.shared.bodyTwin.entriesWithSnapshot
+
+        BodyTwinManager.shared.keepSnapshot(id: id)
+
+        #expect(DigitalTwinEngine.shared.bodyTwin.entriesWithSnapshot == foldedBefore,
+                "Keeping an already-kept id must not fold the snapshot a second time")
+        #expect(PendingSnapshotQueue.shared.count == 0)
+    }
+
+    @Test func pendingQueueCapsAtThirtyDroppingOldest() {
+        resetStores()
+        defer { resetStores() }
+
+        let base = Date(timeIntervalSince1970: 1_780_000_000)
+        for i in 0..<35 {
+            PendingSnapshotQueue.shared.enqueue(
+                HealthSnapshot(capturedAt: base.addingTimeInterval(Double(i) * 60),
+                               sleepHours: 7.0))
+        }
+
+        #expect(PendingSnapshotQueue.shared.count == 30)
+        // Oldest five dropped: the earliest surviving capture is #5.
+        let earliest = PendingSnapshotQueue.shared.items.map(\.snapshot.capturedAt).min()
+        #expect(earliest == base.addingTimeInterval(5 * 60))
     }
 }

--- a/solyn/solynUITests/GenerateScreenshots.swift
+++ b/solyn/solynUITests/GenerateScreenshots.swift
@@ -315,3 +315,57 @@ class ScreenshotTests: XCTestCase {
         add(attachment)
     }
 }
+
+// MARK: - Dark-theme captures
+//
+// Separate class so the App Store suite above (-only-testing:…/ScreenshotTests)
+// never picks these up. `-selectedTheme Dark` lands in the NSArgumentDomain,
+// which ThemeManager's UserDefaults read resolves first — same fixture data,
+// dark appearance. Run explicitly:
+//   -only-testing:solynUITests/DarkScreenshotTests
+
+class DarkScreenshotTests: XCTestCase {
+
+    let app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app.launchArguments += ["-UITesting", "-ScreenshotMode",
+                                "-hasCompletedOnboarding", "YES",
+                                "-selectedTheme", "Dark",
+                                "-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        app.launch()
+    }
+
+    private func tab(_ name: String) {
+        let tabButton = app.tabBars.buttons[name]
+        if tabButton.waitForExistence(timeout: 3) { tabButton.tap(); return }
+        let button = app.buttons[name].firstMatch
+        if button.waitForExistence(timeout: 3) { button.tap() }
+    }
+
+    private func snap(_ name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    func test90_DarkMainTabs() throws {
+        tab("Record"); sleep(3); snap("D1_Record_dark")
+        tab("Journal"); sleep(2); snap("D2_Journal_dark")
+        tab("Insights"); sleep(2)
+        let keepGoing = app.buttons["Keep Going"]
+        if keepGoing.waitForExistence(timeout: 3) { keepGoing.tap(); sleep(1) }
+        snap("D3_Insights_dark")
+        tab("Twin"); sleep(2); snap("D4_Twin_dark")
+        // Scroll until the Body Twin card is up — both new v1.5 Twin cards in frame.
+        let bodyCard = app.staticTexts["Body Twin"].firstMatch
+        var attempts = 0
+        while !bodyCard.isHittable && attempts < 4 {
+            app.swipeUp(); attempts += 1; sleep(1)
+        }
+        snap("D5_Twin_BodyCard_dark")
+        tab("Settings"); sleep(2); snap("D6_Settings_dark")
+    }
+}

--- a/solyn/solynUITests/GenerateScreenshots.swift
+++ b/solyn/solynUITests/GenerateScreenshots.swift
@@ -179,7 +179,133 @@ class ScreenshotTests: XCTestCase {
         takeScreenshot(named: "08_Settings")
     }
 
+    // MARK: - Screenshot 10: Twin tab — Body Twin card
+
+    func test10_TwinTabBodyCard() throws {
+        navigateToTab("Twin")
+        sleep(2)
+
+        // BodyTwinCard sits below the orb header / Ask / Twin Resolution —
+        // scroll until it is on screen, then lift it clear of the tab bar.
+        let bodyCard = app.staticTexts["Body Twin"].firstMatch
+        scrollUntilHittable(bodyCard)
+        liftAboveTabBar()
+        takeScreenshot(named: "10_Twin_BodyCard")
+    }
+
+    // MARK: - Screenshot 11: Review-before-learning sheet (2 pending)
+
+    func test11_BodyReviewSheet() throws {
+        navigateToTab("Twin")
+        sleep(2)
+
+        let bodyCard = app.staticTexts["Body Twin"].firstMatch
+        scrollUntilHittable(bodyCard)
+        XCTAssertTrue(bodyCard.waitForExistence(timeout: 3), "Body Twin card not found on Twin tab")
+        bodyCard.tap()
+        sleep(2)
+
+        XCTAssertTrue(app.staticTexts["Your body had a say"].waitForExistence(timeout: 3),
+                      "Review sheet did not open")
+        takeScreenshot(named: "11_Twin_ReviewSheet")
+    }
+
+    // MARK: - Screenshot 12: Settings — Health section
+
+    func test12_SettingsHealth() throws {
+        navigateToTab("Settings")
+        sleep(2)
+
+        // Anchor on the section's last row, then nudge so the master toggle
+        // (section top) sits just under the nav bar — whole section framed.
+        let wipeButton = app.buttons["Wipe All Health Snapshots"].firstMatch
+        scrollUntilHittable(wipeButton, maxSwipes: 8)
+        let masterToggle = app.staticTexts["Body Twin"].firstMatch
+        let topY = masterToggle.frame.minY
+        if topY < 140 {
+            nudgeContentDown(by: 150 - topY)
+        }
+        takeScreenshot(named: "12_Settings_Health")
+    }
+
+    // MARK: - Screenshot 13: Today idle — body whisper
+
+    func test13_TodayWhisper() throws {
+        navigateToTab("Record")
+        sleep(3)   // whisper computes in TodayView's .task
+        takeScreenshot(named: "13_Today_Whisper")
+    }
+
+    // MARK: - Screenshot 14: Insights — Body & Mood card
+
+    func test14_InsightsBodyMood() throws {
+        navigateToTab("Insights")
+        sleep(2)
+
+        let keepGoingButton = app.buttons["Keep Going"]
+        if keepGoingButton.waitForExistence(timeout: 3) {
+            keepGoingButton.tap()
+            sleep(1)
+        }
+
+        // Scroll to the card's footer line so the whole card is framed.
+        let footer = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS %@", "a noticing, not a prescription")).firstMatch
+        scrollUntilHittable(footer, maxSwipes: 10)
+        liftAboveTabBar()
+        takeScreenshot(named: "14_Insights_BodyMood")
+    }
+
+    // MARK: - Screenshot 15: Today idle — one-time Health invite
+
+    func test15_TodayInviteCard() throws {
+        // Relaunch in the not-yet-authorized state (same pattern as
+        // test00's -OnboardingDemo relaunch).
+        app.terminate()
+        app.launchArguments = ["-UITesting", "-ScreenshotMode", "-BodyTwinInviteDemo",
+                               "-hasCompletedOnboarding", "YES",
+                               "-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        app.launch()
+
+        navigateToTab("Record")
+        sleep(2)
+        XCTAssertTrue(app.staticTexts["Your Twin can learn what your body felt"]
+            .waitForExistence(timeout: 5), "Invite card not shown under -BodyTwinInviteDemo")
+        takeScreenshot(named: "15_Today_InviteCard")
+    }
+
     // MARK: - Helpers
+
+    /// Swipes up until `element` reports hittable (or swipes run out).
+    private func scrollUntilHittable(_ element: XCUIElement, maxSwipes: Int = 4) {
+        var attempts = 0
+        while !element.isHittable && attempts < maxSwipes {
+            app.swipeUp()
+            attempts += 1
+            sleep(1)
+        }
+    }
+
+    /// Gentle partial scroll (~30% of the screen) so a just-revealed card sits
+    /// clear of the floating tab bar; slow velocity + hold suppress inertia.
+    private func liftAboveTabBar() {
+        let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.72))
+        let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.42))
+        start.press(forDuration: 0.1, thenDragTo: end,
+                    withVelocity: .slow, thenHoldForDuration: 0.3)
+        sleep(1)
+    }
+
+    /// Reverse-scrolls by an exact number of points (drag downward), used to
+    /// re-reveal content that a full swipe carried off the top.
+    private func nudgeContentDown(by points: CGFloat) {
+        guard points > 0 else { return }
+        let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.35))
+        let end = start.withOffset(CGVector(dx: 0, dy: points))
+        start.press(forDuration: 0.1, thenDragTo: end,
+                    withVelocity: .slow, thenHoldForDuration: 0.3)
+        sleep(1)
+    }
 
     private func takeScreenshot(named name: String) {
         let screenshot = app.screenshot()


### PR DESCRIPTION
## What this is

The v1.5 release: **Body Twin iPhone layer** — HealthKit background snapshots, activity context, the review-and-discard queue (the gate every future passive signal flows through), Settings → Health, body whisper, and embodied insights. Twin Resolution, the Liquid Glass tab bar, and the Twin-tab perf fix are already on main and ship with it. Version bumped to **1.5.0 (build 19)**.

## How it was built and verified

- Understand-phase workflow (8 mappers + critic) before any code; all design decisions ratified up front (binding: health data local-only, never CloudKit; fold only on user Keep; background signals only — no recording HR claims until the Watch release)
- 7 sequential build-verified implementation stages
- **52-agent adversarial review** (6 dimensions, 2 independent refuters per finding): 23 raw → 14 confirmed + 7 split findings — **all fixed**, incl. backup re-import double-fold (now tombstoned + fold-once guarded + unit-tested), sleep window anchored to the calendar night (was capture−18h), Motion usage string rewritten to shipping behavior only, workout queries stripped (no Workouts type on the permission sheet)
- Tests: engine **57/57**, app unit **18/18**, six Body Twin UI screenshot tests green (94 s — the perf fix at work)
- Screenshot-verified UI on iOS 26 sim, light + dark (two dark-theme legibility bugs caught and fixed); shots at `/private/tmp/ob_shots/bodytwin/`
- Static audits: widget extension zero health surface; plist keys ship in the same commit as live call paths; no Core Data/CloudKit schema change at all

## App Review posture (2.5.1 history)

Real HealthKit code ships behind the keys this time; read-only, five types, value-framed ask after entry 3 (never at first launch); health data provably never reaches iCloud (engine guard tests). `aps-environment` untouched (archive flips it as usual).

## Needs your device test before merge (sim has no health data)

1. HealthKit permission flow (invite card after 3rd entry, and via Settings → Health)
2. A real capture: record an entry at rest → snapshot appears in the review queue → Keep → Body card count increments
3. Motion prompt timing (should appear during enable, not mid-save)
4. Backup export → wipe → import round-trip
5. Whisper card content on a real morning

## Conscious sign-offs I made (flag if you disagree)

- Invite sheet + Health usage string say "never uploaded, never synced" without the encrypted-backup caveat — the Settings footer (the standing promise) carries the full nuance; permission strings stay concise
- `.postWorkout` UI branch retained (unreachable in v1.5) for imported/Watch-era snapshots
- Engine repo: branch merged as DailyVoxTwin PR #1 — the app pins against engine main `f8089bb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)