### PR TITLE
release: v1.5.0 live — roadmap/changelog shipped + Watch-scope fix

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,7 +88,7 @@ This roadmap outlines the planned evolution of DailyVox. Contributions are welco
 | Stage | Release | The Twin... |
 |:--|:--|:--|
 | **Scribe** | v1.0–v1.4.1 *(shipped)* | listens, remembers, and reflects what you tell it |
-| **Body** | v1.5 *(next)* | feels what your body felt — physiology joins the narrative |
+| **Body** | v1.5 *(shipped)* | feels what your body felt — physiology joins the narrative |
 | **Senses** | v1.5.5 | learns from your day — on-device photo and music signals, reviewed before they touch the Twin |
 | **Memory** | v1.6 | remembers you accurately across years — measurable fidelity + semantic memory |
 | **Voice** | v1.7 | converses with a real on-device brain, citing your own entries |
@@ -100,7 +100,9 @@ This roadmap outlines the planned evolution of DailyVox. Contributions are welco
 | **Protocol** | v2.5 | becomes portable — yours, not the app's |
 | **Mirror** | v3.0+ | the most faithful reflection ever built — eventually embodied (v4.0) |
 
-### v1.5 — Body Twin: HealthKit + Apple Watch *(next — in development)*
+### v1.5 — Body Twin: HealthKit *(shipped 2026-07-18, build 19)*
+
+> Shipped as the **iPhone HealthKit layer**: per-entry health snapshots, activity-context tags, the review-and-discard queue, the body whisper, and Body & Mood insights. The **Apple Watch companion** (wrist recording + heart rate sampled during the entry) is deferred to a later Body Twin release — the sections below that describe the Watch app are the plan for that follow-on, not what shipped in build 19.
 
 The Twin gains a body. Until now it has learned only from your words; v1.5 gives it physiological context so it can finally tell the difference between "feeling stressed" and *being* stressed. Directly addresses one of the limitations called out for v3.0 ("Feel what you feel — no embodied experience").
 

--- a/solyn/website/public/about.html
+++ b/solyn/website/public/about.html
@@ -887,19 +887,19 @@
             </div>
           </div>
           <div class="rd-item">
-            <div class="rd-dot rd-now">→</div>
+            <div class="rd-dot rd-done">✓</div>
             <div class="rd-body">
-              <div class="rd-tag rd-now"><span class="rd-tag-text">Latest shipped · v1.4.0 + v1.4.1</span></div>
+              <div class="rd-tag rd-done"><span class="rd-tag-text">Shipped · v1.4.0 + v1.4.1</span></div>
               <h3>The warm redesign</h3>
-              <p><strong>Design:</strong> a complete visual rework to a warm, calm palette — sage, gold, and terracotta on ivory — across every screen, with the Digital Twin moved to the center of the app. SF Rounded typography, warmed light and dark themes, refined onboarding, and a polished Journal. The unused HealthKit entitlement was removed; it returns with Body Twin in v1.5. v1.4.1 made onboarding voice-first: the final welcome step invites you to speak your first entry, and your own words become the first star in your constellation.</p>
+              <p><strong>Design:</strong> a complete visual rework to a warm, calm palette — sage, gold, and terracotta on ivory — across every screen, with the Digital Twin moved to the center of the app. SF Rounded typography, warmed light and dark themes, refined onboarding, and a polished Journal. v1.4.1 made onboarding voice-first: the final welcome step invites you to speak your first entry, and your own words become the first star in your constellation.</p>
             </div>
           </div>
           <div class="rd-item">
-            <div class="rd-dot rd-next">○</div>
+            <div class="rd-dot rd-now">→</div>
             <div class="rd-body">
-              <div class="rd-tag rd-next"><span class="rd-tag-text">Next · v1.5</span></div>
-              <h3>Body Twin — HealthKit + Apple Watch</h3>
-              <p><strong>Tech:</strong> <code>HealthKit</code> reads sleep, HRV (SDNN), resting heart rate, steps, mindful minutes — all on-device, "Data Not Collected" label preserved. Per-entry <code>HealthSnapshot</code> in Core Data (~10 floats). Activity context detected via <code>HKWorkoutSession</code> + <code>CMMotionActivity</code> classifier. <code>WatchKit</code> companion via <code>WatchConnectivity</code>. Heart rate sampled during recording — but only when at rest, so a workout isn't read as emotional stress. HR stored as delta from your personal hour-of-day baseline. Constellation pulse renders from HR delta on at-rest entries.</p>
+              <div class="rd-tag rd-now"><span class="rd-tag-text">Latest shipped · v1.5.0</span></div>
+              <h3>Body Twin — HealthKit</h3>
+              <p><strong>Tech:</strong> <code>HealthKit</code> reads sleep, HRV (SDNN), resting heart rate, steps, mindful minutes — all on-device, "Data Not Collected" label preserved. Per-entry <code>HealthSnapshot</code> in Core Data (~10 floats), each tagged with activity context detected via <code>HKWorkoutSession</code> + <code>CMMotionActivity</code>, so a workout isn't read as emotional stress. HR is stored as a delta from your personal hour-of-day baseline. Every captured signal waits in a review-and-discard queue before it reaches the Twin. The <strong>Apple Watch companion</strong> — wrist recording and heart rate sampled during the entry — is the next step in Body Twin, not part of this release.</p>
             </div>
           </div>
           <div class="rd-item">

--- a/solyn/website/public/blog/index.html
+++ b/solyn/website/public/blog/index.html
@@ -45,7 +45,7 @@
     <div class="page-header">
       <h1>Blog</h1>
       <p class="updated">Journaling, privacy &amp; on-device AI</p>
