### PR TITLE
fix: add NSHealthUpdateUsageDescription for upload validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to DailyVox are documented here.
 - `MARKETING_VERSION` 1.4.1 → 1.5.0
 - `CURRENT_PROJECT_VERSION` 18 → 19
 - HealthKit entitlement + Health/Motion usage descriptions added to the app target only
+- `NSHealthUpdateUsageDescription` added (upload validation requires it whenever `requestAuthorization(toShare:read:)` is referenced, even read-only with an empty share set); the string states plainly that DailyVox never writes to Apple Health
 
 ## [1.4.1] — 2026-07-04
 

--- a/solyn/AppStore/ReviewNotes_1.5.0.md
+++ b/solyn/AppStore/ReviewNotes_1.5.0.md
@@ -40,6 +40,7 @@ Everything below is paste-ready. Source of truth for copy: `metadata.json` (mach
 - [x] `MARKETING_VERSION = 1.5.0`, `CURRENT_PROJECT_VERSION = 19`
 - [x] Release build at main: **BUILD SUCCEEDED**
 - [x] `NSHealthShareUsageDescription` + `NSMotionUsageDescription` in app Info.plist, real HealthKit code behind them
+- [x] `NSHealthUpdateUsageDescription` in app Info.plist (2026-07-17: upload validation demands it because `requestAuthorization(toShare:read:)` is referenced, even with an empty share set; string honestly states the app never writes to Health)
 - [x] Widget Info.plist has **zero** health keys; widget bundles `solyn.momd` (PR #39 fix)
 - [x] HealthKit entitlement on app target only
 

--- a/solyn/solyn/Info.plist
+++ b/solyn/solyn/Info.plist
@@ -10,6 +10,8 @@
 	<string>DailyVox uses Face ID to lock and unlock access to your private diary entries.</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>DailyVox reads sleep, heart, steps and mindfulness data on this iPhone so your Twin can understand what your body felt around each entry. You review every signal before your Twin learns it; nothing is uploaded or synced.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>DailyVox never writes or changes anything in Apple Health. The app only reads sleep, heart, steps and mindfulness data on this iPhone; no update access is requested or used.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>DailyVox needs microphone access to record your voice diary entries.</string>
 	<key>NSMotionUsageDescription</key>


### PR DESCRIPTION
App Store upload validation requires the update (write) purpose string whenever
the binary references HKHealthStore.requestAuthorization(toShare:read:) — even
with an empty share set, as in our read-only Body Twin. The string states
plainly that DailyVox never writes to Apple Health.

Verified: Release build succeeded; key present in built solyn.app Info.plist;
widget appex has zero health keys. App target only.
