### PR TITLE
Research pilot: recording-time emotion self-labels + research export

### DIFF
--- a/solyn/solyn/BackupService.swift
+++ b/solyn/solyn/BackupService.swift
@@ -29,6 +29,10 @@ struct ExportableEntry: Codable, Identifiable {
     let audioFileName: String?
     let audioFileNames: String?
     let photoFileNames: String?
+    /// Research-pilot self-label (7-class canon + intensity 1–3). Optional so
+    /// pre-existing backups decode unchanged and older builds ignore them.
+    let selfLabelEmotion: String?
+    let selfLabelIntensity: Int?
 
     init(from entry: DiaryEntry) {
         self.id = entry.id ?? UUID()
@@ -41,6 +45,9 @@ struct ExportableEntry: Codable, Identifiable {
         self.audioFileName = entry.audioFileName
         self.audioFileNames = entry.value(forKey: "audioFileNames") as? String
         self.photoFileNames = entry.value(forKey: "photoFileNames") as? String
+        self.selfLabelEmotion = entry.value(forKey: "selfLabelEmotion") as? String
+        let intensity = entry.value(forKey: "selfLabelIntensity") as? Int16 ?? 0
+        self.selfLabelIntensity = intensity > 0 ? Int(intensity) : nil
     }
 }
 
@@ -127,7 +134,88 @@ final class BackupService {
         
         return try exportToJSON(entries: filteredEntries)
     }
-    
+
+    // MARK: - Research Export (pilot)
+
+    /// One row of the pilot research export: the fields the affect research
+    /// protocol requires (docs/research-affect, R1 §"what the pilot MUST
+    /// collect") — transcript, recording-time self-label + intensity,
+    /// timestamp, duration — joinable on the entry's stable id.
+    struct ResearchEntry: Codable {
+        let id: UUID
+        let date: Date
+        let text: String
+        let emotions: [String]      // corpus-shaped: [selfLabelEmotion rawValue]
+        let intensity: Int?         // 1–3, nil when the participant skipped it
+        let duration: Double
+        let audioCount: Int         // >1 flags a multi-recording day (label = latest)
+    }
+
+    struct ResearchExport: Codable {
+        let name: String
+        let source: String
+        let exportDate: Date
+        let deviceModel: String
+        let systemVersion: String
+        let appleIntelligenceAvailable: Bool
+        let entryCount: Int
+        let entries: [ResearchEntry]
+    }
+
+    /// Export ONLY self-labeled entries as research JSON, chronological
+    /// (the analysis protocol splits per-user by time, never randomly).
+    /// User-initiated share only — this file is handed to the share sheet
+    /// and goes wherever the participant chooses to send it.
+    func exportResearchJSON(entries: [DiaryEntry], appleIntelligenceAvailable: Bool) throws -> URL {
+        let labeled = entries
+            .filter { ($0.value(forKey: "selfLabelEmotion") as? String)?.isEmpty == false }
+            .sorted { ($0.date ?? .distantPast) < ($1.date ?? .distantPast) }
+
+        let rows: [ResearchEntry] = labeled.map { entry in
+            let intensity = entry.value(forKey: "selfLabelIntensity") as? Int16 ?? 0
+            let audio = AudioFileList.parse(entry.value(forKey: "audioFileNames") as? String,
+                                            legacy: entry.value(forKey: "audioFileName") as? String)
+            return ResearchEntry(
+                id: entry.id ?? UUID(),
+                date: entry.date ?? Date(),
+                text: entry.text ?? "",
+                emotions: [(entry.value(forKey: "selfLabelEmotion") as? String) ?? ""],
+                intensity: intensity > 0 ? Int(intensity) : nil,
+                duration: entry.duration,
+                audioCount: audio.count
+            )
+        }
+
+        #if canImport(UIKit)
+        let model = UIDevice.current.model
+        let osVersion = "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
+        #else
+        let model = "Mac"
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersionString
+        #endif
+
+        let export = ResearchExport(
+            name: "dailyvox-pilot-export",
+            source: "DailyVox research pilot — writer self-report at recording time",
+            exportDate: Date(),
+            deviceModel: model,
+            systemVersion: osVersion,
+            appleIntelligenceAvailable: appleIntelligenceAvailable,
+            entryCount: rows.count,
+            entries: rows
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(export)
+
+        let fileName = "dailyvox_research_\(formattedDate()).json"
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+        try data.write(to: tempURL)
+        return tempURL
+    }
+
     // MARK: - JSON Import
     
     /// Import entries from JSON backup
@@ -161,6 +249,8 @@ final class BackupService {
                 newEntry.audioFileName = exportedEntry.audioFileName
                 newEntry.setValue(exportedEntry.audioFileNames, forKey: "audioFileNames")
                 newEntry.setValue(exportedEntry.photoFileNames, forKey: "photoFileNames")
+                newEntry.setValue(exportedEntry.selfLabelEmotion, forKey: "selfLabelEmotion")
+                newEntry.setValue(Int16(exportedEntry.selfLabelIntensity ?? 0), forKey: "selfLabelIntensity")
 
                 importedCount += 1
             }
@@ -503,6 +593,8 @@ final class BackupService {
                 newEntry.audioFileName = exportedEntry.audioFileName
                 newEntry.setValue(exportedEntry.audioFileNames, forKey: "audioFileNames")
                 newEntry.setValue(exportedEntry.photoFileNames, forKey: "photoFileNames")
+                newEntry.setValue(exportedEntry.selfLabelEmotion, forKey: "selfLabelEmotion")
+                newEntry.setValue(Int16(exportedEntry.selfLabelIntensity ?? 0), forKey: "selfLabelIntensity")
 
                 importedCount += 1
             }

--- a/solyn/solyn/SelfLabelPicker.swift
+++ b/solyn/solyn/SelfLabelPicker.swift
@@ -1,0 +1,167 @@
+//
+//  SelfLabelPicker.swift
+//  solyn
+//
+//  Research-pilot self-label capture: an optional one-tap "How did that feel?"
+//  picker shown right after a recording is saved (pilot participants only —
+//  gated by the "pilotLabelingEnabled" setting in Settings → Research).
+//
+//  The label is stored in the dedicated selfLabelEmotion/selfLabelIntensity
+//  attributes and deliberately NEVER touches the `mood` field or the Twin
+//  engine (`processEntry`/`TwinEntryInput`) — the manual mood chain feeds
+//  emotionalSignature.emotionFrequency, and research labels must not
+//  contaminate the Twin's automatic model of the user. Labels leave the
+//  device only through the user-initiated research export in Settings.
+//
+//  Taxonomy: the research 7-class canon (6 emotions + neutral), a strict
+//  subset of the engine's DetectedEmotion rawValues so exports stay
+//  corpus-compatible.
+//
+
+import SwiftUI
+import CoreData
+
+/// The 7-class self-report canon (anger, disgust, fear, joy, neutral,
+/// sadness, surprise). Raw values match `DetectedEmotion` in the engine.
+enum SelfLabelEmotion: String, CaseIterable, Identifiable {
+    case joy = "joy"
+    case sadness = "sadness"
+    case anger = "anger"
+    case fear = "fear"
+    case surprise = "surprise"
+    case disgust = "disgust"
+    case neutral = "neutral"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .joy: return "Joy"
+        case .sadness: return "Sadness"
+        case .anger: return "Anger"
+        case .fear: return "Fear"
+        case .surprise: return "Surprise"
+        case .disgust: return "Disgust"
+        case .neutral: return "Neutral"
+        }
+    }
+
+    /// SF Symbols matching DetectedEmotion.emoji so the vocabulary reads
+    /// the same wherever emotions appear in the app.
+    var icon: String {
+        switch self {
+        case .joy: return "sun.max.fill"
+        case .sadness: return "cloud.rain.fill"
+        case .anger: return "flame.fill"
+        case .fear: return "wind"
+        case .surprise: return "sparkles"
+        case .disgust: return "xmark.circle.fill"
+        case .neutral: return "circle.fill"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .joy: return .yellow
+        case .sadness: return .blue
+        case .anger: return .red
+        case .fear: return .indigo
+        case .surprise: return .orange
+        case .disgust: return .brown
+        case .neutral: return .secondary
+        }
+    }
+}
+
+/// Compact post-recording picker card. One tap on an emotion saves
+/// (emotion + currently selected intensity) onto the entry and dismisses;
+/// Skip stores nothing. Latest-wins when the day already has a label.
+struct SelfLabelPickerCard: View {
+    @Environment(\.managedObjectContext) private var viewContext
+
+    let entry: DiaryEntry
+    let onDone: () -> Void
+
+    @State private var intensity: Int = 2
+
+    private let columns = [GridItem(.adaptive(minimum: 72), spacing: 10)]
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Text("How did that feel?")
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+
+            Text("One tap — this stays on your phone and helps the research pilot.")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            LazyVGrid(columns: columns, spacing: 10) {
+                ForEach(SelfLabelEmotion.allCases) { emotion in
+                    Button {
+                        save(emotion)
+                    } label: {
+                        VStack(spacing: 6) {
+                            Image(systemName: emotion.icon)
+                                .font(.system(size: 20))
+                                .foregroundColor(emotion.color)
+                            Text(emotion.displayName)
+                                .font(.caption2.weight(.medium))
+                                .foregroundColor(.primary)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(Color(.secondarySystemBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(emotion.displayName), intensity \(intensity)")
+                }
+            }
+
+            // Intensity 1–3, applied to whichever emotion is tapped next.
+            HStack(spacing: 14) {
+                Text("How strongly?")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                ForEach(1...3, id: \.self) { level in
+                    Button {
+                        intensity = level
+                    } label: {
+                        Circle()
+                            .fill(level <= intensity ? DS.Palette.gold : Color(.tertiarySystemFill))
+                            .frame(width: 14, height: 14)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Intensity \(level)")
+                }
+            }
+
+            Button("Skip") {
+                onDone()
+            }
+            .font(.subheadline.weight(.medium))
+            .foregroundColor(.secondary)
+        }
+        .padding(20)
+        .frame(maxWidth: 340)
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .shadow(color: .black.opacity(0.2), radius: 20, y: 10)
+    }
+
+    private func save(_ emotion: SelfLabelEmotion) {
+        // KVC (house pattern, cf. EntryDetailView.saveMood) — NOT the `mood`
+        // field; see header note on contamination.
+        entry.setValue(emotion.rawValue, forKey: "selfLabelEmotion")
+        entry.setValue(Int16(intensity), forKey: "selfLabelIntensity")
+        entry.setValue(Date(), forKey: "updatedAt")
+        do {
+            try viewContext.save()
+            HapticManager.shared.moodSelected()
+        } catch {
+            // Never block or fail the recording flow over a label.
+        }
+        onDone()
+    }
+}

--- a/solyn/solyn/SettingsView.swift
+++ b/solyn/solyn/SettingsView.swift
@@ -41,6 +41,7 @@ struct SettingsView: View {
     @AppStorage("authorName") private var authorName: String = ""
     @AppStorage("authorDescription") private var authorDescription: String = ""
     @AppStorage("iCloudSyncEnabled") private var iCloudSyncEnabled: Bool = true
+    @AppStorage("pilotLabelingEnabled") private var pilotLabelingEnabled: Bool = false
 
     enum ExportPeriod: String, CaseIterable, Identifiable {
         case monthly = "Monthly"
@@ -820,8 +821,53 @@ struct SettingsView: View {
                 }
                 .padding(.vertical, 4)
             }
+
+            Toggle(isOn: $pilotLabelingEnabled) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Label my entries after recording")
+                        .font(.subheadline.weight(.semibold))
+                    Text("For pilot participants — a one-tap feeling check after each recording")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .tint(DS.Palette.gold)
+
+            if pilotLabelingEnabled {
+                Button {
+                    exportResearchData()
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "square.and.arrow.up")
+                            .font(.subheadline)
+                            .foregroundColor(DS.Palette.gold)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Export research data")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundColor(.primary)
+                            Text("Your labeled entries as JSON — you choose where it goes")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
         } footer: {
-            Text("Opens getdailyvox.com. Taking part is voluntary and consented; nothing about your journal is collected or transmitted by the app.")
+            Text("Opens getdailyvox.com. Taking part is voluntary and consented; nothing about your journal is collected or transmitted by the app. Self-labels stay on this phone until you export and share them yourself, under the pilot consent covering research and model-training use.")
+        }
+    }
+
+    private func exportResearchData() {
+        do {
+            // Device AI availability rides the export per the research
+            // protocol (NLEmbedding/OS version skew is an analysis variable).
+            let aiAvailable = TwinBrainManager.shared.status == .ready
+            exportURL = try BackupService.shared.exportResearchJSON(
+                entries: Array(entries),
+                appleIntelligenceAvailable: aiAvailable
+            )
+        } catch {
+            exportError = "Research export failed: \(error.localizedDescription)"
         }
     }
 

--- a/solyn/solyn/TodayView.swift
+++ b/solyn/solyn/TodayView.swift
@@ -46,6 +46,10 @@ struct TodayView: View {
     @State private var firstTimePulse: Bool = false
     @State private var recordingRingPulse: Bool = false
 
+    // Research pilot: optional post-recording self-label picker (Settings → Research).
+    @AppStorage("pilotLabelingEnabled") private var pilotLabelingEnabled = false
+    @State private var labelTarget: DiaryEntry?
+
     @FetchRequest private var todayEntries: FetchedResults<DiaryEntry>
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \DiaryEntry.date, ascending: true)],
@@ -145,6 +149,23 @@ struct TodayView: View {
             }
         }
         .animation(.spring(response: 0.4), value: showFirstEntryMoment)
+        .overlay {
+            if let target = labelTarget, !showFirstEntryMoment {
+                ZStack {
+                    Color.black.opacity(0.35)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            withAnimation(.spring(response: 0.3)) { labelTarget = nil }
+                        }
+
+                    SelfLabelPickerCard(entry: target) {
+                        withAnimation(.spring(response: 0.3)) { labelTarget = nil }
+                    }
+                    .transition(.scale.combined(with: .opacity))
+                }
+            }
+        }
+        .animation(.spring(response: 0.4), value: labelTarget != nil)
         .onReceive(NotificationCenter.default.publisher(for: .startRecordingFromSiri)) { _ in
             // Auto-start recording when triggered from Siri shortcut
             if recordingState == .idle {
@@ -908,6 +929,14 @@ struct TodayView: View {
             // ONLY capture site (onboarding seeds, Siri, imports and edits
             // deliberately never snapshot).
             Task { await BodyTwinManager.shared.captureSnapshotIfEligible() }
+
+            // Research pilot: offer the one-tap self-label right at the recording
+            // moment (labels must never be retrospective). Does not wait for
+            // transcription; latest-wins if the day already carries a label.
+            if pilotLabelingEnabled
+                || ProcessInfo.processInfo.arguments.contains("-PilotLabelDemo") {
+                withAnimation(.spring(response: 0.4)) { labelTarget = entry }
+            }
         } catch {
             logger.error("Failed to save entry: \(error.localizedDescription)")
             recordingState = .idle

--- a/solyn/solyn/solyn.xcdatamodeld/solyn.xcdatamodel/contents
+++ b/solyn/solyn/solyn.xcdatamodeld/solyn.xcdatamodel/contents
@@ -16,6 +16,8 @@
         <attribute name="isStarred" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="mood" optional="YES" attributeType="String"/>
         <attribute name="photoFileNames" optional="YES" attributeType="String"/>
+        <attribute name="selfLabelEmotion" optional="YES" attributeType="String"/>
+        <attribute name="selfLabelIntensity" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="text" optional="YES" attributeType="String"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>


### PR DESCRIPTION
## What

Pilot participants can now self-label entries at the recording moment and export their labeled data for the research pilot — the feature Experiment A (closed DATA-LIMITED, memos in the engine repo) identified as the binding constraint for the Twin's emotion head.

- **Post-recording picker** (pilot-only, `pilotLabelingEnabled` toggle in Settings → Research; `-PilotLabelDemo` launch arg for testing): one-tap 7-class emotion (DetectedEmotion-compatible rawValues) + intensity 1–3, shown right after the first save — never retrospective, never blocks transcription. Latest-wins on multi-recording days.
- **Storage**: new `selfLabelEmotion`/`selfLabelIntensity` attributes on `DiaryEntry` (additive + optional/defaulted = CloudKit-safe lightweight migration; widget shares the compiled model, no widget changes).
- **Isolation**: labels never touch `mood`/`processEntry`/`TwinEntryInput` — the manual-mood chain feeds `emotionalSignature`, and research labels must not contaminate the Twin. Verified by diff grep.
- **Export**: 'Export research data' (visible only when the toggle is on) → chronological JSON of labeled entries only, with device model / OS / Apple Intelligence availability per the research protocol; shared via the existing share sheet. Labels also ride standard JSON + encrypted backups and both import paths (optional fields — old backups decode unchanged).

## Privacy

App stays App Store 'Data Not Collected': labels are on-device, export is a manual user-initiated share under the pilot consent.

## Verified

- Clean `xcodebuild` (scheme solyn, iPhone 17 Pro sim)
- Lightweight migration: new build launched against a pre-existing old-model store — entries intact
- Contamination grep: no new `mood`/`processEntry`/`TwinEntryInput` touches in the diff
- Device test (Karthik): record → picker → label → export JSON; Skip path; toggle-off default

🤖 Generated with [Claude Code](https://claude.com/claude-code)