### PR TITLE
v1.7 Twin Brain: free-text grounded chat (Foundation Models, iOS 26+)

### DIFF
--- a/solyn/solyn/SemanticSearchManager.swift
+++ b/solyn/solyn/SemanticSearchManager.swift
@@ -88,10 +88,12 @@ final class SemanticSearchManager: ObservableObject {
 
     /// Search by meaning. Returns [] when the best match is below the
     /// abstention threshold (the honest "I don't have anything on that").
-    func search(_ query: String, topK: Int = 12) -> [Hit] {
+    /// `dateRange` (v1.7) narrows candidates before ranking — the Twin
+    /// Brain's recallEntries "monthsBack" window.
+    func search(_ query: String, topK: Int = 12, in dateRange: ClosedRange<Date>? = nil) -> [Hit] {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.count >= 3 else { return [] }
-        let results = index.search(trimmed, topK: topK)
+        let results = index.search(trimmed, topK: topK, in: dateRange)
         guard let best = results.first, best.score >= Self.abstentionThreshold else { return [] }
         return results.map { Hit(id: $0.entryId, score: $0.score) }
     }

--- a/solyn/solyn/SettingsView.swift
+++ b/solyn/solyn/SettingsView.swift
@@ -72,6 +72,9 @@ struct SettingsView: View {
     @ObservedObject private var ambientQueue = PendingAmbientSignalQueue.shared
     @State private var showAmbientReview = false
 
+    // Twin Brain (v1.7 Foundation Models)
+    @ObservedObject private var twinBrain = TwinBrainManager.shared
+
     var body: some View {
         Form {
             exportSection
@@ -85,6 +88,7 @@ struct SettingsView: View {
             iCloudSection
             healthSection
             ambientSection
+            twinBrainSection
             privacySection
             researchSection
             backupSection
@@ -315,6 +319,46 @@ struct SettingsView: View {
         }
         .sheet(isPresented: $showAmbientReview) {
             AmbientReviewView()
+        }
+    }
+
+    // MARK: - Twin Brain (v1.7 Foundation Models)
+
+    /// Absent entirely on iOS < 26 and on hardware that can't run Apple
+    /// Intelligence — no dead toggle to explain (healthSection pattern).
+    /// Default ON where available: this gates no new permission or data flow;
+    /// the toggle is a kill-switch back to the classic template chat.
+    @ViewBuilder
+    private var twinBrainSection: some View {
+        if twinBrain.isSupportedHere {
+            Section {
+                Toggle("Conversational answers", isOn: $twinBrain.enabled)
+
+                switch twinBrain.status {
+                case .modelNotReady:
+                    Label("Apple Intelligence is still preparing the on-device model — DailyVox switches automatically when it's ready.",
+                          systemImage: "hourglass")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                case .appleIntelligenceOff:
+                    #if os(iOS)
+                    Button {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    } label: {
+                        Label("Turn on Apple Intelligence in Settings", systemImage: "gear")
+                            .font(.caption)
+                    }
+                    #endif
+                default:
+                    EmptyView()
+                }
+            } header: {
+                Text("Twin Brain")
+            } footer: {
+                Text("Ask Your Twin answers in your own words, grounded in your entries and citing the ones it drew from. Runs entirely on this iPhone with Apple's on-device model — zero network calls, nothing leaves the device. Turning it off returns the classic question chips.")
+            }
         }
     }
 

--- a/solyn/solyn/TwinBrainManager.swift
+++ b/solyn/solyn/TwinBrainManager.swift
@@ -1,0 +1,81 @@
+//
+//  TwinBrainManager.swift
+//  solyn
+//
+//  Availability + preference gate for the v1.7 Foundation Models Twin. The
+//  gate is purely framework-reported (SystemLanguageModel availability via
+//  the engine's FoundationTwinChat) — no hardware-model sniffing, matching
+//  the SpeechAnalyzer adoption pattern. Default ON where available: the
+//  feature adds no new permissions or data flows (all on-device, zero
+//  network), so the Settings toggle is a kill-switch back to the classic
+//  template chat, not a permission.
+//
+
+import Foundation
+import SwiftUI
+import DailyVoxTwinEngine
+
+@MainActor
+final class TwinBrainManager: ObservableObject {
+    static let shared = TwinBrainManager()
+
+    enum Status: Equatable {
+        /// iOS < 26 — the classic chat, no Settings section at all.
+        case unsupportedOS
+        /// iOS 26+ but hardware can't run Apple Intelligence — section omitted.
+        case deviceNotEligible
+        /// Eligible, but Apple Intelligence is off in system Settings.
+        case appleIntelligenceOff
+        /// Eligible and enabled; the OS is still preparing the model.
+        case modelNotReady
+        case ready
+    }
+
+    /// Kill-switch (default ON — see header). Stored, so it survives launches.
+    @AppStorage("twinFoundationModelEnabled") var enabled = true
+
+    private init() {}
+
+    var status: Status {
+        guard #available(iOS 26.0, *) else { return .unsupportedOS }
+        #if canImport(FoundationModels)
+        switch FoundationTwinChat.availability() {
+        case .ready: return .ready
+        case .modelNotReady: return .modelNotReady
+        case .appleIntelligenceNotEnabled: return .appleIntelligenceOff
+        case .deviceNotEligible: return .deviceNotEligible
+        case .unavailable: return .deviceNotEligible
+        }
+        #else
+        return .unsupportedOS
+        #endif
+    }
+
+    /// Whether the Settings section should exist at all (healthSection
+    /// pattern: absent entirely where the capability can't exist).
+    var isSupportedHere: Bool {
+        switch status {
+        case .unsupportedOS, .deviceNotEligible: return false
+        default: return true
+        }
+    }
+
+    var isActive: Bool { status == .ready && enabled }
+
+    /// Builds the FM pipeline wired to the live engine + Core Data adapter.
+    /// Returned as `Any?` because stored properties can't be availability-
+    /// gated on an iOS 17 type — callers downcast inside #available blocks.
+    func makePipeline() -> Any? {
+        guard isActive else { return nil }
+        if #available(iOS 26.0, *) {
+            #if canImport(FoundationModels)
+            return FoundationTwinChat(twin: DigitalTwinEngine.shared,
+                                      profile: TwinChatProfile(from: LocalAIEngine.shared.userProfile),
+                                      evidence: TwinChatEvidenceAdapter())
+            #else
+            return nil
+            #endif
+        }
+        return nil
+    }
+}

--- a/solyn/solyn/TwinChatEvidenceAdapter.swift
+++ b/solyn/solyn/TwinChatEvidenceAdapter.swift
@@ -1,0 +1,75 @@
+//
+//  TwinChatEvidenceAdapter.swift
+//  solyn
+//
+//  The app's side of the Twin Brain evidence seam (v1.7). The engine has no
+//  Core Data and the semantic index returns only entry ids, so this adapter
+//  resolves queries to id + snippet tuples: SemanticSearchManager (which owns
+//  the abstention threshold) finds the ids, Core Data supplies the text, and
+//  snippets are word-boundary truncated here so raw full entries never reach
+//  a prompt. All work hops to the main actor — the same singleton-access
+//  discipline as the rest of the app.
+//
+
+import Foundation
+import CoreData
+import DailyVoxTwinEngine
+
+final class TwinChatEvidenceAdapter: TwinChatEvidenceSource, @unchecked Sendable {
+
+    /// Snippet cap matches FoundationTwinChat.Options.snippetMaxChars.
+    private let snippetMaxChars: Int
+
+    init(snippetMaxChars: Int = 600) {
+        self.snippetMaxChars = snippetMaxChars
+    }
+
+    func recall(query: String, topK: Int, dateRange: ClosedRange<Date>?) async -> [TwinChatEvidence] {
+        await MainActor.run {
+            let hits = SemanticSearchManager.shared.search(query, topK: topK, in: dateRange)
+            guard !hits.isEmpty else { return [] }
+            let context = PersistenceController.shared.container.viewContext
+            return hits.compactMap { hit -> TwinChatEvidence? in
+                guard let uuid = UUID(uuidString: hit.id) else { return nil }
+                let request = NSFetchRequest<DiaryEntry>(entityName: "DiaryEntry")
+                request.predicate = NSPredicate(format: "id == %@", uuid as CVarArg)
+                request.fetchLimit = 1
+                guard let entry = (try? context.fetch(request))?.first,
+                      let text = entry.text, !text.isEmpty else { return nil }
+                return TwinChatEvidence(entryId: hit.id,
+                                        date: entry.date ?? Date(timeIntervalSince1970: 0),
+                                        snippet: Self.truncate(text, to: snippetMaxChars),
+                                        score: hit.score)
+            }
+        }
+    }
+
+    func recentEntries(days: Int) async -> [TwinEntryInput] {
+        await MainActor.run {
+            let context = PersistenceController.shared.container.viewContext
+            let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: Date()) ?? Date()
+            let request = NSFetchRequest<DiaryEntry>(entityName: "DiaryEntry")
+            request.predicate = NSPredicate(format: "date >= %@", cutoff as NSDate)
+            request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: true)]
+            guard let entries = try? context.fetch(request) else { return [] }
+            return entries.map {
+                TwinEntryInput(date: $0.date,
+                               text: $0.text,
+                               mood: $0.mood,
+                               duration: $0.duration,
+                               isStarred: $0.isStarred)
+            }
+        }
+    }
+
+    /// Head-truncate at a word boundary. Long entries collapse to their
+    /// opening; per-sentence snippet windowing is a Phase E follow-up.
+    static func truncate(_ text: String, to maxChars: Int) -> String {
+        guard text.count > maxChars else { return text }
+        let head = String(text.prefix(maxChars))
+        if let lastSpace = head.lastIndex(of: " "), head.distance(from: head.startIndex, to: lastSpace) > maxChars / 2 {
+            return String(head[..<lastSpace]) + "…"
+        }
+        return head + "…"
+    }
+}

--- a/solyn/solyn/TwinChatView.swift
+++ b/solyn/solyn/TwinChatView.swift
@@ -2,45 +2,27 @@
 //  TwinChatView.swift
 //  solyn
 //
-//  Ask Your Twin - a conversational interface to explore your journal data.
-//  All responses are generated from on-device Digital Twin data.
-//  No external APIs or LLMs are used.
+//  Ask Your Twin — a conversational interface to explore your journal data.
+//
+//  v1.7: on Apple-Intelligence devices (iOS 26+) answers come from the
+//  on-device Foundation Models Twin — free-text questions, grounded in
+//  retrieved journal entries, every answer citing the entries it drew from,
+//  audited before render (engine `FoundationTwinChat`). Everywhere else, and
+//  whenever the brain declines a turn, the classic template chat answers via
+//  the engine's eval-locked `TwinResponseGenerator`. Zero network calls on
+//  either path.
+//
+//  The in-tree template copy was deleted in v1.7 — `TwinQuestion` and
+//  `TwinResponseGenerator` now resolve to the engine's injectable,
+//  eval-tested definitions (DailyVoxTwinEngine/TwinChat.swift).
 //
 
 import SwiftUI
+import CoreData
 import DailyVoxTwinEngine
-
-// MARK: - Question Types
-
-enum TwinQuestion: String, CaseIterable, Identifiable {
-    case moodPattern = "What's my mood pattern this week?"
-    case talkAboutMost = "Who do I talk about most?"
-    case happiestWhen = "When am I happiest?"
-    case dominantTopics = "What topics dominate my thoughts?"
-    case moodOverTime = "How has my mood changed over time?"
-    case communicationStyle = "What's my communication style?"
-    case stressTriggers = "What triggers my stress?"
-    case positiveOrNegative = "Am I more positive or negative overall?"
-    case personality = "What's my personality like?"
-    case bestJournalTime = "What time should I journal?"
-
-    var id: String { rawValue }
-
-    var icon: String {
-        switch self {
-        case .moodPattern: return "chart.line.uptrend.xyaxis"
-        case .talkAboutMost: return "person.2.fill"
-        case .happiestWhen: return "sun.max.fill"
-        case .dominantTopics: return "tag.fill"
-        case .moodOverTime: return "arrow.up.right"
-        case .communicationStyle: return "text.bubble.fill"
-        case .stressTriggers: return "bolt.heart.fill"
-        case .positiveOrNegative: return "plusminus"
-        case .personality: return "person.crop.circle.fill"
-        case .bestJournalTime: return "clock.fill"
-        }
-    }
-}
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
 
 // MARK: - Chat Message
 
@@ -49,413 +31,24 @@ struct TwinChatMessage: Identifiable {
     let text: String
     let isUser: Bool
     let timestamp = Date()
-}
-
-// MARK: - Response Generator
-
-struct TwinResponseGenerator {
-
-    private static let insufficientData = "I need more journal entries to answer that well. Keep journaling and I'll have better insights for you soon!"
-
-    static func generateResponse(for question: TwinQuestion) -> String {
-        let twin = DigitalTwinEngine.shared
-        let profile = LocalAIEngine.shared.userProfile
-        let hasEnoughData = twin.summary.dataPointsCollected >= 5
-
-        switch question {
-        case .moodPattern:
-            return moodPatternResponse(twin: twin, hasData: hasEnoughData)
-        case .talkAboutMost:
-            return talkAboutMostResponse(twin: twin, hasData: hasEnoughData)
-        case .happiestWhen:
-            return happiestWhenResponse(twin: twin, hasData: hasEnoughData)
-        case .dominantTopics:
-            return dominantTopicsResponse(twin: twin, profile: profile, hasData: hasEnoughData)
-        case .moodOverTime:
-            return moodOverTimeResponse(twin: twin, hasData: hasEnoughData)
-        case .communicationStyle:
-            return communicationStyleResponse(twin: twin, hasData: hasEnoughData)
-        case .stressTriggers:
-            return stressTriggersResponse(twin: twin, hasData: hasEnoughData)
-        case .positiveOrNegative:
-            return positiveOrNegativeResponse(twin: twin, hasData: hasEnoughData)
-        case .personality:
-            return personalityResponse(twin: twin, hasData: hasEnoughData)
-        case .bestJournalTime:
-            return bestJournalTimeResponse(twin: twin, profile: profile, hasData: hasEnoughData)
-        }
-    }
-
-    // MARK: - Individual Response Builders
-
-    private static func moodPatternResponse(twin: DigitalTwinEngine, hasData: Bool) -> String {
-        guard hasData else { return insufficientData }
-
-        let sig = twin.emotionalSignature
-        var parts: [String] = []
-
-        // Recent sentiments
-        if !sig.recentSentiments.isEmpty {
-            let recent = Array(sig.recentSentiments.suffix(7))
-            let avg = recent.reduce(0, +) / Double(recent.count)
-            let moodWord: String
-            if avg > 0.3 { moodWord = "quite positive" }
-            else if avg > 0.1 { moodWord = "generally good" }
-            else if avg > -0.1 { moodWord = "fairly balanced" }
-            else if avg > -0.3 { moodWord = "a bit low" }
-            else { moodWord = "on the tougher side" }
-            parts.append("Your recent mood has been \(moodWord).")
-        }
-
-        // Weekday vs weekend
-        let weekdayLabel = sentimentWord(sig.weekdayMood)
-        let weekendLabel = sentimentWord(sig.weekendMood)
-        if weekdayLabel != weekendLabel {
-            parts.append("Weekdays feel \(weekdayLabel), while weekends are \(weekendLabel).")
-        } else {
-            parts.append("Your mood stays pretty consistent between weekdays and weekends.")
-        }
-
-        // Emotional range
-        if sig.emotionalRange > 0.6 {
-            parts.append("You experience a wide range of emotions - lots of highs and lows.")
-        } else if sig.emotionalRange < 0.3 {
-            parts.append("Your emotions tend to stay steady without big swings.")
-        }
-
-        return parts.isEmpty ? insufficientData : parts.joined(separator: " ")
-    }
-
-    private static func talkAboutMostResponse(twin: DigitalTwinEngine, hasData: Bool) -> String {
-        guard hasData else { return insufficientData }
-
-        let people = twin.knowledgeGraph.topNodes(ofType: .person, limit: 5)
-        guard !people.isEmpty else {
-            return "I haven't picked up on specific people in your entries yet. Try mentioning people by name and I'll start tracking who matters most to you."
-        }
-
-        var parts: [String] = []
-        let top = people[0]
-        parts.append("\(top.label) comes up the most in your journal (\(top.mentions) mentions).")
-
-        if top.sentimentAssociation > 0.2 {
-            parts.append("You tend to feel positive when writing about them.")
-        } else if top.sentimentAssociation < -0.2 {
-            parts.append("Entries about them carry some heavier emotions.")
-        }
-
-        if people.count > 1 {
-            let others = people.dropFirst().prefix(3).map { $0.label }
-            parts.append("You also mention \(others.joined(separator: ", ")) frequently.")
-        }
-
-        return parts.joined(separator: " ")
-    }
-
-    private static func happiestWhenResponse(twin: DigitalTwinEngine, hasData: Bool) -> String {
-        guard hasData else { return insufficientData }
-
-        let sig = twin.emotionalSignature
-        var parts: [String] = []
-
-        // Time of day
-        let morningBetter = sig.morningMood > sig.eveningMood
-        if abs(sig.morningMood - sig.eveningMood) > 0.1 {
-            parts.append("You tend to be happier in the \(morningBetter ? "morning" : "evening").")
-        } else {
-            parts.append("Your mood is fairly consistent throughout the day.")
-        }
-
-        // Weekday vs weekend
-        if sig.weekendMood > sig.weekdayMood + 0.1 {
-            parts.append("Weekends clearly lift your spirits.")
-        } else if sig.weekdayMood > sig.weekendMood + 0.1 {
-            parts.append("Interestingly, you seem happier on weekdays.")
-        }
-
-        // Positive triggers
-        let positiveTriggers = sig.positiveTriggersTopics
-            .sorted { $0.value > $1.value }
-            .prefix(3)
-            .map { $0.key.capitalized }
-
-        if !positiveTriggers.isEmpty {
-            parts.append("Topics that lift your mood include: \(positiveTriggers.joined(separator: ", ")).")
-        }
-
-        return parts.isEmpty ? insufficientData : parts.joined(separator: " ")
-    }
-
-    private static func dominantTopicsResponse(twin: DigitalTwinEngine, profile: UserProfile, hasData: Bool) -> String {
-        guard hasData else { return insufficientData }
-
-        let graphTopics = twin.knowledgeGraph.topNodes(ofType: .topic, limit: 5)
-        let profileTopics = profile.commonTopics.sorted { $0.value > $1.value }.prefix(5)
-
-        var allTopics: [String] = []
-        for node in graphTopics {
-            allTopics.append(node.label)
-        }
-        for (topic, _) in profileTopics {
-            let capitalized = topic.capitalized
-            if !allTopics.contains(where: { $0.lowercased() == capitalized.lowercased() }) {
-                allTopics.append(capitalized)
-            }
-        }
-
-        guard !allTopics.isEmpty else {
-            return "I haven't identified strong themes yet. The more you journal, the clearer your thought patterns will become."
-        }
-
-        let topList = allTopics.prefix(5).joined(separator: ", ")
-        var response = "The themes that dominate your journal are: \(topList)."
-
-        // Add concerns if available
-        let concerns = twin.thoughtPatterns.topConcerns
-            .sorted { $0.value > $1.value }
-            .prefix(2)
-            .map { $0.key.capitalized }
-        if !concerns.isEmpty {
-            response += " Your main concerns seem to revolve around \(concerns.joined(separator: " and "))."
-        }
-
-        return response
-    }
-
-    private static func moodOverTimeResponse(twin: DigitalTwinEngine, hasData: Bool) -> String {
-        guard hasData else { return insufficientData }
-
-        let sig = twin.emotionalSignature
-        var parts: [String] = []
-
-        // Trend
-        if sig.sentimentTrend > 0.05 {
-            parts.append("Your mood has been trending upward recently. Things are looking brighter.")
-        } else if sig.sentimentTrend < -0.05 {
-            parts.append("Your mood has been dipping a bit lately. That's okay - acknowledging it is the first step.")
-        } else {
-            parts.append("Your emotional state has been fairly stable recently.")
-        }
-
-        // Baseline
-        let baselineWord: String
-        if sig.baselineValence > 0.2 { baselineWord = "positive" }
-        else if sig.baselineValence > -0.1 { baselineWord = "balanced" }
-        else { baselineWord = "reflective" }
-        parts.append("Your overall emotional baseline is \(baselineWord).")
-
-        // Resilience
-        if sig.resilienceScore > 0.6 {
-            parts.append("You show good emotional resilience - you bounce back well.")
-        }
-
-        // Data points
-        if sig.recentSentiments.count >= 10 {
-            parts.append("This is based on your last \(sig.recentSentiments.count) journal entries.")
-        }
-
-        return parts.joined(separator: " ")
-    }
-
-    private static func communicationStyleResponse(twin: DigitalTwinEngine, hasData: Bool) -> String {
-        guard hasData, twin.communicationStyle.analysisCount >= 3 else { return insufficientData }
-
-        let style = twin.communicationStyle
-        var parts: [String] = []
-
-        // Formality
-        if style.formalityLevel > 0.6 {
-            parts.append("You write in a fairly formal, polished way.")
-        } else if style.formalityLevel < 0.4 {
-            parts.append("Your writing style is casual and conversational.")
-        } else {
-            parts.append("Your writing strikes a nice balance between casual and formal.")
-        }
-
-        // Expressiveness
-        if style.expressiveness > 0.6 {
-            parts.append("You're quite expressive - you use exclamations and vivid language.")
-        } else if style.expressiveness < 0.3 {
-            parts.append("You tend to be measured and understated in your expression.")
-        }
-
-        // Directness
-        if style.directness > 0.6 {
-            parts.append("You're direct and to the point.")
-        } else if style.directness < 0.4 {
-            parts.append("You often take a more nuanced, reflective approach.")
-        }
-
-        // Sentence length
-        parts.append("Your average sentence is about \(Int(style.averageSentenceLength)) words long.")
-
-        // Signature words
-        let topWords = style.signatureWords
-            .sorted { $0.value > $1.value }
-            .prefix(5)
-            .map { $0.key }
-        if !topWords.isEmpty {
-            parts.append("Some of your signature words are: \(topWords.joined(separator: ", ")).")
-        }
-
-        return parts.joined(separator: " ")
-    }
-
-    private static func stressTriggersResponse(twin: DigitalTwinEngine, hasData: Bool) -> String {
-        guard hasData else { return insufficientData }
-
-        let negativeTriggers = twin.emotionalSignature.negativeTriggersTopics
-            .sorted { $0.value > $1.value }
-            .prefix(5)
-
-        guard !negativeTriggers.isEmpty else {
-            // No celebratory spin on a data gap: an empty trigger map means the
-            // Twin hasn't learned triggers yet — it says nothing about how the
-            // person is doing. The old "actually a good sign!" copy misfired on
-            // genuinely-negative baselines (engine groundedness tonal audit).
-            return "I haven't identified clear stress triggers yet — I need more entries before patterns in what weighs on you become visible."
-        }
-
-        let triggerList = negativeTriggers.map { $0.key.capitalized }
-        var response = "Based on your entries, these topics tend to bring your mood down: \(triggerList.joined(separator: ", "))."
-
-        // Contrast with positive
-        let positiveTriggers = twin.emotionalSignature.positiveTriggersTopics
-            .sorted { $0.value > $1.value }
-            .prefix(3)
-            .map { $0.key.capitalized }
-        if !positiveTriggers.isEmpty {
-            response += " On the flip side, \(positiveTriggers.joined(separator: ", ")) tend to lift you up."
-        }
-
-        return response
-    }
-
-    private static func positiveOrNegativeResponse(twin: DigitalTwinEngine, hasData: Bool) -> String {
-        guard hasData else { return insufficientData }
-
-        let valence = twin.emotionalSignature.baselineValence
-        var parts: [String] = []
-
-        if valence > 0.2 {
-            parts.append("Overall, your journal entries lean positive. You tend to focus on good things.")
-        } else if valence > 0.05 {
-            parts.append("You're slightly on the positive side - a healthy, realistic optimism.")
-        } else if valence > -0.05 {
-            parts.append("You're remarkably balanced. Your entries show an even mix of positive and negative.")
-        } else if valence > -0.2 {
-            parts.append("Your entries lean slightly toward processing challenges. That's what journaling is great for.")
-        } else {
-            parts.append("You've been working through some tough things. Your journal is a safe space for that.")
-        }
-
-        // Emotion frequency breakdown
-        let emotions = twin.emotionalSignature.emotionFrequency
-            .sorted { $0.value > $1.value }
-            .prefix(3)
-        if !emotions.isEmpty {
-            let topEmotions = emotions.map { "\($0.key.capitalized)" }
-            parts.append("Your most frequent moods are: \(topEmotions.joined(separator: ", ")).")
-        }
-
-        return parts.joined(separator: " ")
-    }
-
-    private static func personalityResponse(twin: DigitalTwinEngine, hasData: Bool) -> String {
-        guard hasData else { return insufficientData }
-
-        let twinProfile = TwinProfileGenerator.generate()
-        var parts: [String] = []
-
-        parts.append("Here's what your journal reveals about you:")
-
-        // Core traits from profile
-        let traitDescriptions = twinProfile.traits.map { $0.displayLabel }
-        if !traitDescriptions.isEmpty {
-            parts.append("Your core traits are: \(traitDescriptions.joined(separator: ", ")).")
-        }
-
-        // Communication & thinking style
-        parts.append("Communication style: \(twinProfile.communicationStyle). Thinking style: \(twinProfile.thinkingStyle).")
-
-        // Dominant mood
-        parts.append("Your dominant mood is \(twinProfile.dominantMood) with \(twinProfile.emotionalRange.lowercased()) emotional range.")
-
-        // Growth indicators
-        if twin.thoughtPatterns.growthMindsetScore > 0.6 {
-            parts.append("You show a strong growth mindset.")
-        }
-        if twin.thoughtPatterns.gratitudeTendency > 0.5 {
-            parts.append("Gratitude is a natural part of how you think.")
-        }
-        if twin.thoughtPatterns.selfAwarenessLevel > 0.6 {
-            parts.append("You have a high level of self-awareness.")
-        }
-
-        return parts.joined(separator: " ")
-    }
-
-    private static func bestJournalTimeResponse(twin: DigitalTwinEngine, profile: UserProfile, hasData: Bool) -> String {
-        guard hasData else { return insufficientData }
-
-        var parts: [String] = []
-
-        // Peak hour from behavioral patterns
-        if let peakHour = twin.behavioralPatterns.peakHour {
-            parts.append("Based on your habits, you journal most often around \(formatHour(peakHour)).")
-        }
-
-        // Cross-reference with mood
-        let sig = twin.emotionalSignature
-        if sig.morningMood > sig.eveningMood + 0.1 {
-            parts.append("You tend to be in a better mood in the morning, so that might be ideal for reflection.")
-        } else if sig.eveningMood > sig.morningMood + 0.1 {
-            parts.append("Your evening entries tend to be more positive - evenings might be your sweet spot.")
-        }
-
-        // Peak day
-        if let peakDay = twin.behavioralPatterns.peakDay {
-            let days = ["", "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-            if peakDay >= 1 && peakDay <= 7 {
-                parts.append("\(days[peakDay]) is when you journal most frequently.")
-            }
-        }
-
-        // Consistency note
-        if twin.behavioralPatterns.consistencyScore > 0.5 {
-            parts.append("You've built a solid journaling habit - keep it up!")
-        } else {
-            parts.append("Try picking a consistent time each day to build the habit.")
-        }
-
-        return parts.isEmpty ? insufficientData : parts.joined(separator: " ")
-    }
-
-    // MARK: - Helpers
-
-    private static func sentimentWord(_ value: Double) -> String {
-        if value > 0.3 { return "great" }
-        if value > 0.1 { return "good" }
-        if value > -0.1 { return "neutral" }
-        if value > -0.3 { return "a bit low" }
-        return "tough"
-    }
-
-    private static func formatHour(_ hour: Int) -> String {
-        if hour == 0 { return "midnight" }
-        if hour < 12 { return "\(hour)am" }
-        if hour == 12 { return "noon" }
-        return "\(hour - 12)pm"
-    }
+    /// Journal entries this answer cited ("From your journal" chips).
+    var citations: [TwinChatEvidence] = []
 }
 
 // MARK: - Twin Chat View
 
 struct TwinChatView: View {
     @ObservedObject private var themeManager = ThemeManager.shared
+    @ObservedObject private var brain = TwinBrainManager.shared
+    @Environment(\.managedObjectContext) private var viewContext
+
     @State private var messages: [TwinChatMessage] = []
     @State private var askedQuestions: Set<TwinQuestion> = []
-    @Namespace private var bottomAnchor
+    @State private var inputText = ""
+    @State private var isThinking = false
+    @State private var latestFollowUps: [String] = []
+    @State private var pipeline: Any?
+    @State private var citationEntry: DiaryEntry?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -473,6 +66,10 @@ struct TwinChatView: View {
                             chatBubble(for: message)
                         }
 
+                        if isThinking {
+                            thinkingBubble
+                        }
+
                         // Invisible anchor for scrolling
                         Color.clear
                             .frame(height: 1)
@@ -486,16 +83,42 @@ struct TwinChatView: View {
                         proxy.scrollTo("bottom", anchor: .bottom)
                     }
                 }
+                .onChange(of: isThinking) { _ in
+                    withAnimation(.easeOut(duration: 0.3)) {
+                        proxy.scrollTo("bottom", anchor: .bottom)
+                    }
+                }
             }
 
             Divider()
                 .background(themeManager.secondaryTextColor.opacity(0.3))
