### PR TITLE
seo: stop advertising a report that was never published

### DIFF
--- a/solyn/website/public/sitemap-core.xml
+++ b/solyn/website/public/sitemap-core.xml
@@ -13,7 +13,6 @@
   <url><loc>https://getdailyvox.com/privacy</loc><lastmod>2026-07-17</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://getdailyvox.com/support</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://getdailyvox.com/research</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://getdailyvox.com/reports/journal-app-privacy-audit-2026</loc><lastmod>2026-05-06</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://getdailyvox.com/facts</loc><lastmod>2026-07-04</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://getdailyvox.com/changelog</loc><lastmod>2026-07-31</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://getdailyvox.com/demo</loc><lastmod>2026-06-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>


### PR DESCRIPTION
Found while verifying the site's internal linking is intact ahead of the repo restructure. **This is a live bug, unrelated to Android.**

## The sitemap advertises a 404

`sitemap-core.xml` listed `/reports/journal-app-privacy-audit-2026` at **priority 0.8** with a `2026-05-06` lastmod. There is no `reports/` directory on the site.

We have been telling Google to crawl a 404 for three months. That's the one kind of broken link that actually costs something — an unlinked 404 is invisible to search, a sitemap-advertised one is a quality signal against the whole domain.

Removed. Sitemap XML re-validated after the edit.

## How it was found

A full internal-link crawl of the deployed tree, honouring the deployment contract from `vercel.json` — `cleanUrls`, `trailingSlash: false`, and the 16 redirect sources, so a link to a redirect source is correctly not counted as broken.

| | |
|---|---|
| Pages crawled | 1,728 |
| Served URLs | 3,495 |
| Broken internal link targets | **4** (all under `/reports/`) |
| Sitemap URLs pointing at missing files | **1** (this one) |

## Not fixed here — your call

**Eight pages still link to that report in prose**: `facts.html`, `press.html`, `research/index.html`, and five blog posts. Two more link to `/reports/state-of-on-device-ai-journaling-2026`, which also doesn't exist.

Those links promise readers something that isn't there. Either publish the reports or remove the promise — both are edits to marketing copy, so I've left them alone rather than deciding for you.

## Also checked, and fine

**1,563 pages have no inbound link and aren't in a sitemap.** That looks alarming and isn't: I sampled 200 and **197 carry `noindex`**. That's the June doorway-page prune working exactly as intended. No action needed.