### PR TITLE
blog: Building a Personal Digital Twin on iPhone

### DIFF
--- a/solyn/website/content/articles/personal-digital-twin.md
+++ b/solyn/website/content/articles/personal-digital-twin.md
@@ -1,0 +1,69 @@
+---
+title: Building a Personal Digital Twin on iPhone
+description: A personal digital twin is an on-device model of your emotional patterns built from daily voice journaling without cloud tracking.
+date: 2026-08-03
+---
+
+A personal digital twin is a software model that reflects your emotional, cognitive, and behavioral patterns over time. It processes personal inputs—like daily voice notes or journal entries—and maps how your mood shifts, what triggers stress, and how your thinking evolves. 
+
+Most digital twins run on remote cloud servers. I think that is a mistake. Private thoughts do not belong in a central database. I built DailyVox to create a personal digital twin that runs on an iPhone. Your twin should belong to you, not an AI company.
+
+Here is how local personal digital twins work, how privacy trade-offs break down, and how current journaling tools handle your data.
+
+## How an On-Device Digital Twin Works
+
+A digital twin needs three components: input processing, pattern extraction, and a persistent memory model.
+
+In DailyVox, you speak. Apple's Speech framework transcribes the audio on your device. The text passes into an on-device language model that evaluates sentiment, recurring topics, and emotional state. The app updates your local twin profile.
+
+Nothing touches an external server. The App Store privacy label reads "Data Not Collected" because no data leaves the hardware. Turn on airplane mode. It still works.
+
+Most AI tools send raw voice or text to remote endpoints. That approach is easier to build. Server GPUs process text fast. But every entry exposes intimate details to remote infrastructure. Local execution flips the priority. Speed takes a small hit, but privacy remains complete.
+
+## Comparing Digital Twin and Journaling Options
+
+Different tools approach personal tracking from different angles. Here is how the current options compare:
+
+### DailyVox
+DailyVox is a free, open-source iPhone app for voice journaling. It uses Apple's native frameworks to build an emotional twin locally. It costs nothing, has no accounts, and collects zero data.
+
+### Rosebud
+Rosebud is an interactive AI journal. It acts as a conversation partner, asking follow-up questions to prompt reflection. It uses cloud-based language models to generate responses. The interactive feedback is helpful, but your entries leave your device for cloud processing.
+
+### Day One
+Day One is a structured digital journal. It supports text, photos, audio, and location data. It syncs across Mac, iOS, and Android using encrypted cloud storage. Day One does not build an AI emotional twin, but it excels at archival storage.
+
+### Apple Journal
+Apple Journal comes built into iOS. It suggests prompts based on photos, workouts, and locations recorded by your phone. It operates on-device with end-to-end encryption. However, it focuses on daily event prompts rather than modeling personal emotional patterns over time.
+
+### Daylio
+Daylio uses a micro-journaling format with icons and mood pickers. You tap buttons to track activities and moods without writing text. It generates clear statistical charts over time. It does not use natural language processing or AI modeling.
+
+## The Honest Limitation
+
+DailyVox has a plain limitation. It is iPhone-only.
+
+There is no web version. There is no Android version. If you switch platforms tomorrow, your digital twin stays on your old device. 
+
+On-device AI processing also drains battery faster than API calls. Transcribing twenty minutes of continuous audio locally makes the phone warm up and drops the battery percentage faster than standard apps do.
+
+## Why Local Architecture Matters for Digital Twins
+
+Your personal digital twin holds your raw thoughts, anxieties, and relationship patterns. Cloud-based AI services change privacy policies, update terms, and face security risks.
+
+When a twin runs locally:
+- You own the code under an open-source MIT license.
+- No third party monetizes your emotional trends.
+- The model runs off-grid in airplane mode.
+- Deleting the app removes every trace permanently.
+
+## Frequently Asked Questions
+
+### What is a personal digital twin?
+A personal digital twin is a software representation of an individual's mental, emotional, or physical patterns. It uses personal historical data—such as voice recordings or journal entries—to identify trends, mood shifts, and recurring topics over time.
+
+### Is my data safe when building a personal digital twin?
+Data safety depends on where processing happens. Cloud tools send entries to remote servers, creating privacy risks if policies change or servers leak. On-device tools process audio and text directly on phone hardware, keeping data offline.
+
+### Can I move my personal digital twin to Android or the web?
+With DailyVox, no. It relies strictly on Apple frameworks like Apple Speech and CoreML models, making it an iPhone-only app. Other services like Day One or Daylio offer web or Android sync by using cloud databases.


### PR DESCRIPTION
Drafted by autoseo against measured search demand, and approved in Telegram before
this PR was opened.

**Target query:** `personal digital twin`
**Why:** 36 impressions for 'personal digital twin' at position 30.2. Demand is proven; the page is on page 4.
**Quality gate:** PASS · slop 0 · max duplication 0%

Renders through `render_articles.py`, so it gets the same schema and styling as the other
`content/articles/` posts.

Review the copy before merging — the gate checks for AI-writing tells and duplication against the
existing 1,722 pages, but it cannot tell you whether the piece is *right*.