+
+            // Free-text input (Foundation Models path only)
+            if brain.isActive {
+                inputBar
+            } else if brain.status == .modelNotReady || brain.status == .appleIntelligenceOff {
+                classicModeCaption
+            }
 
             // Suggested questions chips
             questionChips
         }
         .navigationTitle("Ask Your Twin")
         .background(themeManager.backgroundColor.ignoresSafeArea())
+        .task {
+            // The chat's grounding depends on index freshness — the save path
+            // in TodayView doesn't index, so catch up here (idempotent).
+            SemanticSearchManager.shared.indexAll(from: viewContext)
+            if pipeline == nil {
+                pipeline = brain.makePipeline()
+            }
+        }
+        .sheet(item: $citationEntry) { entry in
+            NavigationView {
+                EntryDetailView(entry: entry)
+            }
+            .environment(\.managedObjectContext, viewContext)
+        }
     }
 
     // MARK: - Welcome Card
@@ -528,7 +151,9 @@ struct TwinChatView: View {
                 .font(.headline)
                 .foregroundColor(themeManager.textColor)
 
-            Text("Tap a question below to get insights from your Digital Twin. All answers come from your on-device data.")
+            Text(brain.isActive
+                 ? "Ask in your own words, or tap a question below. Answers come from your entries, on this device — and show which entries they drew from."
+                 : "Tap a question below to get insights from your Digital Twin. All answers come from your on-device data.")
                 .font(.subheadline)
                 .foregroundColor(themeManager.secondaryTextColor)
                 .multilineTextAlignment(.center)
@@ -544,27 +169,8 @@ struct TwinChatView: View {
             if message.isUser {
                 Spacer(minLength: 60)
             } else {
-                // Twin orb icon
-                ZStack {
-                    Circle()
-                        .fill(
-                            RadialGradient(
-                                colors: [
-                                    themeManager.accentColor.opacity(0.7),
-                                    themeManager.accentColor.opacity(0.3)
-                                ],
-                                center: .center,
-                                startRadius: 2,
-                                endRadius: 14
-                            )
-                        )
-                        .frame(width: 28, height: 28)
-
-                    Image(systemName: "person.crop.circle.fill")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.white)
-                }
-                .padding(.top, 4)
+                twinOrb
+                    .padding(.top, 4)
             }
 
             VStack(alignment: message.isUser ? .trailing : .leading, spacing: 4) {
@@ -579,6 +185,10 @@ struct TwinChatView: View {
                                   ? themeManager.accentColor
                                   : themeManager.cardBackgroundColor)
                     )
+
+                if !message.citations.isEmpty {
+                    citationRow(for: message.citations)
+                }
             }
 
             if !message.isUser {
@@ -587,11 +197,130 @@ struct TwinChatView: View {
         }
     }
 
