### PR TITLE
fix(v1.5.1): name vocabulary, question truncation, iCloud default-off

### DIFF
--- a/solyn/solyn/CustomVocabulary.swift
+++ b/solyn/solyn/CustomVocabulary.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// User-taught words that speech recognition keeps getting wrong — names,
+/// places, anything uncommon. Fed into `SFSpeechURLRecognitionRequest`'s
+/// `contextualStrings` so recognition is biased toward them on every entry,
+/// which is what makes a correction *stick*: transcription itself has no
+/// memory, so without this an uncommon name (a child's name, say) is re-heard
+/// wrong every single time no matter how often the text is edited afterward.
+///
+/// Stored locally in UserDefaults — like everything else, it never leaves the
+/// device. Apple caps `contextualStrings` influence, so this biases, never
+/// forces; a very long list also dilutes the effect, hence the cap.
+final class CustomVocabulary: ObservableObject {
+    static let shared = CustomVocabulary()
+
+    private let key = "customVocabularyTerms"
+    /// Apple's guidance is that contextualStrings works best as a short,
+    /// high-value list; keep the most recent N.
+    static let maxTerms = 100
+
+    @Published private(set) var terms: [String]
+
+    private init() {
+        terms = UserDefaults.standard.stringArray(forKey: key) ?? []
+    }
+
+    /// Add a term (trimmed, deduplicated case-insensitively, newest kept).
+    func add(_ raw: String) {
+        let term = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !term.isEmpty else { return }
+        var next = terms.filter { $0.caseInsensitiveCompare(term) != .orderedSame }
+        next.insert(term, at: 0)
+        if next.count > Self.maxTerms { next = Array(next.prefix(Self.maxTerms)) }
+        terms = next
+        persist()
+    }
+
+    func remove(at offsets: IndexSet) {
+        terms.remove(atOffsets: offsets)
+        persist()
+    }
+
+    func remove(_ term: String) {
+        terms.removeAll { $0.caseInsensitiveCompare(term) == .orderedSame }
+        persist()
+    }
+
+    /// The bias list handed to speech recognition. Empty is fine (no bias).
+    var contextualStrings: [String] { terms }
+
+    private func persist() {
+        UserDefaults.standard.set(terms, forKey: key)
+    }
+}

--- a/solyn/solyn/Persistence.swift
+++ b/solyn/solyn/Persistence.swift
@@ -133,7 +133,18 @@ struct PersistenceController {
 
     /// Check if CloudKit should be enabled (requires both iCloud availability and user preference)
     private static var shouldEnableCloudKit: Bool {
-        let userEnabled = UserDefaults.standard.object(forKey: "iCloudSyncEnabled") as? Bool ?? true
+        let defaults = UserDefaults.standard
+        // v1.5.1 migration — sync is now OFF by default for NEW installs so the
+        // "your entries live on this iPhone" promise matches the code. We decide
+        // once, the first time the preference is read without having been set:
+        // an install that has already completed onboarding is an existing user
+        // who was silently syncing on the old default, so we preserve their sync
+        // (nobody's data quietly stops); a fresh install starts off.
+        if defaults.object(forKey: "iCloudSyncEnabled") == nil {
+            let isExistingInstall = defaults.bool(forKey: "hasCompletedOnboarding")
+            defaults.set(isExistingInstall, forKey: "iCloudSyncEnabled")
+        }
+        let userEnabled = defaults.bool(forKey: "iCloudSyncEnabled")
         return userEnabled && FileManager.default.ubiquityIdentityToken != nil
     }
 

--- a/solyn/solyn/SettingsView.swift
+++ b/solyn/solyn/SettingsView.swift
@@ -63,11 +63,16 @@ struct SettingsView: View {
     @State private var showWipeHealthConfirm = false
     @State private var isRequestingHealthAccess = false
 
+    // Custom vocabulary
+    @ObservedObject private var vocabulary = CustomVocabulary.shared
+    @State private var newVocabularyTerm = ""
+
     var body: some View {
         Form {
             exportSection
             appearanceSection
             journalingGoalSection
+            vocabularySection
             liveActivitiesSection
             securitySection
             dailyReminderSection
@@ -232,6 +237,35 @@ struct SettingsView: View {
         } footer: {
             Text("Set a weekly journaling target to build a consistent habit.")
         }
+    }
+
+    private var vocabularySection: some View {
+        Section {
+            HStack {
+                TextField("Add a name or word", text: $newVocabularyTerm)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.words)
+                    .onSubmit(addVocabularyTerm)
+                Button(action: addVocabularyTerm) {
+                    Image(systemName: "plus.circle.fill")
+                }
+                .disabled(newVocabularyTerm.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            ForEach(vocabulary.terms, id: \.self) { term in
+                Text(term)
+            }
+            .onDelete { vocabulary.remove(at: $0) }
+        } header: {
+            Text("Spoken Words")
+        } footer: {
+            Text("Names and uncommon words that transcription keeps getting wrong — like a child's name. DailyVox will listen for these on every recording, so a correction sticks instead of coming back wrong. Stays on this iPhone.")
+        }
+    }
+
+    private func addVocabularyTerm() {
+        let term = newVocabularyTerm
+        newVocabularyTerm = ""
+        vocabulary.add(term)
     }
 
     @ViewBuilder

--- a/solyn/solyn/SpeechTranscriber.swift
+++ b/solyn/solyn/SpeechTranscriber.swift
@@ -92,6 +92,15 @@ final class SpeechTranscriber {
                 let request = SFSpeechURLRecognitionRequest(url: audioURL)
                 request.shouldReportPartialResults = false
 
+                // Bias recognition toward words the user has taught us — names
+                // and other uncommon terms that would otherwise be mis-heard on
+                // every entry. This is what makes a correction persist across
+                // recordings (transcription has no memory of its own).
+                let vocabulary = CustomVocabulary.shared.contextualStrings
+                if !vocabulary.isEmpty {
+                    request.contextualStrings = vocabulary
+                }
+
                 // Privacy: Prefer on-device recognition when offline
                 // When online, Apple's servers provide better punctuation
                 // Note: Even server-based recognition goes through Apple, not third parties

--- a/solyn/solyn/TwinResolutionView.swift
+++ b/solyn/solyn/TwinResolutionView.swift
@@ -211,7 +211,8 @@ struct TwinResolutionSheet: View {
                 .foregroundColor(agree >= 0.75 ? TR.forest : agree >= 0.5 ? TR.gold : TR.coral)
             VStack(alignment: .leading, spacing: 2) {
                 Text(q.prompt).font(.system(size: 13, weight: .medium, design: .rounded))
-                    .foregroundColor(.primary).lineLimit(1)
+                    .foregroundColor(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
                 Text("Twin guessed: \(twinGuess.lowercased())")
                     .font(.system(size: 12, design: .rounded)).foregroundColor(.secondary)
             }


### PR DESCRIPTION
- CustomVocabulary: user-editable 'Spoken Words' list (Settings) fed into
  SFSpeechURLRecognitionRequest.contextualStrings so recognition biases toward
  taught names every recording — a correction now sticks instead of coming back
  wrong (fixes 'Adyah' re-mis-heard every time). Stays on device (UserDefaults).
- TwinResolutionView: question prompt was capped at lineLimit(1) → truncated to
  '…'; now wraps via fixedSize(vertical). Full question reveals.
- Persistence: iCloud sync now OFF by default for NEW installs, matching the
  'entries live on this iPhone' promise. One-time migration preserves sync for
  existing installs (decided by hasCompletedOnboarding) so nobody silently stops.

Release build SUCCEEDED (CustomVocabulary picked up by synchronized folder).
