### PR TITLE
Debug: on-device peak memory harness (v1.10 voice gate)

### DIFF
--- a/solyn/solyn/MemoryProbe.swift
+++ b/solyn/solyn/MemoryProbe.swift
@@ -1,0 +1,438 @@
+//
+//  MemoryProbe.swift
+//  DailyVox
+//
+//  Measures what a workload actually costs this process in memory, on a real
+//  iPhone, using the same ledger the kernel consults when it decides which app
+//  to kill.
+//
+//  Why this exists: the v1.10 "your own voice" candidates (Kyutai Pocket TTS,
+//  MOSS-TTS-Nano) are gated on a measured peak footprint, not a projected one.
+//  The previous candidate — chatterbox-turbo — was projected to fit and then
+//  measured 953.7 MB against a ~250 MB ceiling. Every number this file produces
+//  is measured on device or it does not count.
+//
+//  DEBUG-only by construction: this is a development instrument, not a feature,
+//  and the whole file compiles out of Release builds.
+//
+
+#if DEBUG
+
+import Foundation
+import Darwin
+import os
+
+// MARK: - Snapshot
+
+/// One reading of the process's memory position, from `TASK_VM_INFO`.
+///
+/// The field that matters is ``physFootprint``, not resident size. Jetsam bills
+/// a process for its phys_footprint — that is the number a model has to fit
+/// inside. `resident_size` omits compressed pages and would flatter every
+/// result we take.
+struct MemorySnapshot: Codable, Sendable {
+
+    /// What jetsam bills this process for. The number that decides life or death.
+    let physFootprint: UInt64
+
+    /// Kernel-tracked high-water mark of ``physFootprint`` for the life of this
+    /// process. There is no user-space call to reset it, which is the whole
+    /// reason ``PeakConfidence`` exists.
+    let ledgerPeak: Int64
+
+    /// Bytes remaining before this process hits its jetsam limit. `nil` on
+    /// kernels that predate the field (rev4).
+    let limitBytesRemaining: UInt64?
+
+    /// Footprint attributed to Neural Engine allocations. A CoreML or
+    /// ExecuTorch model executing on the ANE appears here *as well as* in
+    /// ``physFootprint`` — it is not a separate budget, it is a breakdown.
+    let neuralFootprint: Int64?
+
+    /// Compressed-memory footprint. Watch this on calibration runs: if a
+    /// workload's pages are compressible, the footprint understates what an
+    /// equivalent volume of real model weights would cost.
+    let compressed: UInt64
+
+    /// `os_proc_available_memory()` — headroom as the OS reports it to apps.
+    /// Independent of ``limitBytesRemaining`` and worth cross-checking against it.
+    let availableMemory: Int
+
+    /// Wall-clock offset from the start of the run, in seconds. Zero for
+    /// one-shot reads.
+    var elapsed: TimeInterval = 0
+}
+
+// MARK: - Reading the ledger
+
+enum MemoryProbe {
+
+    /// Reads `TASK_VM_INFO` for the current process.
+    ///
+    /// Fields arrived in the struct over successive kernel revisions, and the
+    /// kernel reports back how much it actually filled in. We ask for the full
+    /// struct and then only trust a field if the returned count covers it —
+    /// reading past that boundary yields whatever was on the stack, which is
+    /// exactly the kind of plausible-looking garbage this harness exists to
+    /// avoid.
+    static func snapshot() -> MemorySnapshot? {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<natural_t>.size
+        )
+
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+
+        return MemorySnapshot(
+            physFootprint: info.phys_footprint,
+            ledgerPeak: info.ledger_phys_footprint_peak,
+            limitBytesRemaining: filled(count, \.limit_bytes_remaining, size: 8)
+                ? info.limit_bytes_remaining : nil,
+            neuralFootprint: filled(count, \.ledger_tag_neural_footprint, size: 8)
+                ? info.ledger_tag_neural_footprint : nil,
+            compressed: info.compressed,
+            availableMemory: os_proc_available_memory()
+        )
+    }
+
+    /// Did the kernel fill in far enough to cover this field?
+    ///
+    /// `count` comes back in units of `natural_t`, so a field is safe to read
+    /// only once the reported count reaches past the field's last byte.
+    private static func filled(
+        _ count: mach_msg_type_number_t,
+        _ keyPath: PartialKeyPath<task_vm_info_data_t>,
+        size: Int
+    ) -> Bool {
+        guard let offset = MemoryLayout<task_vm_info_data_t>.offset(of: keyPath) else {
+            return false
+        }
+        let unit = MemoryLayout<natural_t>.size
+        let needed = (offset + size + unit - 1) / unit
+        return Int(count) >= needed
+    }
+}
+
+// MARK: - Peak confidence
+
+/// How much a reported peak can be trusted.
+///
+/// The kernel's high-water mark cannot be reset from user space, so a workload
+/// that stays below a mark set earlier in the process's life leaves the ledger
+/// untouched. When that happens we fall back to the sampler, which can miss a
+/// spike shorter than its interval. The distinction is the difference between a
+/// number you can gate a release on and one you cannot, so it travels with
+/// every result rather than living in a footnote.
+enum PeakConfidence: String, Codable, Sendable {
+
+    /// The workload pushed the process to a new lifetime high, so the kernel
+    /// ledger recorded the peak itself. Exact: no sampling gap can hide a spike.
+    case exact
+
+    /// The workload stayed under a high-water mark set earlier in this process's
+    /// life. The reported peak is the highest value the sampler observed and is
+    /// a **lower bound** — relaunch the app and re-run to get an exact reading.
+    case sampled
+
+    var summary: String {
+        switch self {
+        case .exact: return "Exact — kernel high-water mark"
+        case .sampled: return "Lower bound — sampled, relaunch to confirm"
+        }
+    }
+}
+
+// MARK: - Sampler
+
+/// Polls `phys_footprint` on a dedicated thread for the duration of a workload.
+///
+/// Sampling exists only to cover the ``PeakConfidence/sampled`` case. When the
+/// ledger moves, the ledger wins — it is exact and this is not.
+private final class FootprintSampler {
+
+    private struct State {
+        var running = true
+        var peak: UInt64 = 0
+        var samples = 0
+        var trace: [MemorySnapshot] = []
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let interval: useconds_t
+    private let traceEvery: Int
+    private var thread: Thread?
+
+    /// - Parameters:
+    ///   - interval: microseconds between reads. 500 µs keeps the thread under
+    ///     ~1% of a core while being fine enough to catch a model load.
+    ///   - traceEvery: keep one snapshot per N samples for the timeline, so a
+    ///     long run does not accumulate an unbounded array.
+    init(interval: useconds_t = 500, traceEvery: Int = 40) {
+        self.interval = interval
+        self.traceEvery = traceEvery
+    }
+
+    func start(startedAt: Date) {
+        let thread = Thread { [state, interval, traceEvery] in
+            while state.withLock({ $0.running }) {
+                if var reading = MemoryProbe.snapshot() {
+                    reading.elapsed = Date().timeIntervalSince(startedAt)
+                    state.withLock { current in
+                        current.peak = max(current.peak, reading.physFootprint)
+                        current.samples += 1
+                        if current.samples % traceEvery == 0 {
+                            current.trace.append(reading)
+                        }
+                    }
+                }
+                usleep(interval)
+            }
+        }
+        thread.qualityOfService = .userInitiated
+        thread.name = "MemoryProbe.sampler"
+        self.thread = thread
+        thread.start()
+    }
+
+    /// Stops the thread and returns what it saw.
+    func stop() -> (peak: UInt64, samples: Int, trace: [MemorySnapshot]) {
+        state.withLock { $0.running = false }
+        // The sampler checks the flag once per interval; give it a couple of
+        // intervals to notice and exit before we read the final state.
+        usleep(interval * 3)
+        return state.withLock { ($0.peak, $0.samples, $0.trace) }
+    }
+}
+
+// MARK: - Result
+
+/// What one measured workload cost.
+struct MemoryProbeResult: Codable, Sendable, Identifiable {
+    var id: String { "\(label)-\(startedAt.timeIntervalSince1970)" }
+
+    let label: String
+    let startedAt: Date
+    let duration: TimeInterval
+
+    /// Footprint immediately before the workload ran.
+    let baseline: UInt64
+    /// Highest footprint observed during the workload.
+    let peak: UInt64
+    /// Footprint after the workload returned and its allocations were released.
+    let settled: UInt64
+
+    let confidence: PeakConfidence
+    let sampleCount: Int
+    let trace: [MemorySnapshot]
+
+    /// Snapshot taken at the moment of peak-adjacent measurement, for the ANE
+    /// and jetsam-headroom fields.
+    let atPeak: MemorySnapshot?
+
+    /// Device and OS, because the jetsam limit is per-device and a number
+    /// without its device is not a result.
+    let device: String
+    let systemVersion: String
+    let physicalMemory: UInt64
+
+    /// What the workload itself cost, over the process baseline. This is the
+    /// number a model budget is spent against.
+    var peakDelta: Int64 { Int64(peak) - Int64(baseline) }
+
+    /// Memory not returned when the workload finished. Persistently non-zero
+    /// means a leak or a cache that outlives the run — either way, the next
+    /// run's baseline is polluted.
+    var retained: Int64 { Int64(settled) - Int64(baseline) }
+}
+
+// MARK: - Runner
+
+extension MemoryProbe {
+
+    /// Measures the peak footprint cost of `work`.
+    ///
+    /// Runs `work` synchronously on the calling thread while a sampler watches
+    /// from another. Call this off the main thread for anything slow.
+    ///
+    /// - Note: Relaunch the app before a measurement that matters. The kernel's
+    ///   high-water mark only ever rises, so a fresh process is what buys an
+    ///   ``PeakConfidence/exact`` reading.
+    ///
+    /// - Important: Only one measurement may be in flight at a time, and nothing
+    ///   else in the app should be doing heavy work while one runs. This reads
+    ///   the *process* footprint, so a concurrent allocation anywhere is
+    ///   indistinguishable from the workload's own. The test suite establishes
+    ///   this the hard way: running these measurements in parallel made them
+    ///   fail non-deterministically until the suite was marked `.serialized`.
+    static func measure(
+        label: String,
+        settleDelay: TimeInterval = 0.5,
+        work: () throws -> Void
+    ) rethrows -> MemoryProbeResult {
+
+        let before = snapshot()
+        let baseline = before?.physFootprint ?? 0
+        let ledgerBefore = before?.ledgerPeak ?? 0
+
+        let startedAt = Date()
+        let sampler = FootprintSampler()
+        sampler.start(startedAt: startedAt)
+
+        // `defer` so a throwing workload still stops the thread.
+        var stopped: (peak: UInt64, samples: Int, trace: [MemorySnapshot])?
+        defer { if stopped == nil { _ = sampler.stop() } }
+
+        try work()
+
+        let duration = Date().timeIntervalSince(startedAt)
+        let atPeak = snapshot()
+        let result = sampler.stop()
+        stopped = result
+
+        let ledgerAfter = atPeak?.ledgerPeak ?? 0
+
+        // If the workload moved the kernel's high-water mark, the kernel saw the
+        // true peak and the sampler is irrelevant. Otherwise the sampler's best
+        // observation is all we have, and it is a lower bound.
+        let confidence: PeakConfidence = ledgerAfter > ledgerBefore ? .exact : .sampled
+        let peak = confidence == .exact
+            ? UInt64(max(0, ledgerAfter))
+            : max(result.peak, baseline)
+
+        // Let deallocation and the compressor settle before reading what stuck.
+        Thread.sleep(forTimeInterval: settleDelay)
+        let settled = snapshot()?.physFootprint ?? baseline
+
+        var system = utsname()
+        uname(&system)
+        let machine = withUnsafeBytes(of: &system.machine) { raw in
+            Array(raw.prefix { $0 != 0 })
+        }
+
+        return MemoryProbeResult(
+            label: label,
+            startedAt: startedAt,
+            duration: duration,
+            baseline: baseline,
+            peak: peak,
+            settled: settled,
+            confidence: confidence,
+            sampleCount: result.samples,
+            trace: result.trace,
+            atPeak: atPeak,
+            device: String(decoding: machine, as: UTF8.self),
+            systemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            physicalMemory: ProcessInfo.processInfo.physicalMemory
+        )
+    }
+}
+
+// MARK: - Calibration
+
+/// Workloads whose true cost is known in advance, used to check that the
+/// harness reports what actually happened.
+///
+/// This is the step that separates this harness from the projection that killed
+/// chatterbox-turbo. If a run that allocates a known 200 MB does not measure as
+/// ~200 MB, then no reading this file produces about a TTS model means anything
+/// either, and that has to be discovered here rather than after a shipping
+/// decision.
+enum MemoryCalibration {
+
+    /// Allocates `megabytes` of **incompressible** memory, touches every page so
+    /// it is genuinely resident, and holds it until the closure returns.
+    ///
+    /// Incompressible matters. iOS compresses idle pages, and phys_footprint
+    /// counts compressed pages at their compressed size — so a calibration that
+    /// wrote zeros would compress to almost nothing and report a wildly
+    /// optimistic number. Model weights do not compress; neither does this.
+    static func holdingIncompressible(
+        megabytes: Int,
+        _ body: (UnsafeMutableRawPointer) -> Void = { _ in }
+    ) {
+        let byteCount = megabytes * 1024 * 1024
+        let buffer = UnsafeMutableRawPointer.allocate(
+            byteCount: byteCount,
+            alignment: MemoryLayout<UInt64>.alignment
+        )
+        defer { buffer.deallocate() }
+
+        // A cheap xorshift PRNG: deterministic, and its output does not compress.
+        var seed: UInt64 = 0x2545F4914F6CDD1D
+        let stride = MemoryLayout<UInt64>.size
+        let words = byteCount / stride
+        let typed = buffer.bindMemory(to: UInt64.self, capacity: words)
+        for index in 0..<words {
+            seed ^= seed << 13
+            seed ^= seed >> 7
+            seed ^= seed << 17
+            typed[index] = seed
+        }
+
+        body(buffer)
+    }
+
+    /// Runs a calibration at `megabytes` and reports how far the harness's
+    /// measurement landed from the known truth.
+    static func verify(megabytes: Int) -> (result: MemoryProbeResult, errorPercent: Double) {
+        let result = MemoryProbe.measure(label: "Calibration \(megabytes) MB") {
+            holdingIncompressible(megabytes: megabytes) { _ in
+                // Hold briefly at peak so a sampled reading has a chance to see
+                // it. An exact reading does not need this; a sampled one does.
+                Thread.sleep(forTimeInterval: 0.25)
+            }
+        }
+        let expected = Double(megabytes) * 1024 * 1024
+        let error = (Double(result.peakDelta) - expected) / expected * 100
+        return (result, error)
+    }
+}
+
+// MARK: - Formatting
+
+extension MemoryProbeResult {
+
+    static func format(bytes: Int64) -> String {
+        let mb = Double(bytes) / 1024 / 1024
+        if abs(mb) >= 1024 {
+            return String(format: "%.2f GB", mb / 1024)
+        }
+        return String(format: "%.1f MB", mb)
+    }
+
+    static func format(bytes: UInt64) -> String { format(bytes: Int64(bytes)) }
+
+    /// A one-line summary suitable for pasting into a decision record.
+    var headline: String {
+        "\(label): peak +\(Self.format(bytes: peakDelta)) over a "
+            + "\(Self.format(bytes: baseline)) baseline "
+            + "(\(confidence.rawValue), \(device), \(systemVersion))"
+    }
+}
+
+// MARK: - Export
+
+enum MemoryProbeExport {
+
+    /// Writes results as JSON to a temporary file for the share sheet.
+    static func write(_ results: [MemoryProbeResult]) throws -> URL {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+
+        let stamp = ISO8601DateFormatter().string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dailyvox-memory-probe-\(stamp).json")
+
+        try encoder.encode(results).write(to: url)
+        return url
+    }
+}
+
+#endif

--- a/solyn/solyn/MemoryProbeView.swift
+++ b/solyn/solyn/MemoryProbeView.swift
@@ -1,0 +1,214 @@
+//
+//  MemoryProbeView.swift
+//  DailyVox
+//
+//  The on-device face of MemoryProbe: run a workload, read what it cost, share
+//  the JSON. Exists so the v1.10 voice measurement can be taken on the phone
+//  itself rather than from an Xcode session — the same constraint the app holds
+//  for features applies to the instrument that gates them.
+//
+//  DEBUG-only, like the probe it drives.
+//
+
+#if DEBUG
+
+import SwiftUI
+
+struct MemoryProbeView: View {
+
+    @State private var results: [MemoryProbeResult] = []
+    @State private var running: String?
+    @State private var live: MemorySnapshot?
+    @State private var exportURL: URL?
+    @State private var exportError: String?
+
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        Form {
+            liveSection
+            calibrationSection
+            if !results.isEmpty { resultsSection }
+            guidanceSection
+        }
+        .navigationTitle("Memory Probe")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { live = MemoryProbe.snapshot() }
+        .onReceive(timer) { _ in if running == nil { live = MemoryProbe.snapshot() } }
+        .sheet(item: Binding(
+            get: { exportURL.map { IdentifiableURL(url: $0) } },
+            set: { if $0 == nil { exportURL = nil } }
+        )) { item in
+            ShareSheet(activityItems: [item.url])
+        }
+        .alert("Export error", isPresented: Binding(
+            get: { exportError != nil },
+            set: { if !$0 { exportError = nil } }
+        )) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(exportError ?? "")
+        }
+    }
+
+    // MARK: - Live
+
+    private var liveSection: some View {
+        Section {
+            if let live {
+                row("Footprint", MemoryProbeResult.format(bytes: live.physFootprint))
+                row("Lifetime peak", MemoryProbeResult.format(bytes: live.ledgerPeak))
+                if let remaining = live.limitBytesRemaining {
+                    row("Headroom to jetsam", MemoryProbeResult.format(bytes: remaining))
+                }
+                row("OS reports available", MemoryProbeResult.format(bytes: Int64(live.availableMemory)))
+                if let neural = live.neuralFootprint, neural > 0 {
+                    row("Neural Engine", MemoryProbeResult.format(bytes: neural))
+                }
+                row("Compressed", MemoryProbeResult.format(bytes: live.compressed))
+            } else {
+                Text("TASK_VM_INFO unavailable")
+                    .foregroundColor(.secondary)
+            }
+        } header: {
+            Text("Live")
+        } footer: {
+            Text("Footprint is what jetsam bills this process for — not resident size, which omits compressed pages. The lifetime peak only ever rises, so relaunch the app before a run that matters.")
+        }
+    }
+
+    // MARK: - Calibration
+
+    private var calibrationSection: some View {
+        Section {
+            ForEach([50, 100, 250], id: \.self) { megabytes in
+                Button {
+                    runCalibration(megabytes: megabytes)
+                } label: {
+                    HStack {
+                        Text("Allocate \(megabytes) MB")
+                        Spacer()
+                        if running == "Calibration \(megabytes) MB" {
+                            ProgressView()
+                        }
+                    }
+                }
+                .disabled(running != nil)
+            }
+        } header: {
+            Text("Calibration")
+        } footer: {
+            Text("Allocates a known volume of incompressible bytes and checks that the harness measures what it actually allocated. Run this first: if a known 250 MB does not read as ~250 MB, no number this screen reports about a TTS model means anything either. That is the mistake that cost the chatterbox-turbo evaluation.")
+        }
+    }
+
+    // MARK: - Results
+
+    private var resultsSection: some View {
+        Section {
+            ForEach(results) { result in
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(result.label)
+                            .font(.subheadline.weight(.semibold))
+                        Spacer()
+                        Text(MemoryProbeResult.format(bytes: result.peakDelta))
+                            .font(.subheadline.monospacedDigit())
+                            .foregroundColor(DS.Palette.gold)
+                    }
+                    Text(result.confidence.summary)
+                        .font(.caption)
+                        .foregroundColor(result.confidence == .exact ? .secondary : .orange)
+                    Text("baseline \(MemoryProbeResult.format(bytes: result.baseline)) · retained \(MemoryProbeResult.format(bytes: result.retained)) · \(result.sampleCount) samples · \(String(format: "%.2fs", result.duration))")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.vertical, 2)
+            }
+
+            Button {
+                share()
+            } label: {
+                Label("Export results as JSON", systemImage: "square.and.arrow.up")
+            }
+
+            Button(role: .destructive) {
+                results.removeAll()
+            } label: {
+                Text("Clear")
+            }
+        } header: {
+            Text("Results")
+        } footer: {
+            Text("Peak delta is the workload's own cost over the process baseline — the number a model budget is spent against. Retained is what did not come back; persistently non-zero means the next run starts from a polluted baseline.")
+        }
+    }
+
+    private var guidanceSection: some View {
+        Section {
+            Text("Running a model measurement")
+                .font(.subheadline.weight(.semibold))
+            Text("1. Force-quit and relaunch DailyVox, so the lifetime peak is low and the reading comes back exact rather than sampled.\n2. Run a calibration at roughly the size you expect, and confirm the error is small.\n3. Run the model workload once, cold.\n4. Export before doing anything else — a second run's baseline includes whatever the first one retained.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        } header: {
+            Text("Protocol")
+        } footer: {
+            Text("A measurement taken inside the full app is the one that counts: jetsam bills the whole process, so a model measured alone in a bare harness reports a number the app can never actually achieve.")
+        }
+    }
+
+    // MARK: - Actions
+
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label)
+            Spacer()
+            Text(value)
+                .font(.body.monospacedDigit())
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func runCalibration(megabytes: Int) {
+        let label = "Calibration \(megabytes) MB"
+        running = label
+        // Off the main thread: the workload is synchronous and would otherwise
+        // block the sampler's own scheduling as well as the UI.
+        DispatchQueue.global(qos: .userInitiated).async {
+            let (result, errorPercent) = MemoryCalibration.verify(megabytes: megabytes)
+            DispatchQueue.main.async {
+                // Fold the calibration error into the label so it survives
+                // export and screenshotting alongside the number it qualifies.
+                let annotated = MemoryProbeResult(
+                    label: "\(result.label) (error \(String(format: "%+.1f%%", errorPercent)))",
+                    startedAt: result.startedAt,
+                    duration: result.duration,
+                    baseline: result.baseline,
+                    peak: result.peak,
+                    settled: result.settled,
+                    confidence: result.confidence,
+                    sampleCount: result.sampleCount,
+                    trace: result.trace,
+                    atPeak: result.atPeak,
+                    device: result.device,
+                    systemVersion: result.systemVersion,
+                    physicalMemory: result.physicalMemory
+                )
+                results.insert(annotated, at: 0)
+                running = nil
+                live = MemoryProbe.snapshot()
+            }
+        }
+    }
+
+    private func share() {
+        do {
+            exportURL = try MemoryProbeExport.write(results)
+        } catch {
+            exportError = error.localizedDescription
+        }
+    }
+}
+
+#endif

