### PR TITLE
chore: Phase 0 guardrails ahead of the Android port

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,9 +8,26 @@
 # allowed on purpose, so the in-tree legacy engine can be migrated out.
 #
 # Enable once with:  git config core.hooksPath .githooks
+#
+# LANGUAGE-AGNOSTIC SINCE 2026-08-14. It previously matched `\.swift` only,
+# which was correct while the engine existed in exactly one language. With a
+# Kotlin engine coming, `DigitalTwinEngine.kt` would have committed clean into
+# an MIT-licensed public repository — and a licence leak is not recoverable
+# once pushed, because the object stays in every clone's history. The guard now
+# keys on the engine's FILE STEMS and accepts any source extension.
+#
+# Note on `android/engine/`: a thin Kotlin ADAPTER in the public app repo is
+# fine and expected. What must never land here is the engine implementation
+# itself, which is what these stems name.
 
-# Proprietary engine files that must not live in dailyvox (basenames / paths).
-BLOCKED='DigitalTwinEngine\.swift|LocalAIEngine\.swift|InsightsEngine\.swift|TwinPredictions\.swift|NLPipeline\.swift|TwinPersistence\.swift|/BodyTwin/|HealthKitService\.swift|ActivityContextDetector\.swift'
+# Engine stems, matched against any source extension below.
+#   `Mood` is deliberately ABSENT: solyn/solyn/Mood.swift is a legitimate app
+#   file that collides by name with the engine's own, and blocking it would
+#   wedge ordinary app work. Verified 2026-08-14 as the only such collision.
+STEMS='DigitalTwinEngine|EntityGraph|EntrySentiment|InsightsEngine|LocalAIEngine|NLPipeline|ProsodyFeatures|SemanticMemory|TraitHead|TwinChat|TwinEntryInput|TwinPersistence|TwinPredictions|TwinStateStore|HealthKitService|ActivityContextDetector'
+EXTS='swift|kt|kts|java'
+
+BLOCKED="(${STEMS})\.(${EXTS})$|/BodyTwin/"
 
 # Staged Added/Modified files only (Deletions pass through).
 offenders=$(git diff --cached --name-status --diff-filter=AM | awk '{print $2}' | grep -E "$BLOCKED")

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,8 +24,9 @@ What actually happened.
 If applicable, add screenshots or recordings to help explain the issue.
 
 **Device info**
-- Device: [e.g. iPhone 15 Pro]
-- iOS version: [e.g. 18.2]
+- Platform: [iOS / Android]
+- Device: [e.g. iPhone 15 Pro, Pixel 8]
+- OS version: [e.g. iOS 18.2, Android 15]
 - App version: [e.g. 1.3]
 
 **Additional context**

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -81,3 +81,18 @@
 - name: "v2.0"
   color: "5319e7"
   description: Foundation Models integration
+
+# Platform routing (added 2026-08-14). With two apps in one repo, an issue with
+# no platform label is unroutable — "voice recording is broken" means different
+# code, different reviewer and different release train depending on the answer.
+- name: "platform:ios"
+  color: "1d76db"
+  description: iOS app only
+
+- name: "platform:android"
+  color: "3ddc84"
+  description: Android app only
+
+- name: "platform:shared"
+  color: "5319e7"
+  description: Website, docs, engine contract, or anything affecting both apps

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,14 +1,23 @@
-name: Build & Test
+name: Build & Test (iOS)
 
+# Path filter excludes the website. It lives under solyn/ today purely for
+# historical reasons (it is 1,770 files, 90% of the repo, and belongs to neither
+# platform), so every blog and SEO commit was firing a full macos-15 Xcode
+# build+test for a directory containing no Swift. The negation drops that.
+#
+# When the website moves to repo-root website/ and solyn/ becomes ios/, the two
+# 'solyn/**' lines below become 'ios/**' and the negations can be deleted.
 on:
   pull_request:
     branches: [main]
     paths:
       - 'solyn/**'
+      - '!solyn/website/**'
   push:
     branches: [main]
     paths:
       - 'solyn/**'
+      - '!solyn/website/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,19 @@ relay/
 # private DailyVoxTwin package, e.g. `.wt-retrieval/`). These are thousands of
 # files belonging to another repository and must never be committed here.
 .wt-*/
+
+# ── Android (added 2026-08-14, ahead of the port) ──────────────────────────
+# Signing keys FIRST, because this is the entry that cannot be added late: a
+# keystore pushed to a public MIT repo is compromised permanently, and rotating
+# an app-signing key on Play is not a thing you get to do casually.
+*.jks
+*.keystore
+android/keystore.properties
+android/local.properties
+
+# Gradle build output and caches — the Android analogue of DerivedData.
+android/.gradle/
+android/build/
+android/**/build/
+.gradle/
+local.properties


### PR DESCRIPTION
Zero-risk groundwork from `docs/android/01-port-plan.md` (engine repo). **Nothing here touches a build**, and every item is safe regardless of how the remaining port decisions land.

## The one that matters: the engine guard was language-blind

`.githooks/pre-commit` keeps the proprietary engine out of this MIT-licensed public repo. It matched `\.swift` only — correct while the engine existed in one language. With a Kotlin engine coming, **`DigitalTwinEngine.kt` would have committed clean**, and a licence leak is not recoverable once pushed: the object stays in every clone's history.

Now keyed on engine file *stems* across `swift|kt|kts|java`.

`Mood` is deliberately excluded from the stem list. `solyn/solyn/Mood.swift` is a legitimate app file that collides by name with the engine's own — the only such collision across all 13 engine files — and blocking it would wedge ordinary app work.

Verified by running the hook against staged fixtures rather than by reading it:

| case | expected | result |
|---|---|---|
| `DigitalTwinEngine.kt` | blocked | exit 1 |
| `LocalAIEngine.swift` | blocked | exit 1 |
| `solyn/solyn/Mood.swift` | allowed | exit 0 |

## Signing keys, before they can exist

`.gitignore` gains `*.jks`, `*.keystore`, `local.properties` and Gradle output. The keystore lines are the point: a signing key pushed to a public repo is compromised permanently, and Play app-signing keys are not casually rotated.

## CI: stop building Xcode for blog posts

`build.yml` path-filtered on `solyn/**`, and the website lives inside `solyn/` — 1,770 files, 90% of the repo, belonging to neither platform. Every SEO commit fired a full `macos-15` Xcode build and test over a directory containing no Swift.

Renamed to `ios.yml` with `!solyn/website/**` negated out.

Checked first that **`main` carries no branch protection**, so renaming the workflow cannot orphan a required status check — that was the flagged risk and it does not apply here. `android.yml` lands with the `android/` skeleton; an empty workflow that can never trigger is clutter.

## Routing

`platform:ios` / `platform:android` / `platform:shared` labels, and the bug template asks for the platform instead of assuming iPhone. With two apps in one repo, an unlabelled issue is unroutable.

## Not included

- **Tracking the website generators.** The plan calls for it so website fixes are reproducible, but they are SEO page-generation machinery plus 264 KB of keyword data, and this repo is public. Recommend tracking them privately instead — flagged for a decision, not done silently.
- **`android.yml`**, until there is an `android/` to build.