+    private var twinOrb: some View {
+        ZStack {
+            Circle()
+                .fill(
+                    RadialGradient(
+                        colors: [
+                            themeManager.accentColor.opacity(0.7),
+                            themeManager.accentColor.opacity(0.3)
+                        ],
+                        center: .center,
+                        startRadius: 2,
+                        endRadius: 14
+                    )
+                )
+                .frame(width: 28, height: 28)
+
+            Image(systemName: "person.crop.circle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(.white)
+        }
+    }
+
+    private var thinkingBubble: some View {
+        HStack(alignment: .top, spacing: 8) {
+            twinOrb
+                .padding(.top, 4)
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Thinking…")
+                    .font(.subheadline)
+                    .foregroundColor(themeManager.secondaryTextColor)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(themeManager.cardBackgroundColor)
+            )
+            Spacer(minLength: 40)
+        }
+    }
+
+    // MARK: - Citations
+
+    private func citationRow(for citations: [TwinChatEvidence]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("From your journal")
+                .font(.caption2)
+                .foregroundColor(themeManager.secondaryTextColor)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(citations) { citation in
+                        Button {
+                            citationEntry = entry(for: citation.entryId)
+                        } label: {
+                            HStack(spacing: 4) {
+                                Image(systemName: "book.closed.fill")
+                                    .font(.system(size: 9))
+                                Text("\(citation.date, format: .dateTime.month(.abbreviated).day()) · \(Int(citation.score * 100))%")
+                                    .font(.caption2)
+                            }
+                            .foregroundColor(themeManager.accentColor)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(
+                                Capsule()
+                                    .fill(themeManager.accentColor.opacity(0.12))
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.leading, 4)
+    }
+
+    // MARK: - Input Bar
+
+    private var inputBar: some View {
+        HStack(spacing: 10) {
+            TextField("Ask your twin anything…", text: $inputText, axis: .vertical)
+                .font(.subheadline)
+                .lineLimit(1...4)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 9)
+                .background(
+                    Capsule()
+                        .fill(themeManager.cardBackgroundColor)
+                )
+                .onSubmit { sendFreeText() }
+
+            Button {
+                sendFreeText()
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 30))
+                    .foregroundColor(canSend ? themeManager.accentColor : themeManager.secondaryTextColor.opacity(0.4))
+            }
+            .disabled(!canSend)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(themeManager.backgroundColor)
+    }
+
+    private var canSend: Bool {
+        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isThinking
+    }
+
+    private var classicModeCaption: some View {
+        Text(brain.status == .modelNotReady
+             ? "Classic mode — Apple Intelligence is still preparing the on-device model."
+             : "Classic mode — turn on Apple Intelligence in Settings for conversational answers.")
+            .font(.caption2)
+            .foregroundColor(themeManager.secondaryTextColor)
+            .padding(.top, 6)
+    }
+
     // MARK: - Question Chips
 
     private var questionChips: some View {
         VStack(spacing: 8) {
-            if availableQuestions.isEmpty {
+            if !brain.isActive && availableQuestions.isEmpty {
                 Text("You've asked all the questions! Tap any to ask again.")
                     .font(.caption)
                     .foregroundColor(themeManager.secondaryTextColor)
@@ -600,6 +329,32 @@ struct TwinChatView: View {
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 10) {
+                    // Model-suggested follow-ups lead the row (FM path).
+                    ForEach(latestFollowUps, id: \.self) { followUp in
+                        Button {
+                            send(text: followUp)
+                        } label: {
+                            HStack(spacing: 6) {
+                                Image(systemName: "arrow.turn.down.right")
+                                    .font(.system(size: 11))
+                                Text(followUp)
+                                    .font(.caption)
+                                    .lineLimit(1)
+                            }
+                            .foregroundColor(themeManager.accentColor)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(
+                                Capsule()
+                                    .fill(themeManager.accentColor.opacity(0.15))
+                            )
+                            .overlay(
+                                Capsule()
+                                    .strokeBorder(themeManager.accentColor.opacity(0.3), lineWidth: 1)
+                            )
+                        }
+                    }
+
                     ForEach(displayedQuestions) { question in
                         Button {
                             askQuestion(question)
@@ -655,19 +410,69 @@ struct TwinChatView: View {
     }
 
     private func askQuestion(_ question: TwinQuestion) {
-        // Add user message
-        let userMessage = TwinChatMessage(text: question.rawValue, isUser: true)
-        messages.append(userMessage)
         askedQuestions.insert(question)
-
-        // Generate response with a small delay for natural feel
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-            let responseText = TwinResponseGenerator.generateResponse(for: question)
-            let twinMessage = TwinChatMessage(text: responseText, isUser: false)
-            withAnimation(.easeIn(duration: 0.2)) {
-                messages.append(twinMessage)
+        if brain.isActive {
+            // Chips are one-tap prompt fillers on the FM path.
+            send(text: question.rawValue)
+        } else {
+            // Classic path — the engine's eval-locked template surface.
+            let userMessage = TwinChatMessage(text: question.rawValue, isUser: true)
+            messages.append(userMessage)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                let responseText = TwinResponseGenerator.generateResponse(
+                    for: question,
+                    twin: DigitalTwinEngine.shared,
+                    profile: TwinChatProfile(from: LocalAIEngine.shared.userProfile))
+                let twinMessage = TwinChatMessage(text: responseText, isUser: false)
+                withAnimation(.easeIn(duration: 0.2)) {
+                    messages.append(twinMessage)
+                }
             }
         }
+    }
+
+    private func sendFreeText() {
+        let trimmed = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        inputText = ""
+        send(text: trimmed)
+    }
+
+    /// The Foundation-Models path: grounded, cited, audited (engine-side).
+    private func send(text: String) {
+        guard !isThinking else { return }
+        messages.append(TwinChatMessage(text: text, isUser: true))
+        latestFollowUps = []
+        isThinking = true
+
+        Task {
+            var answerText = "I couldn't work through that one — try one of the suggested questions."
+            var citations: [TwinChatEvidence] = []
+            var followUps: [String] = []
+
+            #if canImport(FoundationModels)
+            if #available(iOS 26.0, *), let brainPipeline = pipeline as? FoundationTwinChat {
+                let turn = await brainPipeline.ask(text)
+                answerText = turn.answer
+                citations = turn.citations
+                followUps = turn.suggestedFollowUps
+            }
+            #endif
+
+            isThinking = false
+            withAnimation(.easeIn(duration: 0.2)) {
+                messages.append(TwinChatMessage(text: answerText, isUser: false, citations: citations))
+            }
+            latestFollowUps = followUps
+        }
+    }
+
+    private func entry(for idString: String) -> DiaryEntry? {
+        guard let uuid = UUID(uuidString: idString) else { return nil }
+        let request = NSFetchRequest<DiaryEntry>(entityName: "DiaryEntry")
+        request.predicate = NSPredicate(format: "id == %@", uuid as CVarArg)
+        request.fetchLimit = 1
+        return (try? viewContext.fetch(request))?.first
     }
 }
 


### PR DESCRIPTION
The app side of the v1.7 'Voice' stage. On Apple Intelligence devices, Ask Your Twin becomes a real conversation: free-text questions, answered by the on-device foundation model, grounded in your own entries, every answer citing the entries it drew from — tap a citation chip to open the entry. Everywhere else (iOS < 26, ineligible hardware, kill-switch off, or any turn the engine's audit rejects) the classic chip chat answers via the engine's eval-locked template surface. Zero network calls on either path; the 'Data Not Collected' label is untouched.

- Free-text input bar + suggestion chips + model follow-ups + thinking indicator
- Citation chips ('From your journal · Jun 12 · 74%') → entry sheet
- In-tree template duplicate deleted (~435 lines) — engine copy is the single source
- Settings → Twin Brain: default ON where available (no new permissions/data flows; toggle = kill-switch), section absent on unsupported devices
- Engine gate (DailyVoxTwin #26): PASSED twice — honesty 95.3%, fallback 4.7%, 0 injection leaks, unanswerable safety 100%

Remaining human steps: manual sentence audit (row 8) + on-device test on an Apple Intelligence iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)