### PR TITLE
blog: link 1 orphaned page(s) from the index

### DIFF
--- a/solyn/website/public/blog/index.html
+++ b/solyn/website/public/blog/index.html
@@ -49,6 +49,14 @@
     </div>
 
     <div class="blog-list">
+      <a href="/blog/personal-digital-twin" class="blog-list-item">
+          <div class="blog-list-meta">
+            <span class="blog-tag tag-guide">Guide</span>
+            <span class="blog-date">August 7, 2026</span>
+          </div>
+          <h2>Building a Personal Digital Twin on iPhone</h2>
+          <p>A personal digital twin is a local software model of your emotional and behavioral patterns built from daily thoughts.</p>
+        </a>
       <a href="/blog/foundation-models-gate" class="blog-list-item">
         <div class="blog-list-meta">
           <span class="blog-tag tag-guide">Engineering</span>


### PR DESCRIPTION
These pages are live and in the sitemap, but no index page links to them, so a
reader browsing /blog cannot reach them:

- [/blog/personal-digital-twin](https://getdailyvox.com/blog/personal-digital-twin) — Building a Personal Digital Twin on iPhone

Found by `autoseo relink`, which compares the rendered pages under `public/blog/` against the links
on all seven index pages. Pagination is not rebalanced — page one gains the entries.