--- a/solyn/solyn/SettingsView.swift
+++ b/solyn/solyn/SettingsView.swift
@@ -99,6 +99,9 @@ struct SettingsView: View {
             exportSection
             backupSection
             aboutSection
+            #if DEBUG
+            developerSection
+            #endif
         }
         .scrollContentBackground(.hidden)
         .background(themeManager.backgroundColor.ignoresSafeArea())
@@ -1155,6 +1158,35 @@ struct SettingsView: View {
             }
         }
     }
+
+    #if DEBUG
+    /// Development instruments. Compiled out of Release entirely — this section
+    /// and everything it reaches cannot ship.
+    private var developerSection: some View {
+        Section {
+            NavigationLink {
+                MemoryProbeView()
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: "memorychip")
+                        .font(.subheadline)
+                        .foregroundColor(DS.Palette.gold)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Memory probe")
+                            .font(.subheadline.weight(.semibold))
+                        Text("Measure what a workload costs this process")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        } header: {
+            Text("Developer")
+        } footer: {
+            Text("Debug builds only. Gates the v1.10 on-device voice work: a candidate model ships on a measured peak footprint, never a projected one.")
+        }
+    }
+    #endif
 
     private var totalEntriesCount: Int {
         let fetchRequest = DiaryEntry.fetchRequest() as NSFetchRequest<NSFetchRequestResult>

--- a/solyn/solynTests/MemoryProbeTests.swift
+++ b/solyn/solynTests/MemoryProbeTests.swift
@@ -1,0 +1,119 @@
+//
+//  MemoryProbeTests.swift
+//  solynTests
+//
+//  Checks that the memory harness measures what actually happened.
+//
+//  These run on the simulator, where absolute footprints are not
+//  device-representative — the simulator is a macOS process with a different
+//  allocator and no jetsam limit. What they establish is that the *arithmetic*
+//  is right: that a known allocation reads back as that allocation, that peak
+//  and baseline are not transposed, and that the confidence flag reports what it
+//  claims. A device run inherits correct math instead of having to establish it.
+//
+
+#if DEBUG
+
+import Testing
+import Foundation
+@testable import solyn
+
+/// Serialized deliberately. `MemoryProbe` measures the whole process, so two of
+/// these running at once each see the other's allocations as their own baseline
+/// and peak. Running them in parallel — swift-testing's default — made this
+/// suite fail non-deterministically before the trait was added, which is the
+/// same hazard as taking a model measurement while anything else in the app is
+/// busy.
+@Suite(.serialized)
+struct MemoryProbeTests {
+
+    @Test func snapshotReturnsPlausibleValues() throws {
+        let snapshot = try #require(MemoryProbe.snapshot(), "TASK_VM_INFO should be readable")
+
+        #expect(snapshot.physFootprint > 0)
+        // Any running process has a nonzero footprint but is not using the
+        // whole machine; a wild value here means the struct is misaligned and
+        // we are reading the wrong field.
+        #expect(snapshot.physFootprint < ProcessInfo.processInfo.physicalMemory)
+        #expect(snapshot.ledgerPeak >= Int64(snapshot.physFootprint))
+    }
+
+    @Test func peakNeverPrecedesBaseline() {
+        let result = MemoryProbe.measure(label: "no-op") { }
+        #expect(result.peak >= result.baseline, "peak must include the baseline it is measured from")
+        #expect(result.duration >= 0)
+    }
+
+    /// The load-bearing test. A known volume of incompressible bytes must read
+    /// back as that volume — this is the check that would have caught the
+    /// chatterbox-turbo projection before it became a decision.
+    @Test func calibrationMeasuresWhatItAllocated() {
+        let megabytes = 128
+        let (result, errorPercent) = MemoryCalibration.verify(megabytes: megabytes)
+
+        let expected = Int64(megabytes) * 1024 * 1024
+        #expect(
+            result.peakDelta > expected / 2,
+            "measured \(MemoryProbeResult.format(bytes: result.peakDelta)) for a \(megabytes) MB allocation — the harness is under-reporting by more than half"
+        )
+        #expect(
+            abs(errorPercent) < 25,
+            "calibration error \(String(format: "%.1f%%", errorPercent)) exceeds the 25% band; no model measurement from this harness would be trustworthy"
+        )
+    }
+
+    /// Incompressible input is the point: zero-filled pages compress to almost
+    /// nothing and would make every measurement look better than it is.
+    @Test func calibrationBufferDoesNotCompress() {
+        var distinctBytes = Set<UInt8>()
+        MemoryCalibration.holdingIncompressible(megabytes: 1) { buffer in
+            let bytes = buffer.assumingMemoryBound(to: UInt8.self)
+            for index in stride(from: 0, to: 1024 * 1024, by: 997) {
+                distinctBytes.insert(bytes[index])
+            }
+        }
+        // A zero-filled or trivially patterned buffer would show a handful of
+        // distinct values; noise fills the byte space.
+        #expect(distinctBytes.count > 200, "calibration buffer is patterned, so it would compress")
+    }
+
+    @Test func releasedMemoryIsNotRetained() {
+        let result = MemoryProbe.measure(label: "transient 64 MB") {
+            MemoryCalibration.holdingIncompressible(megabytes: 64) { _ in }
+        }
+        // The allocation is freed inside the workload, so almost none of it
+        // should still be charged to us afterwards. A large positive number here
+        // means the next measurement starts from a polluted baseline.
+        #expect(
+            result.retained < 32 * 1024 * 1024,
+            "retained \(MemoryProbeResult.format(bytes: result.retained)) after freeing 64 MB"
+        )
+    }
+
+    @Test func resultsRoundTripThroughJSON() throws {
+        let result = MemoryProbe.measure(label: "export") { }
+        let url = try MemoryProbeExport.write([result])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode([MemoryProbeResult].self, from: Data(contentsOf: url))
+
+        #expect(decoded.count == 1)
+        #expect(decoded.first?.label == "export")
+        #expect(decoded.first?.peak == result.peak)
+    }
+
+    @Test func confidenceIsExactWhenTheLedgerMoves() {
+        // Allocating well past anything this test process has touched should set
+        // a new lifetime high-water mark, which is the condition for an exact
+        // reading. If this ever reports sampled, the ledger comparison is wrong.
+        let (result, _) = MemoryCalibration.verify(megabytes: 256)
+        #expect(
+            result.confidence == .exact,
+            "a 256 MB allocation should move the kernel high-water mark; got \(result.confidence.rawValue)"
+        )
+    }
+}
+
+#endif


