### PR TITLE
Fix TwinChat tonal misfire: no celebratory spin on a stress-trigger data gap

### DIFF
--- a/solyn/solyn/TwinChatView.swift
+++ b/solyn/solyn/TwinChatView.swift
@@ -309,7 +309,11 @@ struct TwinResponseGenerator {
             .prefix(5)
 
         guard !negativeTriggers.isEmpty else {
-            return "I haven't identified clear stress triggers yet. This is actually a good sign! As you journal more, I'll be able to spot patterns in what weighs on you."
+            // No celebratory spin on a data gap: an empty trigger map means the
+            // Twin hasn't learned triggers yet — it says nothing about how the
+            // person is doing. The old "actually a good sign!" copy misfired on
+            // genuinely-negative baselines (engine groundedness tonal audit).
+            return "I haven't identified clear stress triggers yet — I need more entries before patterns in what weighs on you become visible."
         }
 
         let triggerList = negativeTriggers.map { $0.key.capitalized }


### PR DESCRIPTION
## What

One string. The stress-triggers answer in Twin chat ended **"This is actually a good sign!"** whenever the Twin had not yet learned any negative triggers. For a user whose entries run genuinely negative, that framed a data gap as good news about their life.

The engine-side groundedness suite's tonal audit quantified the misfire: **7/15 genuinely-negative personas** received the celebratory line (53.3% tonal honesty). New copy says what is actually true — the Twin needs more entries before trigger patterns are visible — and attaches no verdict.

## Paired engine change

The identical template in the engine (`TwinChat.swift`) is fixed on DailyVoxTwin `feat/emotion-suite` (PR #15), where the audit re-measures **15/15 tonally honest, 0 euphemism misfires**, the euphemism detector is hardened to a celebratory-phrase pattern list, and the regression test proves the validator still catches an injected euphemistic surface.

## Risk

Copy-only; no logic change. The guard branch and all data paths are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)