### PR TITLE
Blog: v1.4.1 Speak Your First Star + v1.5 Body Twin (honest retrospective)

### DIFF
--- a/solyn/website/public/blog/body-twin-v1-5-what-shipped.html
+++ b/solyn/website/public/blog/body-twin-v1-5-what-shipped.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R544S4KDBQ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-R544S4KDBQ');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Body Twin Shipped — And Where It Honestly Falls Short of the Plan</title>
+  <meta name="description" content="DailyVox v1.5 gives the Digital Twin a physiological channel, on-device, with an honesty gate for passive signals and a validation stack built on lift-over-baseline. It also owns three honest shortfalls against the original plan.">
+  <meta name="keywords" content="dailyvox v1.5, body twin, on-device machine learning, model validation, synthetic personas, negative controls, mirror not oracle, no server feature store, per-person baseline, on-device ai">
+  <meta name="theme-color" content="#FAF8F5">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://getdailyvox.com/blog/body-twin-v1-5-what-shipped">
+  <meta property="og:title" content="Body Twin Shipped — And Where It Honestly Falls Short of the Plan">
+  <meta property="og:description" content="What actually shipped in v1.5, the honesty gate we had to build for passive physiological signals, how you validate a model you can never observe — and a candid section on the three places v1.5 falls short of what we promised.">
+  <meta property="og:image" content="https://getdailyvox.com/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="canonical" href="https://getdailyvox.com/blog/body-twin-v1-5-what-shipped">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="/app-icon.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "Body Twin Shipped — And Where It Honestly Falls Short of the Plan",
+    "description": "DailyVox v1.5 gives the Digital Twin a physiological channel, entirely on-device, with an honesty gate for passive signals and a validation stack built on lift-over-baseline. It also owns three honest shortfalls against the original plan.",
+    "url": "https://getdailyvox.com/blog/body-twin-v1-5-what-shipped",
+    "datePublished": "2026-07-05",
+    "dateModified": "2026-07-05",
+    "author": { "@type": "Organization", "name": "DailyVox" },
+    "publisher": { "@type": "Organization", "name": "DailyVox", "url": "https://getdailyvox.com" },
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://getdailyvox.com/blog/body-twin-v1-5-what-shipped" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Did the Apple Watch recording-time body layer ship in v1.5?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No. The original plan promised a live physiological signature captured at the moment you record — what your heart is doing as you speak. Doing that honestly needs the Apple Watch for live sampling, and it is deferred. v1.5 ships only the background-context layer, drawn from health data that is already stable and settled by the time you journal. We chose to ship one layer we could stand behind rather than fabricate a second one from phone-only data that would produce a confident wrong number."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can the DailyVox Twin predict my mood tomorrow?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No, and we measured it. On short-horizon mood, the Twin does not beat a trivial persistence baseline — 'tomorrow is about the same as today.' That is the expected result and it matches the affect-forecasting literature, where persistence baselines are notoriously hard to beat. So the Twin is positioned as a conditional-mean mirror, not an oracle: 'given a day like this, here is your typical response', and 'you have felt this before, and here is what tended to follow.' We let the negative result set the product boundary rather than ship a forecaster that would fail quietly in the field."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is DailyVox's 'measurable fidelity' proven on real people?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Not yet. The whole validation stack runs on synthetic and model-generated personas with known ground-truth traits. That establishes feasibility, style-invariance, and the shape of the learning curves — but not human accuracy. Real-diary validation, under the same lift-over-baseline discipline and the same nothing-collected constraint, is unfinished and gated work. We would rather state plainly what we cannot yet claim than imply a clean synthetic number holds for real people writing real diaries."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Why does DailyVox store heart signals as a delta instead of a heart rate number?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Because absolute heart rate is dominated by between-person variation — fitness, age, medication — that swamps the within-person signal we actually care about. Instead of a raw number, the Twin stores a deviation from your own hour-of-day baseline: this heartbeat relative to what is normal for you at this time of day. Baselining per person and per hour removes most of that nuisance variance, and as a side effect makes the representation portable — a delta means roughly the same thing across two very different bodies, where a raw reading does not. It is per-subject standardisation applied at the moment of capture."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Why can't DailyVox reprocess or backfill its health features later?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Because there is no server-side feature store. Every feature is computed, stored, and consumed on one device. There is no central place to reprocess history when a transform improves, no backfill, no normalisation statistics shared across users, no way to recompute a baseline centrally when its definition changes. Baselines are personal and live locally; migrations run on-device or not at all. That rules out an entire comfortable class of architecture — and it is precisely the constraint that lets the privacy label stay literally 'Data Not Collected.'"
+        }
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://getdailyvox.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://getdailyvox.com/blog"},
+      {"@type": "ListItem", "position": 3, "name": "Body Twin Shipped — And Where It Honestly Falls Short of the Plan"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav>
+    <div class="container">
+      <a href="/" class="nav-brand">
+        <img src="/app-icon.png" alt="DailyVox">
+        <span>DailyVox</span>
+      </a>
+      <ul class="nav-links">
+        <li><a href="/blog">Blog</a></li>
+        <li><a href="/privacy">Privacy</a></li>
+        <li><a href="/support">Support</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <main class="container">
+    <article class="blog-article">
+      <div class="article-header">
+        <a href="/blog" class="back-link">&larr; Back to Blog</a>
+        <span class="blog-tag tag-technology">Engineering</span>
+        <h1>Body Twin Shipped — And Where It Honestly Falls Short of the Plan</h1>
+        <p class="article-meta">July 5, 2026 &middot; 8 min read</p>
+      </div>
+
+      <div class="article-body">
+        <p>A month ago we published <a href="/blog/body-twin-healthkit-watch">the original plan for Body Twin</a>: give the Digital Twin a second channel of truth by reading your body, on the iPhone alone, without breaking the promise that nothing is collected. This is the release retrospective. Some of that plan shipped in v1.5, and it is genuinely the part we are proud of. Some of it did not, and this post is at least as much about the second category as the first. If you only read the plan, you would come away expecting more than v1.5 delivers — so the honest thing is to say exactly what landed, what slipped, and why we think the half we shipped is the defensible half.</p>
+
+        <p>The engineering context that makes all of this unusual: DailyVox has no server-side anything. No feature store, no training cluster, no analytics pipeline you could inspect to see whether a model is misbehaving. The Twin is a small personal model that lives and dies on one device, seen by exactly one person. That framing is easy to say and removes almost every instrument an ML team normally leans on — which is why the validation half of this post exists at all.</p>
+
+        <h2>Two-layer sampling, and why only one layer shipped</h2>
+
+        <p>The design separates two very different physiological signals. The first is <em>background context</em>: sleep, morning heart-rate variability, resting heart rate, steps, mindful minutes — snapshotted at the moment you journal from health data that is already stable and settled. The second is a <em>foreground recording-time signature</em>: what your body is doing in the very moment you speak.</p>
+
+        <p>The second layer is the interesting one, and it is deliberately <strong>not in this build</strong>. Reading it properly needs a wrist sensor for live sampling during the recording; approximating it from phone-only data would produce a confident, wrong number, and a confident wrong number is worse than an honest absence. So v1.5 ships the background-context layer only. The bulk of this post's "what shipped" is really about making that one layer trustworthy — because a single physiological channel with no server to clean it up has to be right the first time, on-device.</p>
+
+        <h2>Activity context is the field everything hinges on</h2>
+
+        <p>A raised heart rate means nothing without knowing why. The same reading is stress at a desk and unremarkable on a jog. So every snapshot carries an activity-context value — at rest, active, post-workout, or unknown — derived from the phone's motion sensing. The critical decision here is that <strong>"unknown" is a first-class value we are willing to emit rather than guess</strong>. Without this tag the physiological signal is not merely noisy; it is systematically misleading, because it would read every workout as anxiety. An honest "unknown" is worth more than a precise lie, and treating it as a real category rather than a fallback is what keeps the background layer from poisoning the model with exercise mislabelled as emotion.</p>
+
+        <h2>Heart signals are stored as deltas, not absolutes</h2>
+
+        <p>We do not store a raw heartbeat. We store a deviation from <em>your own</em> hour-of-day baseline — this heart activity relative to what is normal for you at this time of day. The reason is standard but load-bearing: absolute heart rate is dominated by between-person variation (fitness, age, medication) that swamps the within-person signal we actually care about. Baselining per person and per hour removes most of that nuisance variance, and, as a side effect, makes the representation portable — a delta means roughly the same thing across two very different bodies, where a raw reading does not. It is per-subject standardisation applied at the point of capture, and because there is no server, the baseline it standardises against is computed and refined locally as your entries accumulate.</p>
+
+        <h2>The review-and-discard queue as an honesty primitive</h2>
+
+        <p>Passively-captured signals do not flow straight into the Twin. They land in a review queue and wait for you to explicitly keep or discard each one before it can ever reach the model. This inverts the usual passive-sensing default, where data is ingested first and maybe forgotten later. Here, nothing passive is trusted by default.</p>
+
+        <p>We built it as a reusable gate, not a one-off screen: every future passive signal — the deferred recording-time layer included, whenever it arrives — inherits the same keep-or-discard barrier. It is opt-in consent expressed as a data-flow primitive rather than a settings toggle, and it has a clean consequence for the model: the training set for the physiological channel is, by construction, only the data you chose to include. That is a stronger guarantee than a privacy policy paragraph, because it is enforced by where the data can and cannot go.</p>
+
+        <h2>No server-side feature store — the real ML-systems constraint</h2>
+
+        <p>Health-derived data stays local to the device: never synced to a cloud database, excluded from device backups, and able to leave only inside your own encrypted export. Per-signal opt-outs filter before the read, so a disabled signal is never even fetched. For an ML engineer the consequence is structural, not merely legal: <strong>there is no server-side feature store.</strong> Every feature is computed, stored, and consumed on one device. There is no place to reprocess history when you improve a transform, no backfill, no normalisation statistics shared across users, no way to recompute a baseline centrally when its definition changes. Baselines are personal and live locally; migrations run on-device or not at all. It rules out an entire, comfortable class of architecture — and it is the constraint that makes the rest of the promise credible.</p>
+
+        <p>Riding the same release train: a native Liquid Glass tab bar, a self-prediction fidelity feature we call <strong>Twin Resolution</strong> — a felt read on how well your Twin currently knows you, which is the maturation curve below surfaced honestly to the user — and a fix that stopped the constellation view from pinning the run loop while rendering.</p>
+
+        <h2>How do you validate a model you can never see?</h2>
+
+        <p>This is the part the on-device promise makes genuinely hard, and it is the payoff. We cannot watch the model in production, so validation happens <em>before</em> shipping, on synthetic and model-generated personas, and every result is reported against an explicit baseline. The approach follows the spirit of recent generative-agent and persona-simulation work: construct personas with known ground-truth traits, generate diary-like text from them, and check what the pipeline recovers.</p>
+
+        <p><strong>Lift over an explicit baseline, or it does not count.</strong> The spine of the whole evaluation is a refusal to report raw agreement numbers. A "do-nothing" model — one that ignores the data and always predicts the prior — scores around 75% on a naive agreement metric for these tasks, purely because the label distribution is skewed. That kind of 75% flatters every model equally; it is a vanity metric. So every result is reported as lift over a named baseline plus a tracking correlation: a constant-prior baseline for fidelity, a climatology-plus-persistence baseline for forecasting, a population-mean baseline for personality. If a model cannot beat its baseline, we say so.</p>
+
+        <p><strong>Self-prediction fidelity matures on a curve.</strong> Against synthetic personas with analytic ground truth, the Twin's recovery of a persona's traits beats the do-nothing baseline, and — usefully for product design — the self-model stabilises after roughly twenty entries. That maturation curve is not a nuisance to hide; it is the honest content behind Twin Resolution. Below about twenty entries the model genuinely does not know you well, and the product should say so rather than perform a confidence it has not earned.</p>
+
+        <p><strong>On-device personality inference is feasible, and cheap.</strong> A light regressor over the platform's on-device sentence embeddings recovers assigned Big Five traits from diary text at roughly 0.74&ndash;0.83 correlation on a synthetic corpus — for a model measured in kilobytes, because the embeddings themselves already sit resident in the operating system. Two properties make this more than a curiosity. First, <em>cross-corpus robustness</em>: a model trained on one writing style still recovers personality from a deliberately different style at about 0.74. That gap between train and test styles is the test that it learned personality signal rather than a stylistic fingerprint — and 0.74 sits cleanly above the roughly 0.38 band that human-text-to-personality studies report, which is our sanity ceiling for "is this even a plausible amount of signal." Second, it is honestly bounded: the labels are synthetic, so this demonstrates feasibility and style-invariance, <em>not</em> human accuracy. There is also a size discipline here worth stating: for plain valence and sentiment, the platform's built-in on-device language stack is good enough that a bespoke model is not worth the bytes. Custom ML earns its place specifically for personality, which the built-in stack cannot produce at all.</p>
+
+        <p><strong>Multilingual means per-language heads, not translated rules.</strong> English keyword heuristics do not transfer to other languages — obviously — but neither does a naive "translate then apply" shortcut. The learned embedding path transfers, but only per language, because the embedding spaces differ; a model trained on one language is useless in another. So multilingual support means separately trained heads per language, not one model plus a translation layer. And on-device sentence embeddings exist for only a handful of languages today, which is a concrete constraint on which languages we can prioritise — the platform's coverage, not our ambition, sets the order.</p>
+
+        <p><strong>Negative controls, so the metrics can say no.</strong> A validation suite that only ever produces good news is broken. The evaluation includes negative controls: shuffle the labels or the inputs and confirm the metrics collapse back to baseline. When personality correlation falls to chance under shuffling and forecasting lift disappears, the positive results become trustworthy — we have shown the metric is capable of reporting failure, which is the only thing that makes it capable of reporting success.</p>
+
+        <h2>Where v1.5 falls short of the plan</h2>
+
+        <p>The plan post promised more than this release delivers. That is not something to bury under the good news, so here it is plainly. Three shortfalls, stated as shortfalls.</p>
+
+        <h3>1. The embodied recording-time body layer did not ship</h3>
+
+        <p>The plan promised a live physiological signature captured at the moment of recording — the foreground layer that reads what your body is doing as you actually speak. It is deferred. Reading it honestly requires the wrist sensor for live sampling, and rather than fabricate that layer from phone-only data, we shipped without it. v1.5 delivers the background-context layer alone. This was a deliberate choice — one honest layer over two where one would be invented — but it is still a promise from the plan that this release does not keep, and the more embodied half of "Body Twin" is not yet in your hands.</p>
+
+        <h3>2. The Twin cannot forecast your mood</h3>
+
+        <p>The roadmap leaned on a predictive framing: a Twin that could see a little way ahead. We measured that directly, and it does not hold. On short-horizon mood, the Twin does not beat a trivial persistence baseline — "tomorrow is about the same as today." This is not a bug we are working around; it is the expected result, and it aligns with an affect-forecasting literature in which persistence baselines are famously hard to beat and people are famously poor at predicting their own future feelings. So the Twin behaves as a conditional-mean estimator — "given a day like this, here is your typical response" — not a trajectory predictor. We let the honest negative result set the product boundary: DailyVox is positioned as reflection and precedent ("you have felt this before, and here is what tended to follow"), and never as mood prediction. It is a mirror, not an oracle, and we can prove it fails the oracle test.</p>
+
+        <h3>3. "Measurable fidelity" is proven on synthetic data only</h3>
+
+        <p>Everything in the validation section above runs on synthetic and model-generated personas. That establishes feasibility, style-invariance, and the shape of the learning curves — genuinely useful things to know before shipping. It does <em>not</em> establish human accuracy. No amount of clean synthetic performance substitutes for real people writing real diaries, and we have not yet done that study. Real-diary validation, under the same lift-over-baseline discipline and the same on-device, nothing-collected constraint, is unfinished, gated work. Until it is done, "measurable fidelity" is a claim about the measurement apparatus and the synthetic curves, not a claim about how well the Twin reflects an actual person. We would rather state that boundary than let a synthetic number stand in for a human one.</p>
+
+        <h2>The half we shipped is the half we can defend</h2>
+
+        <p>None of the three shortfalls above is comfortable to publish, and that is rather the point. The Twin is a mirror of your reflective self — the person who shows up in what you chose to write down — not a clone of you, and not a forecaster. The most important results in this release are the negative ones: forecasting that cannot beat persistence, accuracy claims fenced off as synthetic-only, a "do-nothing" baseline held up next to every number so that none of them can flatter us quietly. An engineering team that measures honestly ends up shipping the defensible half and naming the rest as unfinished. That is what v1.5 is. We would rather ship a mirror we can stand behind than an oracle we cannot — especially one we could never watch fail.</p>
+
+        <p>—</p>
+
+        <h2>Related Articles</h2>
+        <ul>
+          <li><a href="/blog/body-twin-healthkit-watch">The Body Twin: How DailyVox v1.5 Brings Apple Health and Apple Watch to Your Digital Twin (the original plan)</a></li>
+          <li><a href="/blog/speak-your-first-star-v1-4-1">DailyVox v1.4.1: Speak Your First Star — the Cold-Start Problem for a Model of One</a></li>
+          <li><a href="/blog/on-device-ai-maturity-model">The On-Device AI Maturity Model</a></li>
+          <li><a href="/blog/your-journal-app-should-predict-not-just-record">Why Your Journal App Should Predict, Not Just Record</a></li>
+        </ul>
+
+        <p><a href="https://apps.apple.com/app/dailyvox">Download DailyVox on the App Store</a> &middot; <a href="/blog/body-twin-healthkit-watch">Read the original Body Twin plan</a> &middot; <a href="/">getdailyvox.com</a></p>
+      </div>
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DailyVox. Voice diary that respects your privacy.</p>
+      <p><a href="/privacy">Privacy</a> &middot; <a href="/support">Support</a> &middot; <a href="/blog">Blog</a></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/solyn/website/public/blog/index.html
+++ b/solyn/website/public/blog/index.html
@@ -49,6 +49,24 @@
     </div>
 
     <div class="blog-list">
+      <a href="/blog/body-twin-v1-5-what-shipped" class="blog-list-item">
+        <div class="blog-list-meta">
+          <span class="blog-tag tag-technology">Engineering</span>
+          <span class="blog-date">July 5, 2026</span>
+        </div>
+        <h2>Body Twin Shipped — And Where It Honestly Falls Short of the Plan</h2>
+        <p>What actually shipped in v1.5: the on-device background-context layer, an honesty gate for passive signals, and a validation stack built on lift-over-baseline — plus a candid account of the three places it falls short of the plan.</p>
+      </a>
+
+      <a href="/blog/speak-your-first-star-v1-4-1" class="blog-list-item">
+        <div class="blog-list-meta">
+          <span class="blog-tag tag-technology">Release</span>
+          <span class="blog-date">July 4, 2026</span>
+        </div>
+        <h2>DailyVox v1.4.1: Speak Your First Star — the Cold-Start Problem for a Model of One</h2>
+        <p>A model of one person has no crowd to borrow strength from, so the first entry is load-bearing. Why v1.4.1 ends onboarding with a microphone rather than a form — and transcribes it entirely on-device.</p>
+      </a>
+
       <a href="/blog/body-twin-healthkit-watch" class="blog-list-item">
         <div class="blog-list-meta">
           <span class="blog-tag tag-technology">Roadmap</span>

--- a/solyn/website/public/blog/speak-your-first-star-v1-4-1.html
+++ b/solyn/website/public/blog/speak-your-first-star-v1-4-1.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R544S4KDBQ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-R544S4KDBQ');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DailyVox v1.4.1: Speak Your First Star — the Cold-Start Problem for a Model of One</title>
+  <meta name="description" content="DailyVox v1.4.1 makes onboarding voice-first to solve the cold-start problem for a personal model of one. The first spoken sentence becomes the first star, transcribed entirely on-device.">
+  <meta name="keywords" content="dailyvox v1.4.1, voice-first onboarding, cold start problem, on-device transcription, personal model, digital twin onboarding, model of one, time to first signal, private voice journal">
+  <meta name="theme-color" content="#FAF8F5">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://getdailyvox.com/blog/speak-your-first-star-v1-4-1">
+  <meta property="og:title" content="DailyVox v1.4.1: Speak Your First Star — the Cold-Start Problem for a Model of One">
+  <meta property="og:description" content="Every personal model starts empty, and a model of one person has nobody to borrow strength from. Here is why v1.4.1 ends onboarding with a microphone rather than a form — and what that buys a model that cannot function until it has data.">
+  <meta property="og:image" content="https://getdailyvox.com/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="canonical" href="https://getdailyvox.com/blog/speak-your-first-star-v1-4-1">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="/app-icon.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "DailyVox v1.4.1: Speak Your First Star — the Cold-Start Problem for a Model of One",
+    "description": "DailyVox v1.4.1 makes onboarding voice-first to solve the cold-start problem for a personal model of one. The first spoken sentence becomes the first star, transcribed entirely on-device.",
+    "url": "https://getdailyvox.com/blog/speak-your-first-star-v1-4-1",
+    "datePublished": "2026-07-04",
+    "dateModified": "2026-07-04",
+    "author": { "@type": "Organization", "name": "DailyVox" },
+    "publisher": { "@type": "Organization", "name": "DailyVox", "url": "https://getdailyvox.com" },
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://getdailyvox.com/blog/speak-your-first-star-v1-4-1" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Why does the first journal entry matter so much for a personal model?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Because a model of one person has no population to borrow strength from. A model trained on millions of rows can absorb a bad or empty first record without noticing. A personal model cannot: there is no pretraining on 'users like you', because the entire premise is that the model is yours and only yours. The first entry is the difference between a prior and a posterior of size one. That is why v1.4.1 treats the first spoken sentence as a real entry rather than throwaway sample data."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Why is DailyVox's onboarding transcription on-device only, even when it is less accurate?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Because an app that promised to collect nothing and then streamed your first spoken sentence to a transcription service would be lying. Speech-to-text runs through the phone's on-device recogniser with on-device recognition required, and there is no cloud fallback even when the network is available. The cost is real: on-device recognition is weaker than server models on rare vocabulary and heavy accents, and we accept that error floor as the price of the guarantee that the audio never leaves your phone."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the constellation actually showing?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "It is a picture of a model gaining data, not a decoration. Each entry is a star, and the growing constellation is the literal shape of the personal model accreting evidence. A personal model's biggest early risk is that it feels like nothing is happening — you write into a void and cannot tell it is learning. Making that accretion visible is how you keep someone contributing during the exact window when the model is still too small to say anything useful. It is a learning curve rendered as a night sky."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does voice-first onboarding make the model better, or just nicer to use?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Better, in a measurable sense. Voice lowers the activation energy for the first data point, and lower activation energy means the model reaches useful size sooner. The argument is not that speaking is pleasant; it is that speaking shortens the time-to-first-signal for a model that cannot function until it has data. A form asks you to compose. A microphone asks you to talk, which most people find far easier under the friction of a first run."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does anything I say during onboarding leave my phone?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No. The recording is transcribed on the device and stored on the device. There are no servers to receive it, no analytics pipeline, and no network call in the recording or transcription path. The privacy label stays 'Data Not Collected', and for the onboarding entry that has to be literally true, not aspirationally true."
+        }
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://getdailyvox.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://getdailyvox.com/blog"},
+      {"@type": "ListItem", "position": 3, "name": "DailyVox v1.4.1: Speak Your First Star — the Cold-Start Problem for a Model of One"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav>
+    <div class="container">
+      <a href="/" class="nav-brand">
+        <img src="/app-icon.png" alt="DailyVox">
+        <span>DailyVox</span>
+      </a>
+      <ul class="nav-links">
+        <li><a href="/blog">Blog</a></li>
+        <li><a href="/privacy">Privacy</a></li>
+        <li><a href="/support">Support</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <main class="container">
+    <article class="blog-article">
+      <div class="article-header">
+        <a href="/blog" class="back-link">&larr; Back to Blog</a>
+        <span class="blog-tag tag-technology">Release</span>
+        <h1>DailyVox v1.4.1: Speak Your First Star — the Cold-Start Problem for a Model of One</h1>
+        <p class="article-meta">July 4, 2026 &middot; 5 min read</p>
+      </div>
+
+      <div class="article-body">
+        <p>Every recommender you have ever used solves the cold-start problem the same way: when it knows nothing about you, it falls back on the crowd. It shows you what people like you tend to want, and it refines from there. DailyVox cannot do that, because the model it builds — the Digital Twin, a personal model assembled entirely from your own journal entries — is a model of exactly one person. There is no crowd to fall back on. v1.4.1, "Speak Your First Star", is a small release aimed squarely at the hardest moment in the life of such a model: the very beginning, when it has no data at all.</p>
+
+        <h2>A model of one has nobody to borrow from</h2>
+
+        <p>A model trained on millions of rows is robust to a weak first record. One noisy row barely moves the parameters, and the population supplies a strong prior that carries a new user until their own data accumulates. A personal model has none of that cushion. The entire premise is that the model is yours and only yours, which means there is no warm-start, no pretraining on "users like you", and no population mean to regress toward. The first entry is therefore load-bearing in a way it never is elsewhere: it is the difference between a prior and a posterior of size one.</p>
+
+        <p>Put plainly, the model does not exist until you feed it. So the design question for onboarding is not "how do we explain the product?" It is "how do we get one honest, real data point into the model as quickly and as painlessly as possible?" Everything in v1.4.1 follows from taking that question literally.</p>
+
+        <h2>The onboarding used to end with a form. Now it ends with a microphone.</h2>
+
+        <p>Previously, the final step of setup was the kind of tidy form every app ships — a few taps, a preference or two, and then you were deposited on an empty home screen with nothing in the model. The new final step of "Speak Your First Star" hands you the microphone and invites you to say something out loud. That recording becomes your real first entry. Not a tutorial, not throwaway sample data seeded to make the screen look populated, but the actual first star in the constellation the Twin begins to fit against.</p>
+
+        <p>The reason is a claim about activation energy. A blank form asks you to compose in writing under the friction of a first run, which is exactly when people are least willing to do work. A microphone asks you to talk, which is close to effortless by comparison. Lowering that activation energy is not a UX nicety in this context; it is the mechanism by which the model reaches useful size sooner. This is the whole machine-learning argument for a voice-first cold start: not that speech is nicer, but that it shortens the time-to-first-signal for a model that cannot say anything until it has been given something to reflect.</p>
+
+        <h2>The first sentence never leaves the phone</h2>
+
+        <p>There is a temptation, when transcription quality matters most, to route that first precious recording to a powerful cloud speech service — the accuracy would be better, and first impressions count. We do not, and we cannot. Speech-to-text runs through the phone's on-device recogniser, with on-device recognition required and no cloud fallback even when the network is available and would be faster.</p>
+
+        <p>This is a hard constraint rather than a preference. An app that told you it collects nothing and then, at the very first opportunity, streamed your opening spoken sentence to someone else's transcription endpoint would simply be lying. The honest cost is worth stating without softening it: on-device recognition is measurably weaker than the best server models on rare vocabulary, proper nouns, and heavy accents. We accept that error floor deliberately, because the alternative quietly trades the core promise of the product for a cleaner transcript. A slightly rougher transcription that never left your device is the correct trade here, and it is the one we made.</p>
+
+        <h2>The constellation is a learning curve rendered as a night sky</h2>
+
+        <p>Once the first entry lands, you see it become a star. Over subsequent days, more entries become more stars, and faint lines draw between the near ones. It reads as a gentle visual metaphor, and it is — but underneath, it is doing real work for a personal model, and that work is the reason it exists.</p>
+
+        <p>The biggest early failure mode for a model of one is not inaccuracy; it is abandonment before there is enough data to be accurate. A new user writes two or three entries, the Twin has almost nothing to work with, the app says little of substance, and the user reasonably concludes that nothing is happening and leaves — right at the point where a few more entries would have tipped the model into usefulness. The constellation is our answer to that gap. It makes accretion visible. Each star is proof that the model got bigger, offered during the exact window when the model is still too small to talk back. It is, quite literally, a learning curve dressed as a sky, designed to keep someone contributing data through the period when the honest thing for the Twin to say is "I do not know you yet."</p>
+
+        <p>The release carried the usual unglamorous maintenance alongside this — small corrections to the widget and Live Activity surfaces that keep the interface honest about the app's current state. Those do not touch the model, but they matter for the same reason everything else here does: the surface should never claim more than the model actually knows.</p>
+
+        <h2>Where this goes next</h2>
+
+        <p>Getting the first data point in is the start of the story, not the end of it. The harder question — how you give that model a second channel of truth, and how you prove any of it works when the whole thing runs on one device you can never observe — is the subject of the next release. <a href="/blog/body-twin-v1-5-what-shipped">Read what actually shipped in v1.5 Body Twin, and where it honestly falls short of the plan &rarr;</a></p>
+
+        <p>—</p>
+
+        <h2>Related Articles</h2>
+        <ul>
+          <li><a href="/blog/body-twin-v1-5-what-shipped">Body Twin Shipped — And Where It Honestly Falls Short of the Plan</a></li>
+          <li><a href="/blog/constellation-update">The Constellation Update: Why Every Journal Entry Is Now a Star</a></li>
+          <li><a href="/blog/what-is-on-device-ai">What Is On-Device AI? Why It Matters for Privacy</a></li>
+          <li><a href="/blog/on-device-ai-maturity-model">The On-Device AI Maturity Model</a></li>
+        </ul>
+
+        <p><a href="https://apps.apple.com/app/dailyvox">Download DailyVox on the App Store</a> &middot; <a href="/blog/body-twin-v1-5-what-shipped">Read the v1.5 Body Twin retrospective</a> &middot; <a href="/">getdailyvox.com</a></p>
+      </div>
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2026 DailyVox. Voice diary that respects your privacy.</p>
+      <p><a href="/privacy">Privacy</a> &middot; <a href="/support">Support</a> &middot; <a href="/blog">Blog</a></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/solyn/website/public/sitemap-blog.xml
+++ b/solyn/website/public/sitemap-blog.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://getdailyvox.com/blog</loc><lastmod>2026-07-04</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://getdailyvox.com/blog</loc><lastmod>2026-07-05</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://getdailyvox.com/blog/body-twin-v1-5-what-shipped</loc><lastmod>2026-07-05</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://getdailyvox.com/blog/speak-your-first-star-v1-4-1</loc><lastmod>2026-07-05</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://getdailyvox.com/blog/body-twin-healthkit-watch</loc><lastmod>2026-06-05</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://getdailyvox.com/blog/dailyvox-vs-granola</loc><lastmod>2026-05-28</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://getdailyvox.com/blog/dailyvox-vs-finch</loc><lastmod>2026-05-28</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>

--- a/solyn/website/public/sitemap.xml
+++ b/solyn/website/public/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap><loc>https://getdailyvox.com/sitemap-core.xml</loc><lastmod>2026-07-04</lastmod></sitemap>
-  <sitemap><loc>https://getdailyvox.com/sitemap-blog.xml</loc><lastmod>2026-07-04</lastmod></sitemap>
+  <sitemap><loc>https://getdailyvox.com/sitemap-blog.xml</loc><lastmod>2026-07-05</lastmod></sitemap>
   <sitemap><loc>https://getdailyvox.com/sitemap-articles.xml</loc><lastmod>2026-06-16</lastmod></sitemap>
 </sitemapindex>


### PR DESCRIPTION
Splits the combined v1.4.1 / v1.5 technical draft into two standalone blog posts and wires them into the site. Both match the existing blog template exactly (gtag head, meta/OG/Twitter/canonical, three JSON-LD blocks — BlogPosting + FAQPage + BreadcrumbList — nav, article, related-articles, footer). Nothing is merged here — this is for human review before publishing.

## Post 1 — `blog/speak-your-first-star-v1-4-1.html` (Release · July 4, 2026, ~5 min)
**DailyVox v1.4.1: Speak Your First Star — the Cold-Start Problem for a Model of One**
Frames v1.4.1 for an ML audience: the cold-start problem for a personal model of one (no population to warm-start from; prior vs posterior of size one), voice-first onboarding as a way to shorten time-to-first-signal, fully on-device transcription with its honest accuracy cost, and the constellation as a visualisation of an accreting model. Ends with a forward teaser to the v1.5 post.

## Post 2 — `blog/body-twin-v1-5-what-shipped.html` (Engineering · July 5, 2026, ~8 min)
**Body Twin Shipped — And Where It Honestly Falls Short of the Plan**
The release retrospective, linking back to the original plan post (`/blog/body-twin-healthkit-watch`). Covers what actually shipped — two-layer sampling (background layer only), activity-context with "unknown" as a first-class value, per-person hour-of-day heart deltas, the review-and-discard queue as an honesty primitive, no server-side feature store — and the validation work (lift-over-baseline, ~20-entry maturation curve, on-device Big Five feasibility + cross-corpus robustness, per-language heads, falsifying negative controls).

**This post explicitly owns three roadmap shortfalls** in a candid "Where v1.5 falls short of the plan" section (headings, verbatim):
1. **The embodied recording-time body layer did not ship** — deferred; needs the wrist sensor for live sampling. v1.5 ships the background-context layer only.
2. **The Twin cannot forecast your mood** — measured, and it does not beat a persistence baseline. It is a conditional-mean mirror, not an oracle.
3. **"Measurable fidelity" is proven on synthetic data only** — feasibility / style-invariance established; human accuracy is unfinished, gated work.

## Wiring
- Both added to the top of `blog/index.html` (v1.5 July-5 first, then v1.4.1 July-4).
- Both URLs added to `sitemap-blog.xml` with `<lastmod>2026-07-05</lastmod>`; blog sitemap lastmod bumped in `sitemap.xml`.
- Related-articles links verified against existing files.

## Verification
- All 3 JSON-LD blocks per post validate as JSON; structural tags balanced; sitemaps well-formed.
- Confidentiality grep clean: no monetisation/pricing/exit/competitive/App-Review/license/engine-internal terms, no code fences, no class/framework tokens, and no reference to the specific unfixed chat-template defect.