### PR TITLE
Fix widget counters stuck at zero: Core Data model missing from widget bundle

### DIFF
--- a/solyn/solyn.xcodeproj/project.pbxproj
+++ b/solyn/solyn.xcodeproj/project.pbxproj
@@ -71,6 +71,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		CF4C16542EDE120000E722CB /* Exceptions for "solyn" folder in "DailyVoxWidgets" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				solyn.xcdatamodeld,
+			);
+			target = FD8D5118AB594947E3082E3B /* DailyVoxWidgets */;
+		};
 		CF4C16532EDE120000E722CA /* Exceptions for "solyn" folder in "solyn" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -85,6 +92,7 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				CF4C16532EDE120000E722CA /* Exceptions for "solyn" folder in "solyn" target */,
+				CF4C16542EDE120000E722CB /* Exceptions for "solyn" folder in "DailyVoxWidgets" target */,
 			);
 			path = solyn;
 			sourceTree = "<group>";


### PR DESCRIPTION
## Root cause (verified in build products, not guessed)

`solyn.momd` existed **only in the app bundle** — `DailyVoxWidgets.appex` shipped with no compiled Core Data model at all. `NSPersistentContainer(name: "solyn")` inside the extension therefore resolved no model, the shared App Group store could never load, every fetch threw, and every widget surface (entry count, streak, constellation stars, today's entry) showed zero/empty **always** — regardless of `reloadAllTimelines` or the store-option matching added in earlier fixes. That's why the v1.4.1 counter fix didn't hold: it treated the symptoms of a store that was never openable.

Mechanism: Xcode 16 synchronized folders — `solyn/` (containing the `.xcdatamodeld`) syncs into the app target only; the widget target's explicit file list never included the model, and nothing in the pbxproj referenced `xcdatamodel` at all.

## Fix

One `PBXFileSystemSynchronizedBuildFileExceptionSet`: `solyn.xcdatamodeld` gains membership in the `DailyVoxWidgets` target.

## Verification

- Build succeeds.
- `DailyVoxWidgets.appex/solyn.momd` present in build products (was absent before).
- Manual check after install: add an entry → widget count/streak/stars populate.

Should ride **build 19** with the v1.5 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)