### PR TITLE
blog: Building a Personal Digital Twin on iPhone

### DIFF
--- a/solyn/website/content/articles/personal-digital-twin.md
+++ b/solyn/website/content/articles/personal-digital-twin.md
@@ -1,69 +1,64 @@
 ---
-title: Building a Personal Digital Twin on iPhone
-description: A personal digital twin is an on-device model of your emotional patterns built from daily voice journaling without cloud tracking.
-date: 2026-08-03
+slug: personal-digital-twin
+title: "Building a Personal Digital Twin on iPhone"
+meta_description: "A personal digital twin is a local software model of your emotional and behavioral patterns built from daily thoughts."
+target_queries: ["personal digital twin"]
+voice: karthik
+cluster: twin
 ---
 
-A personal digital twin is a software model that reflects your emotional, cognitive, and behavioral patterns over time. It processes personal inputs—like daily voice notes or journal entries—and maps how your mood shifts, what triggers stress, and how your thinking evolves. 
+# Building a Personal Digital Twin on iPhone
 
-Most digital twins run on remote cloud servers. I think that is a mistake. Private thoughts do not belong in a central database. I built DailyVox to create a personal digital twin that runs on an iPhone. Your twin should belong to you, not an AI company.
+A personal digital twin is a local software model of your behavioral, emotional, and mental patterns. Unlike industrial digital twins that monitor jet engines or factory equipment, a personal twin models you. It analyzes inputs like voice notes and mood signals to map how your stress, energy, and sentiment shift over time. You use it to spot mental loops before they spiral. The model runs locally on your device, turning private thoughts into structured self-knowledge without sending personal audio or text to third-party servers.
 
-Here is how local personal digital twins work, how privacy trade-offs break down, and how current journaling tools handle your data.
+## How a Personal Digital Twin Works
 
-## How an On-Device Digital Twin Works
+Engineers use digital twins to predict mechanical failure. You can use one to predict burnout.
 
-A digital twin needs three components: input processing, pattern extraction, and a persistent memory model.
+When you record a voice entry, an algorithm processes your speech locally. It extracts tone, tempo, and vocabulary choices. It creates a baseline. Over two weeks, the model learns your norms. You might speak faster when discussing work projects. Your pitch might flatten when discussing family stress. A personal digital twin connects these signals. It flags patterns you miss while living them.
 
-In DailyVox, you speak. Apple's Speech framework transcribes the audio on your device. The text passes into an on-device language model that evaluates sentiment, recurring topics, and emotional state. The app updates your local twin profile.
+Most AI tools run this analysis on cloud servers. That architecture has a fundamental flaw.
 
-Nothing touches an external server. The App Store privacy label reads "Data Not Collected" because no data leaves the hardware. Turn on airplane mode. It still works.
+## Privacy Is the Core Constraint
 
-Most AI tools send raw voice or text to remote endpoints. That approach is easier to build. Server GPUs process text fast. But every entry exposes intimate details to remote infrastructure. Local execution flips the priority. Speed takes a small hit, but privacy remains complete.
+A twin trained on your private life is a massive liability if stored on someone else's infrastructure. I built DailyVox because sending raw voice recordings to remote API endpoints felt unacceptable.
 
-## Comparing Digital Twin and Journaling Options
+When an AI company processes your voice journals on their infrastructure, they store your psychological profile. They can leak it. They can train future models on it. They can change their privacy terms next month.
 
-Different tools approach personal tracking from different angles. Here is how the current options compare:
+A useful personal twin belongs entirely on your hardware. Modern mobile chips handle heavy compute. Apple's Core ML and Speech frameworks let an iPhone run voice transcription and natural language analysis on-device. Your phone does the math. The data stays in your pocket.
 
-### DailyVox
-DailyVox is a free, open-source iPhone app for voice journaling. It uses Apple's native frameworks to build an emotional twin locally. It costs nothing, has no accounts, and collects zero data.
+## How DailyVox Compares to Other Apps
 
-### Rosebud
-Rosebud is an interactive AI journal. It acts as a conversation partner, asking follow-up questions to prompt reflection. It uses cloud-based language models to generate responses. The interactive feedback is helpful, but your entries leave your device for cloud processing.
+Different journaling tools solve different problems. Choosing the right one depends on where you want your data to live and how much analysis you want.
 
-### Day One
-Day One is a structured digital journal. It supports text, photos, audio, and location data. It syncs across Mac, iOS, and Android using encrypted cloud storage. Day One does not build an AI emotional twin, but it excels at archival storage.
+DailyVox is a free, open-source voice journaling app for iPhone. It builds a personal digital twin locally on your device using Apple's frameworks. Everything runs offline. Turn on airplane mode and the app works identically. Data syncs only through your personal CloudKit account if you choose to enable it. 
 
