### PR TITLE
build 22: bump for retrieval path + pilot card additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to DailyVox are documented here.
 - The entire conversation pipeline runs on-device with Apple's system model. Zero network calls; nothing leaves the iPhone; the "Data Not Collected" App Store label is preserved.
 
 ### Build
-- `MARKETING_VERSION` 1.6.0 → 1.7.0; `CURRENT_PROJECT_VERSION` 20 → 21.
+- `MARKETING_VERSION` 1.6.0 → 1.7.0; `CURRENT_PROJECT_VERSION` 20 → 22 (21 = first TestFlight cut; 22 adds the every-device free-text path, the pilot invitation card, and the fallback/diagnostics fixes).
 - Engine (DailyVoxTwin): structured `GroundedTwinAnswer` contract + 14-rule deterministic `AnswerAudit`, Foundation-Models pipeline with per-turn constrained citation schema, three read-only evidence tools, and the new TwinEval `--suite brain` gate (passed 2×: raw honesty 95.3%, fallback 4.7%, zero injection leaks).
 
 ## [1.6.0] — 2026-07-19

--- a/solyn/solyn.xcodeproj/project.pbxproj
+++ b/solyn/solyn.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = SolynWidget/SolynWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = SolynWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "DailyVox Widgets";
@@ -458,7 +458,7 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = SolynWidget/SolynWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = SolynWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "DailyVox Widgets";
@@ -614,7 +614,7 @@
 				CODE_SIGN_ENTITLEMENTS = solyn/solyn.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_ASSET_PATHS = "\"solyn/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -658,7 +658,7 @@
 				CODE_SIGN_ENTITLEMENTS = solyn/solyn.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_ASSET_PATHS = "\"solyn/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -699,7 +699,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.7.0;
@@ -719,7 +719,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.7.0;
@@ -738,7 +738,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.7.0;
@@ -757,7 +757,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.7.0;


### PR DESCRIPTION
Build number 21 → 22 (all targets; marketing stays 1.7.0) so the next TestFlight upload carries the every-device free-text retrieval path, the pilot invitation card, and the fallback/diagnostics fixes. Release build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)