### PR TITLE
v1.6.0 shipped: roadmap + changelog + website sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to DailyVox are documented here.
 
-## [1.6.0] — unreleased (in preparation)
+## [1.6.0] — 2026-07-19
 
 ### Added
 - **Semantic memory** — your Twin can find an entry by meaning, not just keywords. On-device sentence embeddings (Apple NLEmbedding, no shipped model bytes) index every entry for similarity search. Search works best with a full phrase.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,9 +89,9 @@ This roadmap outlines the planned evolution of DailyVox. Contributions are welco
 |:--|:--|:--|
 | **Scribe** | v1.0–v1.4.1 *(shipped)* | listens, remembers, and reflects what you tell it |
 | **Body** | v1.5 *(shipped)* | feels what your body felt — physiology joins the narrative |
-| **Senses** | v1.5.5 | learns from your day — on-device photo and music signals, reviewed before they touch the Twin |
-| **Memory** | v1.6 | remembers you accurately across years — measurable fidelity + semantic memory |
-| **Voice** | v1.7 | converses with a real on-device brain, citing your own entries |
+| **Senses** | v1.5.5 *(shipped in v1.6.0)* | learns from your day — on-device photo and music signals, reviewed before they touch the Twin |
+| **Memory** | v1.6 *(shipped)* | remembers you accurately across years — measurable fidelity + semantic memory |
+| **Voice** | v1.7 *(built — next release)* | converses with a real on-device brain, citing your own entries |
 | **Polyglot** | v1.8 | speaks your language — depth on one platform, breadth in languages |
 | **Citizen** | v2.0 | lives inside the OS — answers through Siri, keeps every byte on-device |
 | **Self** | v2.1 | knows who you are — and lets you talk to who you were |
@@ -150,7 +150,7 @@ All HR readings are stored as **deltas from your personal baseline for that hour
 - **Voice** — HR/HRV during at-rest speech refines stress detection beyond pacing and tone; active-context recordings rely on voice features alone
 - **Graph** — people, places, and activities now link to physiological response, not just sentiment
 
-### v1.5.1 — Trust Defaults *(next build)*
+### v1.5.1 — Trust Defaults *(shipped 2026-07-19, in the v1.6.0 build)*
 
 One small change that makes the code agree with the promise:
 
@@ -161,7 +161,7 @@ One small change that makes the code agree with the promise:
 - **Personal names mis-transcribed and won't stick.** Uncommon proper nouns — e.g. his daughter's name *Adyah* — are mis-heard on every recording and corrections don't carry to the next entry. Root cause: `SpeechTranscriber.swift:92` builds `SFSpeechURLRecognitionRequest` with no `contextualStrings`, so recognition has no vocabulary bias; each new entry re-mis-hears the name (editing an entry *does* reprocess — `EntryDetailView.swift:668` — but transcription itself has no memory). Fix = feed the Twin's known people/place entities (the knowledge graph already holds them) into `request.contextualStrings`, plus a small user-editable names list so a correction persists across entries. The same customization carries to `SpeechAnalyzer` (now v1.6). Secondary: NLTagger NER may still mis-class an uncommon name in the World map — the confirmed-names list seeds that too.
 - **Twin Resolution questions truncate to one line.** `TwinResolutionView.swift:214` caps the question prompt with `.lineLimit(1)`, so every question shows one line + "…" and the full text never reveals. Fix = drop the line limit (or `.fixedSize(horizontal: false, vertical: true)`) so questions wrap.
 
-### v1.5.5 — Ambient Signals *(pulled forward from v2.3)*
+### v1.5.5 — Ambient Signals *(shipped 2026-07-19, in the v1.6.0 build; pulled forward from v2.3)*
 
 The first taste of the Twin learning from your day, not just your words — and the part of the ambient thesis that needs no new conversational brain, so it ships now rather than at v2.3. Both signals run entirely on-device and flow through the v1.5 review-and-discard queue: nothing is learned without your eyes on it first. This is the differentiation the server-based companion apps structurally cannot copy — they ingest the same signals by uploading your life; DailyVox reads them where they already live.
 
@@ -170,7 +170,9 @@ The first taste of the Twin learning from your day, not just your words — and 
 - **Reuses the v1.5 queue**: no new privacy surface beyond the Photos and Media Library permissions; the review-and-discard gate already exists. "Data Not Collected" label preserved; both signals off by default
 - Deliberately *not* here: location, calendar, email — those wait for v2.3's full Ambient Twin (location/calendar) or are ruled out entirely (email credentials). v1.5.5 is the cheapest, highest-trust slice of the ambient bet
 