-### Apple Journal
-Apple Journal comes built into iOS. It suggests prompts based on photos, workouts, and locations recorded by your phone. It operates on-device with end-to-end encryption. However, it focuses on daily event prompts rather than modeling personal emotional patterns over time.
+The primary limitation of DailyVox is platform availability. It is iPhone-only. There is no web app, and there is no Android version. If you switch to Android, your twin stays behind.
 
-### Daylio
-Daylio uses a micro-journaling format with icons and mood pickers. You tap buttons to track activities and moods without writing text. It generates clear statistical charts over time. It does not use natural language processing or AI modeling.
+Here is how other popular apps compare:
 
-## The Honest Limitation
+*   **Rosebud** uses interactive AI prompts to guide your reflection. It offers tailored conversational feedback, but processing requires sending your entry text to cloud LLMs.
+*   **Daylio** relies on quick icon taps. You record moods and activities without typing. It is fast and runs across iOS and Android, but it does not analyze spoken language or construct a continuous conversational model.
+*   **Apple Journal** sits directly inside iOS. It suggests entry topics based on your locations, photos, and workouts. However, it lacks mood analytics or long-term pattern modeling.
+*   **Day One** provides a polished multi-platform archive for text, photos, and audio across iOS, Mac, and Android. It handles raw storage well, but treats entries as static history rather than inputs for an analytical model.
 
-DailyVox has a plain limitation. It is iPhone-only.
+## Building Your Twin step-by-step
 
-There is no web version. There is no Android version. If you switch platforms tomorrow, your digital twin stays on your old device. 
+Start small. Consistency beats intensity.
 
-On-device AI processing also drains battery faster than API calls. Transcribing twenty minutes of continuous audio locally makes the phone warm up and drops the battery percentage faster than standard apps do.
+1. Record ninety seconds of voice every evening. Talk about what drained your battery and what gave you momentum.
+2. Keep your environment relatively consistent so background noise does not distort vocal tone metrics.
+3. Review your emotional baseline after fourteen days.
 
-## Why Local Architecture Matters for Digital Twins
-
-Your personal digital twin holds your raw thoughts, anxieties, and relationship patterns. Cloud-based AI services change privacy policies, update terms, and face security risks.
-
-When a twin runs locally:
-- You own the code under an open-source MIT license.
-- No third party monetizes your emotional trends.
-- The model runs off-grid in airplane mode.
-- Deleting the app removes every trace permanently.
+Once the baseline exists, look at the correlations. You might discover that late-night voice entries consistently register lower sentiment scores, or that specific work topics trigger high speech velocity. You do not need a massive cloud server to spot these trends. An iPhone processor handles the calculation in milliseconds.
 
 ## Frequently Asked Questions
 
-### What is a personal digital twin?
-A personal digital twin is a software representation of an individual's mental, emotional, or physical patterns. It uses personal historical data—such as voice recordings or journal entries—to identify trends, mood shifts, and recurring topics over time.
+### How is a personal digital twin different from a regular journal app?
+A regular journal app is a passive storage container for text or audio entries. A personal digital twin actively processes your entries to model your emotional baseline and highlight behavioral trends over time.
 
-### Is my data safe when building a personal digital twin?
-Data safety depends on where processing happens. Cloud tools send entries to remote servers, creating privacy risks if policies change or servers leak. On-device tools process audio and text directly on phone hardware, keeping data offline.
+### Does a personal digital twin require cloud servers?
+No. Modern mobile processors include neural engines capable of running natural language processing and voice transcription locally on your phone without an internet connection.
 
-### Can I move my personal digital twin to Android or the web?
-With DailyVox, no. It relies strictly on Apple frameworks like Apple Speech and CoreML models, making it an iPhone-only app. Other services like Day One or Daylio offer web or Android sync by using cloud databases.
+### Can I export or delete my personal digital twin data?
+With local-first apps like DailyVox, your data lives in local device storage or your personal iCloud container. You can export your raw entries or wipe the local database instantly at any time.

