### PR TITLE
feat(twin): wire the entity graph to real entries

### DIFF
--- a/solyn/solyn/EntryDetailView.swift
+++ b/solyn/solyn/EntryDetailView.swift
@@ -670,14 +670,16 @@ struct EntryDetailView: View {
                             newText: trimmed,
                             mood: selectedMood.rawValue,
                             date: entry.date ?? Date(),
-                            duration: entry.duration
+                            duration: entry.duration,
+                            entryId: entry.id?.uuidString
                         )
                     } else {
                         DigitalTwinEngine.shared.processEntry(
                             text: trimmed,
                             mood: selectedMood.rawValue,
                             date: entry.date ?? Date(),
-                            duration: entry.duration
+                            duration: entry.duration,
+                            entryId: entry.id?.uuidString
                         )
                     }
                     // v1.6: keep the semantic memory index in step with edits.

--- a/solyn/solyn/OnboardingView.swift
+++ b/solyn/solyn/OnboardingView.swift
@@ -106,7 +106,7 @@ struct OnboardingView: View {
         do {
             try viewContext.save()
             UserDefaults.standard.set(true, forKey: "hasCompletedFirstEntry")
-            DigitalTwinEngine.shared.processEntry(text: text, mood: nil, date: now, duration: entry.duration)
+            DigitalTwinEngine.shared.processEntry(text: text, mood: nil, date: now, duration: entry.duration, entryId: e.id?.uuidString)
             WidgetCenter.shared.reloadAllTimelines()
         } catch {
             // Non-fatal: onboarding still completes; worst case the star isn't pre-seeded.

--- a/solyn/solyn/ScreenshotDataSeeder.swift
+++ b/solyn/solyn/ScreenshotDataSeeder.swift
@@ -183,9 +183,15 @@ struct ScreenshotDataSeeder {
             ),
         ]
 
+        // Keep the generated ids so the Twin fold below can attach each entry's
+        // entities to the SAME row the timeline shows — otherwise the seeded
+        // graph is anchored to entries that, as far as the index knows, do not exist.
+        var seededIds: [UUID] = []
         for entry in entries {
             let diaryEntry = DiaryEntry(context: context)
-            diaryEntry.id = UUID()
+            let id = UUID()
+            diaryEntry.id = id
+            seededIds.append(id)
             let entryDate = calendar.date(byAdding: .day, value: -entry.daysAgo, to: now)!
             // Set time to a reasonable hour (8am-9pm range)
             let hour = 8 + (entry.daysAgo * 3) % 14
@@ -208,13 +214,14 @@ struct ScreenshotDataSeeder {
         }
 
         // Process entries through DigitalTwinEngine so Twin tab populates
-        for entry in entries {
+        for (entry, id) in zip(entries, seededIds) {
             let entryDate = calendar.date(byAdding: .day, value: -entry.daysAgo, to: now)!
             DigitalTwinEngine.shared.processEntry(
                 text: entry.text,
                 mood: entry.mood,
                 date: entryDate,
-                duration: entry.duration
+                duration: entry.duration,
+                entryId: id.uuidString
             )
         }
 

--- a/solyn/solyn/SettingsView.swift
+++ b/solyn/solyn/SettingsView.swift
@@ -1057,8 +1057,15 @@ struct SettingsView: View {
     private func deleteAllData() {
         let fetch: NSFetchRequest<DiaryEntry> = DiaryEntry.fetchRequest()
         if let all = try? viewContext.fetch(fetch) {
+            let deletedIds = all.compactMap { $0.id }
             for entry in all { viewContext.delete(entry) }
             try? viewContext.save()
+            // "Delete all data" has to mean the derived indexes too, or search
+            // and the entity graph keep answering from entries that are gone.
+            for id in deletedIds {
+                SemanticSearchManager.shared.removeEntry(id: id)
+                DigitalTwinEngine.shared.forgetEntry(id.uuidString)
+            }
         }
         Self.clearDirectory(name: "Recordings")
         Self.clearDirectory(name: "Photos")

--- a/solyn/solyn/TimelineView.swift
+++ b/solyn/solyn/TimelineView.swift
@@ -567,12 +567,23 @@ struct TimelineView: View {
     }
 
     private func delete(entries: [DiaryEntry], at offsets: IndexSet) {
+        // Capture the ids BEFORE deleting — a deleted managed object's `id` is
+        // gone, and both derived indexes are keyed by it.
+        var deletedIds: [UUID] = []
         for index in offsets {
             let entry = entries[index]
+            if let id = entry.id { deletedIds.append(id) }
             viewContext.delete(entry)
         }
         do {
             try viewContext.save()
+            // Detach from the derived indexes only after the delete actually
+            // committed. Without this an entry the user deleted stays searchable
+            // and keeps its entities attached to a row that no longer exists.
+            for id in deletedIds {
+                SemanticSearchManager.shared.removeEntry(id: id)
+                DigitalTwinEngine.shared.forgetEntry(id.uuidString)
+            }
             HapticManager.shared.entryDeleted()
             WidgetCenter.shared.reloadAllTimelines()
         } catch {

--- a/solyn/solyn/TodayView.swift
+++ b/solyn/solyn/TodayView.swift
@@ -989,7 +989,8 @@ struct TodayView: View {
                             text: textSegment,
                             mood: entry.mood,
                             date: entry.date ?? Date(),
-                            duration: entry.duration
+                            duration: entry.duration,
+                            entryId: entry.id?.uuidString
                         )
 
                         // Fire the "a new star appeared" Live Activity and

--- a/solyn/solyn/solynApp.swift
+++ b/solyn/solyn/solynApp.swift
@@ -37,6 +37,13 @@ struct DailyVoxApp: App {
         // JSON file, never the CloudKit-synced store above.
         DigitalTwinEngine.configureBodyTwinStore(FileBodyTwinStateStore())
 
+        // The entity→entry mention index is per-entry data and must NEVER go in
+        // the CloudKit-synced `digital_twin` blob (~1 MB at diary scale). Same
+        // device-local, rebuildable-from-entries store the semantic index uses.
+        // Injected BEFORE the seeder below, or seeded entries fold into the
+        // throwaway in-memory default and the index starts empty.
+        DigitalTwinEngine.configureEntityGraphStore(LocalFileTwinStateStore(subfolder: "EntityGraph"))
+
         ScreenshotDataSeeder.seedIfNeeded(context: persistenceController.container.viewContext)
     }
 


### PR DESCRIPTION
The engine's entity→entry mention index shipped **write-only**. Every `processEntry` call site passed no entry id, so `EntityMentionIndex` stayed empty and `graphRetrieval()` had nothing to traverse. Personalized PageRank over an empty graph is still an empty graph.

This is the app half of DailyVoxTwin#35.

## Six sites, not four

`processEntry` greps for four. The fifth is **`reprocessEditedEntry`**, which also takes `entryId` and is the edit path — without it an edited entry silently detaches from the graph it was already in. The sixth is the seeder, which had to keep its generated ids to fold them.

## Two orderings are load-bearing

- `configureEntityGraphStore` runs **before** `ScreenshotDataSeeder.seedIfNeeded`. Otherwise seeded entries fold into the throwaway in-memory default and the index is empty on the exact build we take App Store screenshots with.
- Both delete paths capture ids **before** `viewContext.delete`. A deleted managed object's `id` is nil, so capturing after would forget nothing — silently.

## Store choice

`LocalFileTwinStateStore(subfolder: "EntityGraph")`, not the CloudKit-synced twin blob. This is per-entry data (0.71 MB per 1,000 entries, measured in `EntityGraphScaleTests`) and belongs on device, rebuildable from entries, exactly like the semantic index.

## Drive-by fix

`SemanticSearchManager.removeEntry(id:)` gets its first callers. It has shipped with none, so entries deleted in the app stayed in the semantic index forever and could still be returned by search.

## Verification

Read the simulator container rather than trusting the build (iPhone 16 Pro, `-ScreenshotMode`):

| | |
|---|---|
| mentions persisted | 186 |
| distinct entities | 142 |
| distinct entries | 35 |
| **graph ids matching a real Core Data row** | **35 / 35** |
| orphan graph ids | 0 |

`sarah` resolves to 6 entries — the design doc's worked example, now answerable.

## Not covered

- Delete paths compile but are **not runtime-tested** (needs a swipe-to-delete on device).
- `deleteAllData` loops `forgetEntry`, and each call rewrites the whole payload — O(n²) at scale. A bulk `removeAll()` on `EntityMentionIndex` is the engine-side fix.
- No retrieval behaviour changes. Nothing reads the graph yet, and no fusion weight is chosen — that waits on the eval.