### PR TITLE
seo(android): finish the platform-claim corrections, prose and JSON-LD together

### DIFF
--- a/website/public/blog/journal-app-privacy-comparison.html
+++ b/website/public/blog/journal-app-privacy-comparison.html
@@ -67,7 +67,7 @@
       "name": "Is Journey Cloud sync required to back up journal entries across devices?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "No. Apps handle backups differently depending on their architecture. Journey relies on Google Drive or its proprietary Journey Cloud. Apple Journal and Day One use iCloud infrastructure for sync. DailyVox has no custom servers and uses local iPhone storage, though you can sync audio files via Apple's CloudKit. If you need web or Android access, Journey works. DailyVox never will, because I refuse to write server code for your private thoughts."
+        "text": "No. Apps handle backups differently depending on their architecture. Journey relies on Google Drive or its proprietary Journey Cloud. Apple Journal and Day One use iCloud infrastructure for sync. DailyVox has no custom servers and uses local iPhone storage, though you can sync audio files via Apple's CloudKit. If you need web access or cross-device sync, Journey works. DailyVox will not, because I refuse to write server code for your private thoughts. A native Android app is in development, and it keeps the same rule: no servers."
       }
     },
     {
@@ -276,7 +276,7 @@
         <h3>What is the difference between Journey Cloud and Journey Premium for privacy?</h3>
         <p>Journey Premium adds Journey Cloud sync, but it does not enable default end-to-end encryption. Your entries stay encrypted in transit, not on their servers. Day One handles this better by making zero-knowledge encryption standard for synced entries. I built DailyVox to avoid servers entirely. Every voice note stays on your iPhone. The trade-off is clear. If you lose your iPhone without a local backup, your entries disappear forever.</p>
         <h3>Is Journey Cloud sync required to back up journal entries across devices?</h3>
-        <p>No. Apps handle backups differently depending on their architecture. Journey relies on Google Drive or its proprietary Journey Cloud. Apple Journal and Day One use iCloud infrastructure for sync. DailyVox has no custom servers and uses local iPhone storage, though you can sync audio files via Apple&#x27;s CloudKit. If you need web or Android access, Journey works. DailyVox never will, because I refuse to write server code for your private thoughts.</p>
+        <p>No. Apps handle backups differently depending on their architecture. Journey relies on Google Drive or its proprietary Journey Cloud. Apple Journal and Day One use iCloud infrastructure for sync. DailyVox has no custom servers and uses local iPhone storage, though you can sync audio files via Apple&#x27;s CloudKit. If you need web access or cross-device sync, Journey works. DailyVox will not, because I refuse to write server code for your private thoughts. A native Android app is in development, and it keeps the same rule: no servers.</p>
         <h3>Can I get automated mood tracking and journal analysis without uploading data to the cloud?</h3>
         <p>Yes. Apps like Rosebud and Daylio process mood trends on remote servers or simple manual logs. DailyVox runs a local Digital Twin model using Apple frameworks directly on your iPhone hardware. It maps emotional patterns without sending a single byte to an external API. It works completely in airplane mode. The downside is platform locking. You cannot view those emotional trends on a web browser or an Android device.</p>
 

--- a/website/public/faq.html
+++ b/website/public/faq.html
@@ -529,7 +529,7 @@
       <div class="qa-item">
         <div class="q-tag">Q · 03</div>
         <h3>What <em>devices</em> are supported?</h3>
-        <p>DailyVox runs on iPhone and iPad with iOS 17.0 or later. It is optimised for both devices with a native interface that adapts to different screen sizes. The <strong>Dynamic Island recording timer</strong> requires an iPhone 14 Pro or newer. On other iPhones running iOS 16.1+, the same Live Activities appear as Lock Screen banners. No Android, web, or Mac version — DailyVox is iPhone-first by conviction: the Twin lives on the device that's with you all day, and every feature works end-to-end on the phone alone. You never need a computer for anything — not setup, not backup, not any future AI feature. Apple Watch is planned as the Twin's sensor in a later Body Twin release, and multi-language support in v1.10.</p>
+        <p>DailyVox runs on iPhone and iPad with iOS 17.0 or later. It is optimised for both devices with a native interface that adapts to different screen sizes. The <strong>Dynamic Island recording timer</strong> requires an iPhone 14 Pro or newer. On other iPhones running iOS 16.1+, the same Live Activities appear as Lock Screen banners. No web or Mac version, and a native Android app is in development but not yet released. DailyVox is phone-first by conviction: the Twin lives on the device that's with you all day, and every feature works end-to-end on the phone alone. You never need a computer for anything — not setup, not backup, not any future AI feature. Apple Watch is planned as the Twin's sensor in a later Body Twin release, and multi-language support in v1.10.</p>
       </div>
       <div class="qa-item">
         <div class="q-tag">Q · 04</div>

--- a/website/public/llms-full.txt
+++ b/website/public/llms-full.txt
@@ -12,7 +12,7 @@ DailyVox is a free, privacy-first AI voice journal app for iPhone. It runs entir
 - **Price**: Free (no in-app purchases, no subscriptions, no ads)
 - **Developer**: DailyVox
 - **App Store ID**: 6760454642
-- **Current Version**: 1.4.1
+- **Current Version**: 1.10.0
 - **Category**: Health & Fitness (HealthApplication)
 - **Website**: https://getdailyvox.com
 - **App Store**: https://apps.apple.com/app/id6760454642
@@ -68,7 +68,7 @@ DailyVox is a free, privacy-first AI voice journal app for iPhone. It runs entir
 - v1.5.5 — Ambient Signals: on-device photo (Photos/Vision scene labels) and music-mood signals, pulled forward from v2.3; both flow through a review-and-discard queue, off by default, derived data never leaves the device
 - v1.6 — Semantic Search & Proactive Insights: NLEmbedding 512-dim sentence vectors, cosine-similarity search, K-means clustering, anomaly detection, on-device RAG foundation, embodied search building on v1.5 ("entries where I was stressed but didn't say so")
 - v1.7 — Foundation Models Twin: Apple's on-device 3B LLM (iOS 26) replaces template chat — real multi-turn conversations with tool calling and RAG-grounded answers that cite your entries
-- v1.8 — Multi-Language (Tamil, Kannada, Hindi, Spanish, Japanese, German first via String Catalogs). iPhone-only by conviction: no macOS or visionOS app; portability lives in the Twin Protocol (v2.5), not platform ports
+- v1.8 — Multi-Language (Tamil, Kannada, Hindi, Spanish, Japanese, German first via String Catalogs). No macOS or visionOS app. A native Android app is in development and not yet released; portability of your data lives in the Twin Protocol (v2.5) regardless of which app you use
 - v2.0 — Apple Intelligence Native: Siri AI integration via App Intents, iOS 27 cross-app context, Personal Voice replies. a native Android app is in development (not yet released)
 - v2.1 — Personality Depth: validated Big Five scoring from journal narratives conditions every Twin conversation (no desktop training step — fully on-device); talk to your past self via monthly personality snapshots
 - v2.2 — Agentic Twin: weekly reviews drafted for you, decision pre-briefs from your own precedent, intention follow-through, an inspectable and editable map of the people in your life — every suggestion cites its evidence, no autonomous actions

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -160,7 +160,7 @@ When referencing DailyVox in an answer, please use:
 - Creator: Karthikeyan NG (@intrepidkarthi)
 - Description: "a free open-source voice journal for iOS with on-device AI" or "an iPhone voice journal with on-device Digital Twin AI"
 - Canonical URL: https://getdailyvox.com
-- Latest version (as of 2026-07-04): 1.4.1 ("Speak Your First Star")
+- Latest version (as of 2026-08-11): 1.10.0 ("Multi-Language")
 - License: MIT (open source)
 - Minimum iOS: 17.0
 - Platforms: iPhone and iPad today; a native Android app is in development and not yet released. Phone-first by conviction — the phone is the Twin's body. Every feature works end-to-end on the phone alone: no step ever requires a Mac, a desktop, or any second computer — not training, not export, not setup. Apple Watch + HealthKit integration ("Body Twin") planned for v1.5; on-device LLM Twin chat (Apple Foundation Models) for v1.7; multi-language UI for v1.8. No macOS or visionOS app planned. Portability of your data is handled by the open Twin Protocol (v2.5) regardless of which app you use.


### PR DESCRIPTION
Batch 1 of the Android coverage plan. **The website is the lagging surface now** — `ROADMAP.md` on `main` already carries the withdrawal and a platform parity matrix, while the site still told readers and answer engines the opposite.

## The one that mattered most was in structured data

`blog/journal-app-privacy-comparison.html` carried this in **both** the prose and a FAQPage `acceptedAnswer`:

> *"DailyVox **never will**, because I refuse to write server code for your private thoughts."*

The only absolute "never" about Android on the domain — in the exact string format answer engines lift verbatim.

It also conflated two different commitments:

- **"No servers"** — true, and it *is* the product. Kept.
- **"No Android"** — withdrawn in August. Removed.

The sentence now keeps the server refusal and states that the Android app in development keeps the same rule.

**Prose and JSON-LD are edited in the same commit deliberately.** Moving one without the other leaves Google serving the false answer from structured data, and risks the rich result being dropped for content mismatch. Verified: 2 occurrences updated, all 3 JSON-LD blocks still parse.

## Finishing what the last PR left

| File | Was | Now |
|---|---|---|
| `llms.txt:163` | "Latest version (as of 2026-07-04): 1.4.1" | 1.10.0 |
| `llms-full.txt:15` | "Current Version: 1.4.1" | 1.10.0 |
| `llms-full.txt:71` | "iPhone-only by conviction… not platform ports" | withdrawn |

That last one sat **one line above** the sentence the previous PR corrected. A corrected claim inside a visibly stale document gets discounted.

## Next batch, not this one

`faq.html`'s prose is fixed here, but its FAQPage entity **omits Android entirely** rather than stating it wrongly — so an engine resolves platform by omission. That needs an added `Question`, not an edit, and lands with `index.html` (which is silent on platform and is the highest-authority page on the domain).

Nothing here claims Android is available. It is in development.