--- a/solyn/website/public/blog/personal-digital-twin.html
+++ b/solyn/website/public/blog/personal-digital-twin.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Building a Personal Digital Twin on iPhone</title>
+<meta name="description" content="A personal digital twin is a local software model of your emotional and behavioral patterns built from daily thoughts.">
+<link rel="canonical" href="https://getdailyvox.com/blog/personal-digital-twin">
+<meta name="theme-color" content="#FAF8F5">
+<meta property="og:type" content="article"><meta property="og:title" content="Building a Personal Digital Twin on iPhone">
+<meta property="og:description" content="A personal digital twin is a local software model of your emotional and behavioral patterns built from daily thoughts."><meta property="og:url" content="https://getdailyvox.com/blog/personal-digital-twin">
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "Article", "headline": "Building a Personal Digital Twin on iPhone", "description": "A personal digital twin is a local software model of your emotional and behavioral patterns built from daily thoughts.", "url": "https://getdailyvox.com/blog/personal-digital-twin", "author": {"@type": "Organization", "name": "DailyVox"}, "publisher": {"@type": "Organization", "name": "DailyVox", "url": "https://getdailyvox.com"}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "Home", "item": "https://getdailyvox.com/"}, {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://getdailyvox.com/blog"}, {"@type": "ListItem", "position": 3, "name": "Building a Personal Digital Twin on iPhone"}]}</script>
+<style>
+:root{--ivory:#FAF8F5;--ink:#2B2520;--sage:#5B7C6B;--gold:#D4A547;--terra:#C4956A}
+*{box-sizing:border-box}body{margin:0;background:var(--ivory);color:var(--ink);font:18px/1.7 -apple-system,'Nunito',Segoe UI,sans-serif}
+header,main,footer{max-width:720px;margin:0 auto;padding:0 22px}
+header{display:flex;gap:20px;align-items:center;padding:18px 22px;font-weight:700}
+header a{color:var(--ink);text-decoration:none;font-size:15px}header .logo{color:var(--sage);font-size:20px}
+h1{font-size:34px;line-height:1.2;margin:22px 0 8px}h2{font-size:23px;color:var(--sage);margin-top:34px}
+.bc{font-size:14px;color:#8a8175;margin-top:14px}.bc a{color:#8a8175}
+ol{padding-left:22px}ol li{margin:6px 0}
+.cta{background:var(--sage);color:#fff;border-radius:16px;padding:24px;margin:38px 0;text-align:center}
+.cta a{display:inline-block;background:var(--gold);color:var(--ink);font-weight:800;padding:12px 24px;border-radius:30px;text-decoration:none;margin-top:10px}
+details{border-top:1px solid #e7e0d6;padding:13px 0}summary{font-weight:700;cursor:pointer}
+table{border-collapse:collapse;width:100%;margin:18px 0;font-size:15px}
+th,td{border:1px solid #e7e0d6;padding:9px 12px;text-align:left;vertical-align:top}
+th{background:#f3efe8;color:var(--ink)}td:first-child{font-weight:600}
+.related{display:flex;flex-wrap:wrap;gap:10px;margin:20px 0 50px}.related a{background:#fff;border:1px solid #e7e0d6;border-radius:20px;padding:8px 15px;font-size:14px;color:var(--terra);text-decoration:none}
+footer{color:#8a8175;font-size:14px;padding:28px 22px 60px;border-top:1px solid #e7e0d6}
+a{color:var(--terra)}
+</style></head>
+<body>
+<header><a class="logo" href="/">DailyVox</a><a href="/blog">Blog</a><a href="/faq">FAQ</a><a href="/privacy">Privacy</a></header>
+<main>
+<div class="bc"><a href="/">Home</a> &rsaquo; <a href="/blog">Blog</a></div>
+<h1>Building a Personal Digital Twin on iPhone</h1>
+<p>A personal digital twin is a local software model of your behavioral, emotional, and mental patterns. Unlike industrial digital twins that monitor jet engines or factory equipment, a personal twin models you. It analyzes inputs like voice notes and mood signals to map how your stress, energy, and sentiment shift over time. You use it to spot mental loops before they spiral. The model runs locally on your device, turning private thoughts into structured self-knowledge without sending personal audio or text to third-party servers.</p>
+<h2>How a Personal Digital Twin Works</h2>
+<p>Engineers use digital twins to predict mechanical failure. You can use one to predict burnout.</p>
+<p>When you record a voice entry, an algorithm processes your speech locally. It extracts tone, tempo, and vocabulary choices. It creates a baseline. Over two weeks, the model learns your norms. You might speak faster when discussing work projects. Your pitch might flatten when discussing family stress. A personal digital twin connects these signals. It flags patterns you miss while living them.</p>
+<p>Most AI tools run this analysis on cloud servers. That architecture has a fundamental flaw.</p>
+<h2>Privacy Is the Core Constraint</h2>
+<p>A twin trained on your private life is a massive liability if stored on someone else's infrastructure. I built DailyVox because sending raw voice recordings to remote API endpoints felt unacceptable.</p>
+<p>When an AI company processes your voice journals on their infrastructure, they store your psychological profile. They can leak it. They can train future models on it. They can change their privacy terms next month.</p>
+<p>A useful personal twin belongs entirely on your hardware. Modern mobile chips handle heavy compute. Apple's Core ML and Speech frameworks let an iPhone run voice transcription and natural language analysis on-device. Your phone does the math. The data stays in your pocket.</p>
+<h2>How DailyVox Compares to Other Apps</h2>
+<p>Different journaling tools solve different problems. Choosing the right one depends on where you want your data to live and how much analysis you want.</p>
+<p>DailyVox is a free, open-source voice journaling app for iPhone. It builds a personal digital twin locally on your device using Apple's frameworks. Everything runs offline. Turn on airplane mode and the app works identically. Data syncs only through your personal CloudKit account if you choose to enable it.</p>
+<p>The primary limitation of DailyVox is platform availability. It is iPhone-only. There is no web app, and there is no Android version. If you switch to Android, your twin stays behind.</p>
+<p>Here is how other popular apps compare:</p>
+<p>*   <strong>Rosebud</strong> uses interactive AI prompts to guide your reflection. It offers tailored conversational feedback, but processing requires sending your entry text to cloud LLMs. *   <strong>Daylio</strong> relies on quick icon taps. You record moods and activities without typing. It is fast and runs across iOS and Android, but it does not analyze spoken language or construct a continuous conversational model. *   <strong>Apple Journal</strong> sits directly inside iOS. It suggests entry topics based on your locations, photos, and workouts. However, it lacks mood analytics or long-term pattern modeling. *   <strong>Day One</strong> provides a polished multi-platform archive for text, photos, and audio across iOS, Mac, and Android. It handles raw storage well, but treats entries as static history rather than inputs for an analytical model.</p>
+<h2>Building Your Twin step-by-step</h2>
+<p>Start small. Consistency beats intensity.</p>
+<ol><li>Record ninety seconds of voice every evening. Talk about what drained your battery and what gave you momentum.</li><li>Keep your environment relatively consistent so background noise does not distort vocal tone metrics.</li><li>Review your emotional baseline after fourteen days.</li></ol>
+<p>Once the baseline exists, look at the correlations. You might discover that late-night voice entries consistently register lower sentiment scores, or that specific work topics trigger high speech velocity. You do not need a massive cloud server to spot these trends. An iPhone processor handles the calculation in milliseconds.</p>
+<h2>Frequently Asked Questions</h2>
+<p>### How is a personal digital twin different from a regular journal app? A regular journal app is a passive storage container for text or audio entries. A personal digital twin actively processes your entries to model your emotional baseline and highlight behavioral trends over time.</p>
+<p>### Does a personal digital twin require cloud servers? No. Modern mobile processors include neural engines capable of running natural language processing and voice transcription locally on your phone without an internet connection.</p>
+<p>### Can I export or delete my personal digital twin data? With local-first apps like DailyVox, your data lives in local device storage or your personal iCloud container. You can export your raw entries or wipe the local database instantly at any time.</p>
+<div class="cta"><strong>DailyVox keeps your words on your phone.</strong><br><a href="https://apps.apple.com/app/id6760454642">Get it on the App Store</a></div>
+<div class="related"><a href="/blog/dailyvox-vs-reflection">DailyVox vs Reflection: on-device voice vs cloud AI coach</a><a href="/blog/dailyvox-vs-speakwise">DailyVox vs Speakwise: personal journal vs meeting notes</a><a href="/blog/dailyvox-vs-tinh">DailyVox vs tinh: two on-device voice journals</a><a href="/blog/dailyvox-vs-untold">DailyVox vs Untold: on-device vs cloud voice journaling</a></div>
+</main>
+<footer>DailyVox &middot; Private, on-device voice journaling. Your words never leave your phone.</footer>
+</body></html>

--- a/solyn/website/public/sitemap-articles.xml
+++ b/solyn/website/public/sitemap-articles.xml
@@ -6,5 +6,6 @@
 <url><loc>https://getdailyvox.com/blog/dailyvox-vs-untold</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
 <url><loc>https://getdailyvox.com/blog/dailyvox-vs-voicescriber</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
 <url><loc>https://getdailyvox.com/blog/is-your-diary-app-private</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+<url><loc>https://getdailyvox.com/blog/personal-digital-twin</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
 <url><loc>https://getdailyvox.com/blog/voice-diary-app</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
 </urlset>


### PR DESCRIPTION
Drafted by autoseo against measured search demand, and approved in Telegram before
this PR was opened.

**Target query:** `personal digital twin`
**Why:** 36 impressions for 'personal digital twin' at position 30.2. Demand is proven; the page is on page 4.
**Quality gate:** PASS · slop 0 · max duplication 0%

Includes the rendered HTML and the regenerated sitemap, not just the markdown. The site is served
with `buildCommand: null`, so nothing converts markdown at deploy time — committing the source alone
produces a 404, which is what happened with #68.

Review the copy before merging — the gate checks for AI-writing tells and duplication against the
existing 1,722 pages, but it cannot tell you whether the piece is *right*.