### PR TITLE
seo(android): index FAQ, technology reversal, and the last templated claims

### DIFF
--- a/website/public/blog/dailyvox-vs-bear.html
+++ b/website/public/blog/dailyvox-vs-bear.html
@@ -124,7 +124,7 @@
 
         <p><strong>Bear:</strong> iOS, iPadOS, macOS. Sync between all three with Bear Pro.</p>
 
-        <p><strong>DailyVox:</strong> iOS and iPadOS, by design — iPhone-first, with Apple Watch planned for v1.5 as the Twin's sensor. Android is deferred until the iOS app has proven itself.</p>
+        <p><strong>DailyVox:</strong> iOS and iPadOS, by design — iPhone-first, with Apple Watch planned for v1.5 as the Twin's sensor. A native Android app is in development and not yet released.</p>
 
         <p><strong>Bottom line:</strong> Bear wins right now on platform coverage. DailyVox is catching up but iOS-only at the moment.</p>
 

--- a/website/public/blog/dailyvox-vs-mem.html
+++ b/website/public/blog/dailyvox-vs-mem.html
@@ -120,7 +120,7 @@
 
         <p><strong>Mem.ai:</strong> Web, iOS, macOS, Android (varies by Glean's roadmap).</p>
 
-        <p><strong>DailyVox:</strong> iOS and iPadOS, by design — iPhone-first, with Apple Watch arriving in v1.5 as the Twin's sensor. Android is deferred until the iOS app has proven itself.</p>
+        <p><strong>DailyVox:</strong> iOS and iPadOS, by design — iPhone-first, with Apple Watch arriving in v1.5 as the Twin's sensor. A native Android app is in development and not yet released.</p>
 
         <h2>Who Should Choose What</h2>
 

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -50,16 +50,68 @@
   <!-- FAQPage schema mirroring the six visible Q&A in the FAQ section below. The homepage is the
        highest-authority page on the domain and was the only major page without this, while 66
        lesser pages already carry it. FAQPage maps directly onto how answer engines quote. -->
-  <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
-    {"@type":"Question","name":"Is DailyVox really free?","acceptedAnswer":{"@type":"Answer","text":"Yes. Every feature, forever. No paywall, no premium tier, no free trial. DailyVox is free and open-source."}},
-    {"@type":"Question","name":"Do I need to create an account to use DailyVox?","acceptedAnswer":{"@type":"Answer","text":"No. No signup, no email, no password. Install and start talking. Your data lives on your device, not on our servers — because we don't have servers."}},
-    {"@type":"Question","name":"What happens to my voice recordings?","acceptedAnswer":{"@type":"Answer","text":"They're transcribed by Apple's speech engine, on your phone. The audio is stored locally. Nothing is uploaded, ever. Run a network proxy during a recording and see for yourself — zero bytes leave the device."}},
-    {"@type":"Question","name":"How is DailyVox different from Day One or Apple Journal?","acceptedAnswer":{"@type":"Answer","text":"DailyVox is voice-first with an on-device AI that builds a Digital Twin of your personality. Day One is cloud-based and text-focused. Apple Journal has no AI. Neither has a Twin that learns who you are."}},
-    {"@type":"Question","name":"What if I miss a day of journaling?","acceptedAnswer":{"@type":"Answer","text":"Nothing happens. No streaks broken, no guilt trips. Your Twin is patient — it picks up right where you left off."}},
-    {"@type":"Question","name":"Can I export my journal data?","acceptedAnswer":{"@type":"Answer","text":"Yes. PDF, JSON, Markdown, CSV, or AES-256 encrypted backups. Your data is yours — always portable, never locked in."}}
-  ]}
-  </script>
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is DailyVox really free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Every feature, forever. No paywall, no premium tier, no free trial. DailyVox is free and open-source."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to create an account to use DailyVox?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. No signup, no email, no password. Install and start talking. Your data lives on your device, not on our servers — because we don't have servers."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What happens to my voice recordings?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "They're transcribed by Apple's speech engine, on your phone. The audio is stored locally. Nothing is uploaded, ever. Run a network proxy during a recording and see for yourself — zero bytes leave the device."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How is DailyVox different from Day One or Apple Journal?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "DailyVox is voice-first with an on-device AI that builds a Digital Twin of your personality. Day One is cloud-based and text-focused. Apple Journal has no AI. Neither has a Twin that learns who you are."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is DailyVox available on Android?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Not yet. A native Android app is in development and has not been released. DailyVox shipped on iPhone first because Apple provides speech recognition, language analysis and on-device embeddings as free system services; Android does not, so each had to be built and measured before it could ship. The Android release will be announced here when it is ready — no date promised."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What if I miss a day of journaling?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nothing happens. No streaks broken, no guilt trips. Your Twin is patient — it picks up right where you left off."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I export my journal data?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. PDF, JSON, Markdown, CSV, or AES-256 encrypted backups. Your data is yours — always portable, never locked in."
+      }
+    }
+  ]
+}</script>
 
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"SoftwareApplication","name":"DailyVox","description":"Free on-device AI voice journal with a Digital Twin personality model. Ask Your Twin, mood predictions, shareable personality cards — all on your iPhone, zero cloud.","url":"https://getdailyvox.com","applicationCategory":"HealthApplication","operatingSystem":"iOS 17.0+","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"author":{"@type":"Organization","name":"DailyVox","url":"https://getdailyvox.com","sameAs":["https://github.com/intrepidkarthi/dailyvox","https://apps.apple.com/app/id6760454642"]},"downloadUrl":"https://apps.apple.com/app/id6760454642","softwareVersion":"1.10.0","datePublished":"2026-03-01","sameAs":["https://github.com/intrepidkarthi/dailyvox","https://apps.apple.com/app/id6760454642"]}
@@ -1229,6 +1281,7 @@ footer .wordmark{ display:inline-flex; align-items:center; gap:9px; }
       <details><summary>Do I need to create an account?</summary><p>No. No signup, no email, no password. Install and start talking. Your data lives on your device, not on our servers — because we don't have servers.</p></details>
       <details><summary>What happens to my voice recordings?</summary><p>They're transcribed by Apple's speech engine, on your phone. The audio is stored locally. Nothing is uploaded, ever. Run a network proxy during a recording and see for yourself — zero bytes leave the device.</p></details>
       <details><summary>How is this different from Day One or Apple Journal?</summary><p>DailyVox is voice-first with an on-device AI that builds a Digital Twin of your personality. Day One is cloud-based and text-focused. Apple Journal has no AI. Neither has a Twin that learns who you are.</p></details>
