### PR TITLE
feat(v1.6): SpeechAnalyzer transcription for iOS 26+ devices

### DIFF
--- a/solyn/solyn/SpeechTranscriber.swift
+++ b/solyn/solyn/SpeechTranscriber.swift
@@ -13,6 +13,7 @@
 import Foundation
 import Speech
 import Network
+import AVFoundation
 
 /// Transcribes audio recordings to text using Apple's Speech framework.
 /// Prioritizes on-device recognition for privacy; falls back to Apple's servers when needed.
@@ -67,11 +68,86 @@ final class SpeechTranscriber {
     // MARK: - Transcription
     
     /// Transcribes audio from the given URL to text.
-    /// Uses on-device recognition when offline, Apple's servers when online for better punctuation.
+    ///
+    /// On iOS 26+ this uses Apple's new on-device `SpeechAnalyzer`/`SpeechTranscriber`
+    /// — markedly lower word-error rate on sustained speech, no session length
+    /// limit, fully on-device — and falls back to the proven `SFSpeechRecognizer`
+    /// path on any failure (or on earlier iOS). Both keep audio on the device.
     /// - Parameters:
     ///   - audioURL: URL to the audio file to transcribe
     ///   - completion: Called with the transcription result or error
     func transcribe(from audioURL: URL, completion: @escaping (Result<String, Error>) -> Void) {
+        if #available(iOS 26.0, *) {
+            Task {
+                do {
+                    let text = try await self.transcribeWithSpeechAnalyzer(from: audioURL)
+                    await MainActor.run { completion(.success(text)) }
+                } catch {
+                    // SpeechAnalyzer unavailable for this locale/device, model not
+                    // installable, or produced nothing — use the proven recognizer.
+                    self.transcribeWithSFSpeech(from: audioURL, completion: completion)
+                }
+            }
+        } else {
+            transcribeWithSFSpeech(from: audioURL, completion: completion)
+        }
+    }
+
+    // MARK: - iOS 26+ SpeechAnalyzer path
+
+    @available(iOS 26.0, *)
+    private func transcribeWithSpeechAnalyzer(from audioURL: URL) async throws -> String {
+        // Resolve a supported locale (fall back to en-US) for the transcriber.
+        // Fully qualified — this app's own class is also named SpeechTranscriber.
+        // Sequenced explicitly: `??` can't wrap an `await` in its autoclosure.
+        let preferred = Locale.current
+        var resolved = await Speech.SpeechTranscriber.supportedLocale(equivalentTo: preferred)
+        if resolved == nil {
+            resolved = await Speech.SpeechTranscriber.supportedLocale(equivalentTo: Locale(identifier: "en-US"))
+        }
+        let locale = resolved ?? preferred
+
+        let transcriber = Speech.SpeechTranscriber(locale: locale, preset: .transcription)
+
+        // Ensure the on-device model asset is installed (downloads once, on-device).
+        switch await AssetInventory.status(forModules: [transcriber]) {
+        case .installed:
+            break
+        case .supported, .downloading:
+            if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+                try await request.downloadAndInstall()
+            }
+        case .unsupported:
+            throw TranscriptionError.recognizerUnavailable
+        @unknown default:
+            throw TranscriptionError.recognizerUnavailable
+        }
+
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+        let audioFile = try AVAudioFile(forReading: audioURL)
+
+        // Collect finalized transcript segments as they arrive.
+        var transcript = AttributedString()
+        let collector = Task {
+            for try await result in transcriber.results {
+                transcript.append(result.text)
+            }
+        }
+
+        // Analyze the whole file, then finish so `results` completes.
+        _ = try await analyzer.analyzeSequence(from: audioFile)
+        try await analyzer.finalizeAndFinishThroughEndOfInput()
+        try await collector.value
+
+        var text = String(transcript.characters).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { throw TranscriptionError.noFinalResult }
+        if !text.hasSuffix(".") && !text.hasSuffix("?") && !text.hasSuffix("!") { text += "." }
+        return text
+    }
+
+    // MARK: - SFSpeechRecognizer path (iOS < 26, and the fallback)
+
+    private func transcribeWithSFSpeech(from audioURL: URL, completion: @escaping (Result<String, Error>) -> Void) {
         SFSpeechRecognizer.requestAuthorization { status in
             DispatchQueue.main.async {
                 guard status == .authorized else {


### PR DESCRIPTION
On iOS 26+, transcribe(from:) routes through Apple's on-device SpeechAnalyzer /
SpeechTranscriber (preset .transcription): markedly lower WER on sustained
speech, no session-length limit, model auto-installed via AssetInventory. Any
failure (unsupported locale/device, model uninstallable, empty result) falls
back to the proven SFSpeechRecognizer path; earlier iOS uses it directly. Both
keep audio on-device. API pinned from the iOS 26.2 swiftinterface; the
framework type is fully qualified (Speech.SpeechTranscriber) to disambiguate
from this app's own class of the same name. Release build SUCCEEDED.
