### PR TITLE
UX polish + working Ask Your Twin (hybrid retrieval threshold)

### DIFF
--- a/solyn/solyn/GoalManager.swift
+++ b/solyn/solyn/GoalManager.swift
@@ -74,14 +74,16 @@ final class GoalManager: ObservableObject {
     func checkMilestone(currentStreak: Int) -> Int? {
         let lastMilestone = UserDefaults.standard.integer(forKey: lastMilestoneKey)
 
-        for milestone in Self.milestones {
-            if currentStreak >= milestone && milestone > lastMilestone {
-                UserDefaults.standard.set(milestone, forKey: lastMilestoneKey)
-                return milestone
-            }
+        // Celebrate only the HIGHEST milestone the streak has crossed, once.
+        // (Ascending scan replayed every historical milestone one visit at a
+        // time — a 32-day streak greeted the user with "7-Day Streak!".)
+        guard let highest = Self.milestones.last(where: { currentStreak >= $0 }),
+              highest > lastMilestone else {
+            return nil
         }
 
-        return nil
+        UserDefaults.standard.set(highest, forKey: lastMilestoneKey)
+        return highest
     }
 
     // MARK: - Goal Notification

--- a/solyn/solyn/SemanticSearchManager.swift
+++ b/solyn/solyn/SemanticSearchManager.swift
@@ -32,14 +32,20 @@ final class LocalFileTwinStateStore: TwinStateStore {
 final class SemanticSearchManager: ObservableObject {
     static let shared = SemanticSearchManager()
 
-    /// Below this top-cosine, the index is declining rather than answering —
-    /// the abstention operating point measured by TwinEval's retrieval suite
-    /// (τ ≈ 0.37 on synthetic data; re-measure on real diaries before trusting).
-    static let abstentionThreshold: Double = 0.37
+    /// Below this top HYBRID score, the index is declining rather than
+    /// answering. Single source of truth is the engine's measured operating
+    /// point (TwinEval retrieval suite: best-separating τ=0.29, balanced
+    /// accuracy 98.2% — the old hardcoded 0.37 was calibrated on synthetic
+    /// whole-entry cosine and abstained on essentially every real question).
+    static let abstentionThreshold: Double = SemanticMemoryIndex.recommendedAbstentionThreshold
 
     private let index = SemanticMemoryIndex(store: LocalFileTwinStateStore(subfolder: "SemanticMemory"))
     private var indexedIds = Set<String>()
-    private let indexedIdsKey = "semanticIndexedEntryIds"
+    // ".v2" busts the indexed-set cache so every entry re-embeds into the
+    // hybrid sentence-level format on next indexAll — legacy whole-entry
+    // vectors would otherwise stay on the pure-cosine path and keep
+    // abstaining under the new threshold. Re-indexing is ~5 ms/entry.
+    private let indexedIdsKey = "semanticIndexedEntryIds.v2"
 
     @Published var isReady = false
 

--- a/solyn/solyn/SettingsView.swift
+++ b/solyn/solyn/SettingsView.swift
@@ -78,7 +78,9 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
-            exportSection
+            // Daily-use preferences first; PDF export lives with its sibling
+            // backup/export tools near the bottom instead of greeting the
+            // user with a "Your name" field as the first thing in Settings.
             appearanceSection
             journalingGoalSection
             vocabularySection
@@ -92,9 +94,12 @@ struct SettingsView: View {
             twinBrainSection
             privacySection
             researchSection
+            exportSection
             backupSection
             aboutSection
         }
+        .scrollContentBackground(.hidden)
+        .background(themeManager.backgroundColor.ignoresSafeArea())
         .onAppear { calculateStorage() }
         .navigationTitle("Settings")
         .alert("Notifications Disabled", isPresented: $showPermissionDeniedAlert) {

--- a/solyn/solyn/ThemeManager.swift
+++ b/solyn/solyn/ThemeManager.swift
@@ -78,7 +78,10 @@ final class ThemeManager: ObservableObject {
     // MARK: - Semantic Colors
 
     var backgroundColor: Color {
-        Color(.systemGroupedBackground)
+        // Route through the warm palette so every screen that uses the
+        // semantic color (chat, settings, sheets) matches the branded tabs —
+        // non-ivory themes still fall back to the system color inside.
+        warmBackground
     }
 
     var textColor: Color {
@@ -90,7 +93,7 @@ final class ThemeManager: ObservableObject {
     }
 
     var cardBackgroundColor: Color {
-        Color(.secondarySystemGroupedBackground)
+        warmCardBackground
     }
 
     /// Theme-aware accent color for UI elements

--- a/solyn/solyn/TodayView.swift
+++ b/solyn/solyn/TodayView.swift
@@ -85,7 +85,9 @@ struct TodayView: View {
                 normalView
             }
         }
-        .alert("Recording Error", isPresented: Binding(
+        // "Saved" fallbacks (offline / failed transcription) aren't errors —
+        // don't greet a successfully kept recording with "Recording Error".
+        .alert(errorMessage?.contains("saved") == true ? "Recording Saved" : "Recording Error", isPresented: Binding(
             get: { errorMessage != nil },
             set: { if !$0 { errorMessage = nil } }
         )) {
@@ -1007,7 +1009,7 @@ struct TodayView: View {
                     if let transcriptionError = error as? SpeechTranscriber.TranscriptionError {
                         self.errorMessage = transcriptionError.errorDescription
                     } else {
-                        self.errorMessage = "Transcription failed. Your recording is saved—tap the entry to add text manually."
+                        self.errorMessage = "Transcription failed. Your recording is saved — tap the entry to add text manually."
                     }
                 }
                 recordingState = .idle


### PR DESCRIPTION
Stacked on #64 — merge that first; this retargets cleanly.

## UX fixes (from full-app walkthrough on simulator)
- **Brand consistency**: ThemeManager semantic background/card colors now route through the warm ivory palette — Ask Your Twin and Settings no longer render on the cold gray system background (non-ivory themes keep system colors)
- **Settings IA**: Appearance leads; PDF export moved next to Backup & Export (it was the first thing in Settings, opening with a bare "Your name" field)
- **Milestone modal**: celebrate only the highest crossed streak milestone, once — a 32-day streak no longer replays "7-Day Streak!" on every Insights visit
- **Recording alert**: saved-but-not-transcribed fallbacks (offline / no speech) no longer alert as "Recording Error"

## Working chat (requires DailyVoxTwin `fix/retrieval-hybrid`, a06b076)
- `abstentionThreshold` now reads the engine's measured `SemanticMemoryIndex.recommendedAbstentionThreshold` (0.30) instead of the hardcoded 0.37 that was calibrated on synthetic whole-entry cosine — the cause of Ask Your Twin abstaining on essentially every real-diary question
- Indexed-ids cache key versioned so entries re-embed into the sentence-level hybrid format on first chat open (~5 ms/entry)

Verified on iPhone 17 Pro simulator: "Did I talk about gym?" now answers with the Jul 18 gym entry + scored citations; unrelated queries still abstain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)