-      <a href="/changelog" style="display:inline-block;margin-top:12px;padding:6px 15px;border-radius:30px;background:rgba(91,124,107,0.12);color:#5B7C6B;font-size:13px;font-weight:700;text-decoration:none">Latest: DailyVox v1.4.1 &middot; see changelog &rarr;</a>
+      <a href="/changelog" style="display:inline-block;margin-top:12px;padding:6px 15px;border-radius:30px;background:rgba(91,124,107,0.12);color:#5B7C6B;font-size:13px;font-weight:700;text-decoration:none">Latest: DailyVox v1.5.0 &middot; see changelog &rarr;</a>
     </div>
 
     <div class="blog-list">

--- a/solyn/website/public/changelog.html
+++ b/solyn/website/public/changelog.html
@@ -178,14 +178,15 @@
 
       <section class="version" style="border-left:3px solid var(--uv);padding-left:18px;">
         <div class="v-head">
-          <div class="v-tag" style="color:var(--uv);">◇ next · v1.5</div>
-          <h2 id="v1-5-next">Version 1.5 — Body Twin (in development)</h2>
-          <time class="v-date">coming soon</time>
+          <div class="v-tag" style="color:var(--uv);">◆ latest · v1.5.0</div>
+          <h2 id="v1-5-next">Version 1.5.0 — Body Twin (shipped)</h2>
+          <time class="v-date">July 2026</time>
         </div>
         <div class="v-body">
-        <p><strong>The Digital Twin gains a body.</strong> Body Twin brings Apple Health and an Apple Watch companion into DailyVox so the Twin can finally tell the difference between feeling stressed and being stressed. HealthKit reads sleep, HRV, resting heart rate, steps, and mindful minutes as background context for every entry. Apple Watch records from your wrist and samples heart rate during the recording — only when you're at rest, so a workout isn't mistaken for emotional stress. Every entry gets an activity context tag (<code>at_rest</code> / <code>active</code> / <code>post_workout</code>) that tells the Twin how to interpret the body data. HR is stored as delta from your personal hour-of-day baseline, not raw bpm. The "Data Not Collected" privacy label stays intact — all HealthKit reads happen on-device.</p>
+        <p><strong>The Digital Twin gains a body.</strong> With your permission, Body Twin reads five signals on this iPhone — sleep, morning HRV, resting heart rate, steps, and mindful minutes — and freezes a small snapshot beside each entry, tagged with whether you were at rest or in motion, so a walk is never mistaken for a feeling. Every signal waits in a review queue: keep it or let it go — nothing reaches your Twin without your eyes on it. A body whisper offers one calm line of context before you speak ("Slept 5h 20m. Take a breath."), and Body &amp; Mood insights surface honest correlations only when there's enough data. HR is stored as a delta from your personal hour-of-day baseline, not raw bpm. Health signals stay on this iPhone — never uploaded, never in iCloud, excluded from device backups; the "Data Not Collected" privacy label stays intact.</p>
+        <p style="color:var(--ink-soft); font-size:14px;"><em>The Apple Watch companion (wrist recording + heart rate during the entry) is the next step in Body Twin, not part of this release.</em></p>
         <p><a href="/blog/body-twin-healthkit-watch" style="color:var(--uv); text-decoration:underline;">Read the full Body Twin plan →</a></p>
-        <p style="margin-top:8px; color:var(--ink-soft); font-size:14px;"><em>After v1.5: v1.6 Semantic Search & Proactive Insights · v1.7 Foundation Models Twin (on-device LLM chat) · v1.8 Multi-Language · v2.0 Apple Intelligence Native · <a href="https://github.com/intrepidkarthi/dailyvox/blob/main/ROADMAP.md" style="color:var(--uv); text-decoration:underline;">full roadmap</a></em></p>
+        <p style="margin-top:8px; color:var(--ink-soft); font-size:14px;"><em>After v1.5: v1.6 Semantic Memory + Measurable Fidelity (semantic search, embedding trait heads, SpeechAnalyzer) · v1.7 Foundation Models Twin (on-device LLM chat) · v1.8 Multi-Language · v2.0 Apple Intelligence Native · <a href="https://github.com/intrepidkarthi/dailyvox/blob/main/ROADMAP.md" style="color:var(--uv); text-decoration:underline;">full roadmap</a></em></p>
         </div>
       </section>
 

--- a/solyn/website/public/sitemap-core.xml
+++ b/solyn/website/public/sitemap-core.xml
@@ -16,6 +16,6 @@
   <url><loc>https://getdailyvox.com/reports/state-of-on-device-ai-journaling-2026</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://getdailyvox.com/reports/journal-app-privacy-audit-2026</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://getdailyvox.com/facts</loc><lastmod>2026-07-04</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://getdailyvox.com/changelog</loc><lastmod>2026-07-04</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://getdailyvox.com/changelog</loc><lastmod>2026-07-18</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://getdailyvox.com/demo</loc><lastmod>2026-06-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
 </urlset>


### PR DESCRIPTION
v1.5.0 shipped 2026-07-18 (build 19, iPhone HealthKit layer).
- ROADMAP: v1.5 Body → shipped; title HealthKit (not '+ Apple Watch'); banner clarifies the Watch companion is a later Body Twin release, and the Watch sections below are that follow-on plan, not build 19
- Website changelog: v1.5 'in development/coming soon' → shipped July 2026, rewritten to the actually-shipped scope (review queue, body whisper, insights); removed the 'Apple Watch companion' promise, noted it as the next step
- about.html roadmap: v1.4 card → Shipped; v1.5 card → Latest shipped, Watch scope corrected
- blog badge → v1.5.0; changelog sitemap lastmod → 07-18