-### v1.6 — Semantic Memory & Measurable Fidelity
+### v1.6 — Semantic Memory & Measurable Fidelity *(shipped 2026-07-19, build 20)*
+
+> Shipped: semantic search (NLEmbedding vector index), SpeechAnalyzer transcription on iOS 26+, the openness trait head with per-prediction confidence bands, the prosody/voice-biomarker foundation, the v1.5.5 ambient signals, and the v1.5.1 trust defaults + fixes — all in the single v1.6.0 build. The measurement infrastructure (TwinEval suites incl. groundedness/tonal audits, retrieval and entity evals) lives engine-side and gates releases rather than shipping in-app. **Deferred from the original v1.6 scope** to a later release: proactive-insight clustering/anomaly detection, causal chains, decision-language extraction, embodied search, and the agentic long-term-memory/summary-distillation designs below (superseded in part by v1.7's grounded chat).
 
 Reframed from "semantic search + insights." Now that v1.5 gives the Twin a body, the binding constraint is no longer *more signals* — it's proving the Twin **remembers accurately across years** and **models you rather than imitates you**. So evaluation and long-term memory move onto the critical path *ahead* of v1.7's on-device brain: you can't tell whether the Foundation-Models Twin beats the template Twin without a fidelity number, and you can't ground it without a memory layer. **Measurement infrastructure comes before features.**
 
@@ -195,7 +197,9 @@ Reframed from "semantic search + insights." Now that v1.5 gives the Twin a body,
 
 > **The honest ceiling (unchanged from v3.0's framing).** This is a *mirror* of your reflective self: attitudes, personality, and reflective responses transfer well (83–86% of your own self-consistency); one-shot strategic decisions in novel situations do not. DailyVox is built and marketed as **reflection and precedent, never a decision-making oracle** — and never a mood-diagnosis tool (passive affect sensing tops out ~0.74 AUROC: insight, never diagnosis).
 
-### v1.7 — Foundation Models Twin *(iOS 26, iPhone 15 Pro+)*
+### v1.7 — Foundation Models Twin *(built and evaluation-gated — next release; iOS 26, Apple Intelligence devices)*
+
+> **Status 2026-07-19: built and merged, release pending.** The engine pipeline (structured answer contract + deterministic groundedness audit) and the app integration (free-text chat, entry citations, kill-switch) are on main. The evaluation gate — a live battery against the real on-device model (honesty, fallback rate, anti-sycophancy, injection resistance, abstention safety) — passed twice consecutively; the recorded runs live in the engine repo. Ships as v1.7.0 after on-device verification.
 
 The Twin gets a real brain. Apple's on-device Foundation Models framework has been shipping since iOS 26 — this release adopts it fully, replacing the template-based Twin chat with genuine on-device language model conversations grounded in everything the Twin knows.
 

--- a/solyn/website/public/changelog.html
+++ b/solyn/website/public/changelog.html
@@ -169,7 +169,7 @@
   </header>
 
   <section class="hero wrap">
-    <div class="marker"><span class="diamond">◆</span>RELEASE HISTORY · UPDATED 2026-07-04</div>
+    <div class="marker"><span class="diamond">◆</span>RELEASE HISTORY · UPDATED 2026-07-19</div>
     <h1>Every <em>version</em>, every change.</h1>
     <p class="lede">DailyVox shipped its first version in March 2026. Here is every release since — what we built, what we changed, and (occasionally) what we shouldn't have done. For the developer-facing diff, see the <a href="https://github.com/intrepidkarthi/dailyvox/blob/main/CHANGELOG.md" style="color:var(--uv); text-decoration:underline;">GitHub CHANGELOG</a>.</p>
   </section>
@@ -178,21 +178,21 @@
 
       <section class="version" style="border-left:3px solid var(--uv);padding-left:18px;">
         <div class="v-head">
-          <div class="v-tag" style="color:var(--uv);">◇ next · v1.6.0</div>
-          <h2 id="v1-6-next">Version 1.6.0 — Memory &amp; Measurable Fidelity (in preparation)</h2>
-          <time class="v-date">coming soon</time>
+          <div class="v-tag" style="color:var(--uv);">◆ latest · v1.6.0</div>
+          <h2 id="v1-6-shipped">Version 1.6.0 — Memory &amp; Measurable Fidelity (shipped)</h2>
+          <time class="v-date">July 2026</time>
         </div>
         <div class="v-body">
         <p><strong>Your Twin remembers you better — and says how sure it is.</strong> Search your journal by <em>meaning</em>, not keywords ("the day I decided to leave my job"), entirely on-device. A first learned trait — openness — now comes from a small on-device model trained on real, consented human writing, and it never claims more confidence than it earned. Every Twin prediction shows how sure it is: tentative, moderate, or strong.</p>
         <p><strong>Your Day, if you let it.</strong> DailyVox can read the kind of photos you took and the music you reached for — on-device — and turn each into a one-line note that waits in a review-and-discard queue. Nothing reaches your Twin until you keep it; only derived labels are ever produced, and your photos and audio never leave this iPhone. Off by default.</p>
         <p style="color:var(--ink-soft); font-size:14px;">Also: teach DailyVox names it keeps mis-hearing so a correction sticks; sharper transcription on iOS 26 with Apple's new SpeechAnalyzer; and iCloud sync is now off by default for new installs — your entries live on this iPhone unless you turn it on. (Already syncing? You keep syncing.)</p>
-        <p style="margin-top:8px; color:var(--ink-soft); font-size:14px;"><em>In device testing now — this is the next release, not yet on the App Store.</em></p>
+        <p style="margin-top:8px; color:var(--ink-soft); font-size:14px;"><em>Next: v1.7 Foundation Models Twin — Ask Your Twin becomes a real conversation with an on-device brain, grounded in your entries and citing them. Then v1.8 Multi-Language · v2.0 Apple Intelligence Native · <a href="https://github.com/intrepidkarthi/dailyvox/blob/main/ROADMAP.md" style="color:var(--uv); text-decoration:underline;">full roadmap</a></em></p>
         </div>
       </section>
 
       <section class="version">
         <div class="v-head">
-          <div class="v-tag" style="color:var(--uv);">◆ latest · v1.5.0</div>
+          <div class="v-tag">◆ v1.5.0</div>
           <h2 id="v1-5-shipped">Version 1.5.0 — Body Twin (shipped)</h2>
           <time class="v-date">July 2026</time>
         </div>
@@ -200,7 +200,6 @@
         <p><strong>The Digital Twin gains a body.</strong> With your permission, Body Twin reads five signals on this iPhone — sleep, morning HRV, resting heart rate, steps, and mindful minutes — and freezes a small snapshot beside each entry, tagged with whether you were at rest or in motion, so a walk is never mistaken for a feeling. Every signal waits in a review queue: keep it or let it go — nothing reaches your Twin without your eyes on it. A body whisper offers one calm line of context before you speak ("Slept 5h 20m. Take a breath."), and Body &amp; Mood insights surface honest correlations only when there's enough data. HR is stored as a delta from your personal hour-of-day baseline, not raw bpm. Health signals stay on this iPhone — never uploaded, never in iCloud, excluded from device backups; the "Data Not Collected" privacy label stays intact.</p>
         <p style="color:var(--ink-soft); font-size:14px;"><em>The Apple Watch companion (wrist recording + heart rate during the entry) is the next step in Body Twin, not part of this release.</em></p>
         <p><a href="/blog/body-twin-healthkit-watch" style="color:var(--uv); text-decoration:underline;">Read the full Body Twin plan →</a></p>
-        <p style="margin-top:8px; color:var(--ink-soft); font-size:14px;"><em>After v1.6: v1.7 Foundation Models Twin (on-device LLM chat) · v1.8 Multi-Language · v2.0 Apple Intelligence Native · <a href="https://github.com/intrepidkarthi/dailyvox/blob/main/ROADMAP.md" style="color:var(--uv); text-decoration:underline;">full roadmap</a></em></p>
         </div>
       </section>
 

--- a/solyn/website/public/sitemap.xml
+++ b/solyn/website/public/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <sitemap><loc>https://getdailyvox.com/sitemap-core.xml</loc><lastmod>2026-07-16</lastmod></sitemap>
+  <sitemap><loc>https://getdailyvox.com/sitemap-core.xml</loc><lastmod>2026-07-19</lastmod></sitemap>
   <sitemap><loc>https://getdailyvox.com/sitemap-blog.xml</loc><lastmod>2026-07-16</lastmod></sitemap>
   <sitemap><loc>https://getdailyvox.com/sitemap-articles.xml</loc><lastmod>2026-06-16</lastmod></sitemap>
 </sitemapindex>


### PR DESCRIPTION
Post-approval sweep for v1.6.0 going live (build 20, 2026-07-19): ROADMAP stage table + section statuses (incl. honest shipped-vs-deferred scope note and v1.7 built-and-gated status), repo CHANGELOG dated, website changelog page flipped to shipped with the v1.7 teaser, sitemap lastmod bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)