+      <details><summary>Is DailyVox available on Android?</summary><p>Not yet. A native Android app is in development and has not been released. DailyVox shipped on iPhone first because Apple provides speech recognition, language analysis and on-device embeddings as free system services; Android does not, so each had to be built and measured before it could ship. The Android release will be announced here when it is ready — no date promised.</p></details>
       <details><summary>What if I miss a day?</summary><p>Nothing happens. No streaks broken, no guilt trips. Your Twin is patient — it picks up right where you left off.</p></details>
       <details><summary>Can I export my data?</summary><p>Yes. PDF, JSON, Markdown, CSV, or AES-256 encrypted backups. Your data is yours — always portable, never locked in.</p></details>
     </div>

--- a/website/public/personal-digital-twin.html
+++ b/website/public/personal-digital-twin.html
@@ -82,7 +82,7 @@
   </script>
 
   <script type="application/ld+json">
-  { "@context":"https://schema.org","@type":"SoftwareApplication","name":"DailyVox","description":"Free on-device AI voice journal that builds a personal digital twin — a private personality model of you from your journal entries. iPhone-only, zero cloud.","applicationCategory":"HealthApplication","operatingSystem":"iOS 17.0+","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"downloadUrl":"https://apps.apple.com/app/id6760454642","author":{"@type":"Organization","name":"DailyVox","url":"https://getdailyvox.com"} }
+  { "@context":"https://schema.org","@type":"SoftwareApplication","name":"DailyVox","description":"Free on-device AI voice journal that builds a personal digital twin — a private personality model of you from your journal entries. iPhone and iPad, zero cloud.","applicationCategory":"HealthApplication","operatingSystem":"iOS 17.0+","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"downloadUrl":"https://apps.apple.com/app/id6760454642","author":{"@type":"Organization","name":"DailyVox","url":"https://getdailyvox.com"} }
   </script>
 
   <style>

--- a/website/public/technology.html
+++ b/website/public/technology.html
@@ -1489,8 +1489,8 @@
             <div class="rd-body">
               <div class="rd-tag rd-done"><span class="rd-tag-text">Shipped · v1.10.0</span></div>
               <h3>The Twin speaks your language</h3>
-              <p>The interface ships in Spanish, French, German and Italian, chosen because every feature works fully in them — search by meaning relies on on-device sentence embeddings Apple provides for a limited set of languages. Recording already worked in every language the iPhone can transcribe; this release changed the interface. iPhone-only by conviction: no macOS or visionOS targets. Depth on one platform, breadth in languages.</p>
-              <div class="rd-tags"><span>String Catalogs</span><span>60+ Languages</span><span>iPhone-only</span></div>
+              <p>The interface ships in Spanish, French, German and Italian, chosen because every feature works fully in them — search by meaning relies on on-device sentence embeddings Apple provides for a limited set of languages. Recording already worked in every language the iPhone can transcribe; this release changed the interface. Shipped under an iPhone-only commitment: no macOS or visionOS targets, depth on one platform and breadth in languages. The macOS and visionOS half still holds. The Android half was withdrawn in August 2026 — the cost argument behind it assumed Android needed its own name, sentiment and embedding models, and measurement removed all three.</p>
+              <div class="rd-tags"><span>String Catalogs</span><span>60+ Languages</span><span>iOS · Android in development</span></div>
             </div>
           </div>
           <div class="rd-item">


### PR DESCRIPTION
Batch 2 of the coverage plan. Batch 1 is PR #87.

## `index.html` was silent on platform — and silence isn't neutral

`operatingSystem` reads `iOS 17.0+`, `downloadUrl` is App Store only, and no platform question existed. An answer engine resolves that as **"iOS only, none planned"** by omission — on the highest-authority page on the domain.

Adds a 7th FAQPage `Question` **and its visible `<details>` twin in the same edit**, because the file's own comment at `:50-52` says the block must mirror the schema.

`operatingSystem` is deliberately **not** touched — it's accurate until release.

## `technology.html` is written as a reversal, not a deletion

> ~~"iPhone-only by conviction: no macOS or visionOS targets."~~

becomes a dated position revisited on evidence: the macOS/visionOS half still holds, the Android half was withdrawn, and the cost argument behind it assumed Android needed its own name, sentiment and embedding models — measurement removed all three.

`git log` makes the change legible either way, so the honest framing costs nothing and reads better.

**The tag chip `<span>iPhone-only</span>` is separately indexable**, so a prose-only sweep would have missed it entirely.

## The last templated claims

Two comparison pages carried the withdrawn clause **verbatim** from a shared template — *"Android is deferred until the iOS app has proven itself."* Both fixed; grepped for further copies, none remain.

`personal-digital-twin.html:85` held the only hyphenated permanence claim inside structured data.

## Verified

- 7 FAQPage questions, 7 visible `<details>`
- All JSON-LD across the four touched pages still parses
- No "deferred until" anywhere on the site

## Not included, deliberately

`about.html:814` — *"Android will come, after the user base grows"* — is the retention gate the roadmap declares **waived, not cleared**, on a first-person page. That's your sentence to rewrite, not a patch for me to draft.