### PR DESCRIPTION
Builds the measurement that gates v1.10's "your own voice". Both candidates — Kyutai Pocket TTS (~188 MB projected synthesis path) and MOSS-TTS-Nano (~160 MB int8) — are blocked on the same thing: a **measured** iPhone peak footprint. chatterbox-turbo was projected to fit and then measured 953.7 MB against a ~250 MB ceiling, which is why this is a real instrument rather than a spreadsheet.

## What it measures

`phys_footprint` from `TASK_VM_INFO` — the figure jetsam bills a process for. Resident size is deliberately not used; it omits compressed pages and flatters every reading. Also reports the kernel's lifetime high-water mark, headroom to the jetsam limit, and the `ledger_tag_neural_footprint` breakdown a CoreML/ExecuTorch model shows up in.

## Two design points worth reviewing

**Every result carries a confidence.** The kernel high-water mark can't be reset from user space, so a workload that stays under a mark set earlier in the process's life leaves the ledger untouched. Those readings fall back to the sampler and are reported as a **lower bound**. When the ledger does move, the reading is exact and no sampling gap can hide a spike. This is the difference between a number you can gate a release on and one you can't, so it travels with the result instead of living in a footnote.

**Calibration is the point, not a nicety.** A known volume of incompressible bytes is allocated and the harness is checked against it. Incompressible matters — zero-filled pages compress to nearly nothing, so a naive calibration reports an optimistic number. If a known 250 MB doesn't read back as ~250 MB, nothing this harness says about a model is worth acting on.

Measurement runs **inside the full app** on purpose: jetsam bills the whole process, so a model measured alone in a bare harness reports a number the app can never actually achieve.

## Cannot ship

Everything is behind `#if DEBUG`. Verified rather than asserted: Release `MemoryProbe.o` carries 3 symbols, all compiler boilerplate (`__llvm_profile_runtime`, `__swift_reflection_version`), and the Release binary contains zero occurrences of `Memory probe`, `MemoryProbe`, or `Calibration`. Debug carries 707 symbols in the same object file.

## Verification

- Debug build: succeeded. Release build: succeeded.
- `MemoryProbeTests` 7/7; full `solynTests` suite 28/28.
- Tests are `.serialized` — they failed non-deterministically in parallel because this reads the *process* footprint, so a concurrent allocation is indistinguishable from the workload's own. The same hazard applies to real measurement runs and is documented at the call site.

## Not in this PR

No model is wired in yet. This lands the instrument and its self-check; plugging in Pocket TTS or MOSS-TTS-Nano is the next step, and it now has somewhere trustworthy to report into.