### PR TITLE
research page: pilot-card continuity + two participation tiers

### DIFF
--- a/solyn/website/public/research.html
+++ b/solyn/website/public/research.html
@@ -192,6 +192,7 @@
   <section class="block wrap" style="border-bottom:none;">
     <h2>Join wave one</h2>
     <p>The first wave is deliberately small — a handful of people, measured carefully, reported honestly. If you journal in English on an iPhone and are 18 or older, you're eligible.</p>
+    <p class="fine">Saw the invitation card in the app? This is that study — the card appears once to journalers with a few weeks of entries, and everything beyond it happens here and over email, never inside the app. Two ways to take part: answer the seven-question self-report and compare it with your Twin's estimates (numbers only, two minutes), or additionally share an encrypted export of your diary for model validation — your choice, spelled out in the consent note before anything moves.</p>
     <a class="join-cta" href="mailto:hello@getdailyvox.com?subject=Research%20pilot%20—%20I%27m%20in&body=Hi%20Karthikeyan%2C%0A%0AI%27d%20like%20to%20join%20the%20DailyVox%20research%20pilot.%20Please%20send%20me%20the%20details.%0A%0A">Email hello@getdailyvox.com</a>
     <p class="fine">Questions first? Same address — ask anything before sending your materials.</p>
   </section>


### PR DESCRIPTION
Small addition so the v1.7 in-app invitation lands on explicit continuity: the card→page→email flow and the two tiers (numbers-only vs encrypted export) stated before the CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)